### PR TITLE
HTML formatter breaks Background + Scenario Outline since 1.3.0

### DIFF
--- a/features/html_formatter.feature
+++ b/features/html_formatter.feature
@@ -27,10 +27,37 @@ Feature: HTML output formatter
             | two     |
             | three   |
       """
+    And a file named "features/scenario_outline_with_background.feature" with:
+     """
+     Feature:
+
+       Background:
+         Given I have set up state
+
+       Scenario:
+         Given a number 1
+
+       Scenario Outline:
+         Given a number <number>
+
+         Examples: 
+           | number |
+           | 2      |
+           | 3      |
+           | 4      |
+          """
     And a file named "features/step_definitions/steps.rb" with:
       """
       Given /^this hasn't been implemented yet$/ do
         pending
+      end
+
+      Given(/I have set up state/) do
+        @state = %w{1 2 3 4}
+      end
+
+      Given(/a number (\d+)/) do |n|
+        @state.should include(n)
       end
       """
 
@@ -68,3 +95,6 @@ Feature: HTML output formatter
     Using the default profile...
     """
 
+  Scenario: the background should run for all scenarios and example rows
+    When I run `cucumber features/scenario_outline_with_background.feature --format html`
+    Then it should pass


### PR DESCRIPTION
Backgrounds are not being run for the first example (after the header line) of a Scenario Outline.

This works fine with 1.2.5 or when using the pretty formatter. Here's a shell script that reproduces the problem (notice the output "number 2 with state: nil"):

```bash
#!/bin/bash

set -e
set -x

mkdir -p cucumber-bug/features/step_definitions

cat <<END > cucumber-bug/Gemfile
source "https://rubygems.org"
gem "cucumber", "=> 1.3.0"
END

cat <<END > cucumber-bug/features/bug.feature
Feature: Bug

  Background:
    Given I have set up state
    
  Scenario:
    Given a number 1
    
  Scenario Outline:
    Given a number <number>
    
    Examples: 
      | number |
      | 2      |
      | 3      |
      | 4      |
END

cat <<END > cucumber-bug/features/step_definitions/steps.rb
  Given(/I have set up state/) { @state = true }
  Given(/a number (\d+)/) { |n| puts "number #{n} with state: #{@state.inspect}" }
END


cd cucumber-bug
bundle install
bundle exec cucumber features --format html --out bug.html

if [[ `which open` ]]; then
  open bug.html
fi
```

