### PR TITLE
Test showing World is inconsistently available in Around hook

### DIFF
--- a/examples/hooks/features/hooks.feature
+++ b/examples/hooks/features/hooks.feature
@@ -1,0 +1,14 @@
+Feature: Hooks
+  Scenario
+
+  Scenario: First scenario
+    Given the around hook has run
+    Then the world should be a CustomWorld
+
+  Scenario: Second scenario
+    Given the around hook has run
+    Then the world should be a CustomWorld
+
+  Scenario: Third scenario
+    Given the around hook has run
+    Then the world should be a CustomWorld

--- a/examples/hooks/features/step_definitions/hook_steps.rb
+++ b/examples/hooks/features/step_definitions/hook_steps.rb
@@ -1,0 +1,7 @@
+Given(/^the around hook has run$/) do
+  $around_ran.should be_true
+end
+
+Then(/^the world should be a (.*)$/) do |clazz|
+  $world_class.to_s.should eq clazz
+end

--- a/examples/hooks/features/support/env.rb
+++ b/examples/hooks/features/support/env.rb
@@ -1,0 +1,14 @@
+class CustomWorld
+end
+
+World do
+  CustomWorld.new
+end
+
+Around do |scenario, block|
+  $around_ran = true
+  $world_class = self.class
+  puts "I am a #{self.class}"
+  block.call
+  $around_ran = false
+end


### PR DESCRIPTION
As @mattwynne requested on #52.

Test: `cd examples/hooks; bundle exec cucumber features`

Results on my machine:
```
I am a NilClass
Feature: Hooks
  Scenario

  Scenario: First scenario                 # features/hooks.feature:4
    Given the around hook has run          # features/step_definitions/hook_steps.rb:1
    Then the world should be a CustomWorld # features/step_definitions/hook_steps.rb:5

      expected: "CustomWorld"
           got: "NilClass"

      (compared using ==)
       (RSpec::Expectations::ExpectationNotMetError)
      ./features/support/env.rb:12:in `call'
      ./features/support/env.rb:12:in `block in <top (required)>'
      features/hooks.feature:6:in `Then the world should be a CustomWorld'

  Scenario: Second scenario                # features/hooks.feature:8
    Given the around hook has run          # features/step_definitions/hook_steps.rb:1
      I am a CustomWorld
    Then the world should be a CustomWorld # features/step_definitions/hook_steps.rb:5

  Scenario: Third scenario                 # features/hooks.feature:12
    Given the around hook has run          # features/step_definitions/hook_steps.rb:1
      I am a CustomWorld
    Then the world should be a CustomWorld # features/step_definitions/hook_steps.rb:5

Failing Scenarios:
cucumber features/hooks.feature:4 # Scenario: First scenario
```

