### PR TITLE
Suggested regexes are bad and result in ambiguous matches

### DIFF
--- a/lib/cucumber/rb_support/snippet.rb
+++ b/lib/cucumber/rb_support/snippet.rb
@@ -2,7 +2,7 @@ module Cucumber
   module RbSupport
     module Snippet
 
-      ARGUMENT_PATTERNS = ['"(.*?)"', '(\d+)']
+      ARGUMENT_PATTERNS = ['"([^"]*)"', '(\d+)']
 
       class BaseSnippet
 

--- a/spec/cucumber/rb_support/snippet_spec.rb
+++ b/spec/cucumber/rb_support/snippet_spec.rb
@@ -28,7 +28,7 @@ module Cucumber
           @pattern = 'A "string" with 4 spaces'
 
           snippet_text.should == unindented(%{
-          Given(/^A "(.*?)" with (\\d+) spaces$/) do |arg1, arg2|
+          Given(/^A "([^"]*)" with (\\d+) spaces$/) do |arg1, arg2|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })
@@ -49,7 +49,7 @@ module Cucumber
           @multiline_argument = Core::Ast::DataTable.new([[]], Core::Ast::Location.new(''))
 
           snippet_text.should == unindented(%{
-          Given(/^I have (\\d+) "(.*?)" cukes in (\\d+) "(.*?)"$/) do |arg1, arg2, arg3, arg4, table|
+          Given(/^I have (\\d+) "([^"]*)" cukes in (\\d+) "([^"]*)"$/) do |arg1, arg2, arg3, arg4, table|
             # table is a Cucumber::Core::Ast::DataTable
             pending # Write code here that turns the phrase above into concrete actions
           end
@@ -60,7 +60,7 @@ module Cucumber
           @pattern = 'A "first" arg'
 
           snippet_text.should == unindented(%{
-          Given(/^A "(.*?)" arg$/) do |arg1|
+          Given(/^A "([^"]*)" arg$/) do |arg1|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })
@@ -70,7 +70,7 @@ module Cucumber
           @pattern = 'A "first" and "second" arg'
 
           snippet_text.should == unindented(%{
-          Given(/^A "(.*?)" and "(.*?)" arg$/) do |arg1, arg2|
+          Given(/^A "([^"]*)" and "([^"]*)" arg$/) do |arg1, arg2|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })
@@ -91,7 +91,7 @@ module Cucumber
           @multiline_argument = Core::Ast::DataTable.new([[]], Core::Ast::Location.new(""))
 
           snippet_text.should == unindented(%{
-          Given(/^A "(.*?)" arg$/) do |arg1, table|
+          Given(/^A "([^"]*)" arg$/) do |arg1, table|
             # table is a Cucumber::Core::Ast::DataTable
             pending # Write code here that turns the phrase above into concrete actions
           end
@@ -103,7 +103,7 @@ module Cucumber
           @multiline_argument = Core::Ast::MultilineArgument.from("", Core::Ast::Location.new(""))
 
           snippet_text.should == unindented(%{
-          Given(/^A "(.*?)" arg$/) do |arg1, string|
+          Given(/^A "([^"]*)" arg$/) do |arg1, string|
             pending # Write code here that turns the phrase above into concrete actions
           end
           })


### PR DESCRIPTION
Imagine I'm writing a new scenario that includes something similar to this:
```cucumber
When I press "Submit" button
Then I should see "can't be blank" validation error on "Email"
```

first time I run this new scenario, cucumber will suggest me code snippets to start implementing missing steps. The snippet for validation step would be
```ruby
Then(/^I should see "(.*?)" validation error on "(.*?)"$/) do |arg1, arg2|
  pending # express the regexp above with the code you wish you had
end
```

Later I add another scenario that includes this:
```cucumber
Then I should see "foobar"
```
and cucumber, again, helpfully suggest a snippet to start implementing the step:
```ruby
Then(/^I should see "(.*?)"$/) do |arg1|
```

The problem is, the suggested regexp also matches everything, a previously defined validation step does resulting with lot of previously green steps suddenly go red with `Cucumber::Ambiguous` error.