### PR TITLE
Fix one JUnit formatter scenario (WIP)

### DIFF
--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -230,7 +230,6 @@ can't convert .* into String \(TypeError\)
 You *must* specify --out DIR for the junit formatter
       """
 
-  @wip
   Scenario: one feature, one scenario outline, two examples: one passing, one failing
     When I run `cucumber --format junit --out tmp/ features/scenario_outline.feature`
     Then it should fail with:

--- a/features/lib/step_definitions/junit_steps.rb
+++ b/features/lib/step_definitions/junit_steps.rb
@@ -1,7 +1,7 @@
 Then(/^the junit output file "(.*?)" should contain:$/) do |actual_file, text|
   actual = IO.read(current_dir + '/' + actual_file)
   actual = replace_junit_time(actual)
-  actual.should == text
+  actual.should == text.to_s
 end
 
 module JUnitHelper


### PR DESCRIPTION
The reason this one fails is that the stack trace in the failing scenario isn't quite right. But that was obscured because our new DocString wrapper class doesn't readily compare to a String when used in an RSpec assertion.

There are two things to do here:

- [ ] change `Cucumber::MulitlineArgument::DocString` so it reports better assertion failure messages without having to be converted to a string first.
- [ ] fix the stack trace in the error reported to the formatter.