### PR TITLE
Feature: cucumber --init

### DIFF
--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -1,6 +1,7 @@
 require 'cucumber/cli/profile_loader'
 require 'cucumber/formatter/ansicolor'
 require 'cucumber/rb_support/rb_language'
+require 'cucumber/project_initializer'
 
 module Cucumber
   module Cli
@@ -124,6 +125,12 @@ module Cucumber
             "How to format features (Default: pretty). Available formats:",
             *FORMAT_HELP) do |v|
             @options[:formats] << [v, @out_stream]
+          end
+          opts.on('--init',
+            'Initializes folder structure and generates conventional files for',
+            'a Cucumber project.') do |v|
+            ProjectInitializer.new.run
+            Kernel.exit(0)
           end
           opts.on("-o", "--out [FILE|DIR]",
             "Write output to a file/directory instead of STDOUT. This option",

--- a/lib/cucumber/project_initializer.rb
+++ b/lib/cucumber/project_initializer.rb
@@ -1,0 +1,43 @@
+module Cucumber
+
+  # Generates generic file structure for a cucumber project
+  class ProjectInitializer
+    def run
+      create_directory('features')
+      create_directory('features/step_definitions')
+      create_directory('features/support')
+      create_file('features/support/env.rb')
+    end
+
+    private
+
+    def create_directory(dir_name)
+      create_directory_or_file dir_name, true
+    end
+
+    def create_file(file_name)
+      create_directory_or_file file_name, false
+    end
+
+    def create_directory_or_file(file_name, directory)
+      file_type = if directory
+                    :mkdir_p
+                  else
+                    :touch
+                  end
+
+      report_exists(file_name) || return if File.exists?(file_name)
+
+      report_creating(file_name)
+      FileUtils.send file_type, file_name
+    end
+
+    def report_exists(file)
+      puts "   exist   #{file}"
+    end
+
+    def report_creating(file)
+      puts "  create   #{file}"
+    end
+  end
+end

--- a/spec/cucumber/project_initializer_spec.rb
+++ b/spec/cucumber/project_initializer_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'tmpdir'
+
+module Cucumber
+  describe ProjectInitializer, :isolated_home => true do
+    let(:command_line_config) { ProjectInitializer.new }
+
+    before do
+      allow(command_line_config).to receive(:puts)
+    end
+
+    context "no files created" do
+      around(:example) do |example|
+
+        dir = Dir.mktmpdir
+        original_dir = Dir.pwd
+        begin
+          FileUtils.cd dir
+          example.call
+        ensure
+          FileUtils.cd original_dir
+          FileUtils.rm_rf dir
+        end
+      end
+
+      it "should create features directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features$)
+        command_line_config.run
+      end
+
+      it "should create step_definitions directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/step_definitions$)
+        command_line_config.run
+      end
+
+      it "should create support directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/support$)
+        command_line_config.run
+      end
+
+      it "should create env.rb directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+create\s+features/support/env.rb$)
+        command_line_config.run
+      end
+
+    end
+
+    context "files created" do
+      around(:example) do |example|
+        dir = Dir.mktmpdir
+        FileUtils.mkdir_p "#{dir}/features"
+        FileUtils.mkdir_p "#{dir}/features/step_definitions"
+        FileUtils.mkdir_p "#{dir}/features/support"
+        FileUtils.touch "#{dir}/features/support/env.rb"
+        original_dir = Dir.pwd
+        begin
+          FileUtils.cd dir
+          example.call
+        ensure
+          FileUtils.cd original_dir
+          FileUtils.rm_rf dir
+        end
+      end
+
+      it "should not create features directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features$)
+        command_line_config.run
+      end
+
+      it "should not create step_definitions directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/step_definitions$)
+        command_line_config.run
+      end
+
+      it "should not create support directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/support$)
+        command_line_config.run
+      end
+
+      it "should not create env.rb directory" do
+        expect(command_line_config).to receive(:puts).with %r(^\s+exist\s+features/support/env.rb$)
+        command_line_config.run
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Adds an init feature to the cucumber cli tool.  This feature constructs the standard folder structure for a project using cucumber.