### PR TITLE
Fix transformation of regex with lookahead/lookbehind

### DIFF
--- a/lib/cucumber/rb_support/rb_transform.rb
+++ b/lib/cucumber/rb_support/rb_transform.rb
@@ -39,7 +39,9 @@ module Cucumber
 
     private
       def convert_captures(regexp_source)
-        regexp_source.gsub(/(\()(?!\?:)/,'(?:')
+        regexp_source
+          .gsub(/(\()(?!\?[<:=!])/,'(?:')
+          .gsub(/(\(\?<)(?![=!])/,'(?:<')
       end
 
       def strip_captures(regexp_source)

--- a/spec/cucumber/rb_support/rb_transform_spec.rb
+++ b/spec/cucumber/rb_support/rb_transform_spec.rb
@@ -9,6 +9,26 @@ module Cucumber
       end
 
       describe "#to_s" do
+        it "does not touch positive lookahead captures" do
+          expect(transform(/^xy(?=z)/).to_s).to eq "xy(?=z)"
+        end
+
+        it "does not touch negative lookahead captures" do
+          expect(transform(/^xy(?!z)/).to_s).to eq "xy(?!z)"
+        end
+
+        it "does not touch positive lookbehind captures" do
+          expect(transform(/^xy(?<=z)/).to_s).to eq "xy(?<=z)"
+        end
+
+        it "does not touch negative lookbehind captures" do
+          expect(transform(/^xy(?<!z)/).to_s).to eq "xy(?<!z)"
+        end
+
+        it "converts named captures" do
+          expect(transform(/^(?<str>xyz)/).to_s).to eq "(?:<str>xyz)"
+        end
+
         it "converts captures groups to non-capture groups" do
           expect(transform(/(a|b)bc/).to_s).to eq "(?:a|b)bc"
         end


### PR DESCRIPTION
Fixes transformation of lookbehind/lookahead.

Before fix: 

```ruby
transform(/^xy(?=z)/).to_s) #=> "xy(?:?=z)"
```

After fix

```ruby
transform(/^xy(?=z)/).to_s) #=> "xy(?=z)"
```

It works for positive/negative lookahead/lookbehind and for named capture groups