### PR TITLE
remove 'Scenario: ' prefix from expected output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ unless ENV['CUCUMBER_USE_RELEASED_CORE']
   if File.exist?(core_path) && !ENV['CUCUMBER_USE_GIT_CORE']
     gem 'cucumber-core', :path => core_path
   else
-    gem 'cucumber-core', :git => "git://github.com/cucumber/cucumber-ruby-core.git"
+    gem 'cucumber-core', :git => "https://github.com/richarda/cucumber-ruby-core.git", :branch => '768-scenario-name'
   end
 end

--- a/lib/cucumber/ast/facade.rb
+++ b/lib/cucumber/ast/facade.rb
@@ -65,7 +65,7 @@ module Cucumber
         end
 
         def name
-          @test_case.name
+          "#{@test_case.keyword}: #{@test_case.name}"
         end
 
         def title

--- a/lib/cucumber/formatter/legacy_api/adapter.rb
+++ b/lib/cucumber/formatter/legacy_api/adapter.rb
@@ -54,7 +54,7 @@ module Cucumber
         end
 
         def record_test_case_result(test_case, result)
-          scenario = LegacyResultBuilder.new(result).scenario(test_case.name, test_case.location)
+          scenario = LegacyResultBuilder.new(result).scenario("#{test_case.keyword}: #{test_case.name}", test_case.location)
           results.scenario_visited(scenario)
         end
 


### PR DESCRIPTION
This is related to the [PR #82](https://github.com/cucumber/cucumber-ruby-core/pull/82) in `cucumber-ruby-core` that addresses issue #768.

Test::Case#name was changed to only output the name of the Scenario or Scenario Outline, not "Scenario: name"

This PR changes the expected output to reflect that change.  As noted in the other PR, I think this makes the output more compact while still being meaningful, but I could also prepare a change to keep the existing behavior in `cucumber`.

This PR will most likely fail the Travis build, as it's dependent on the other PR in `cucumber-ruby-core`.