### PR TITLE
Around hooks not executing in correct world context

### DIFF
--- a/features/docs/exception_in_around_hook.feature
+++ b/features/docs/exception_in_around_hook.feature
@@ -1,0 +1,80 @@
+Feature: Exceptions in Around Hooks
+
+  Around hooks are awkward beasts to handle internally.
+
+  Right now, if there's an error in your Around hook before you call `block.call`,
+  we won't even print the steps for the scenario.
+
+  This is because that `block.call` invokes all the logic that would tell Cucumber's
+  UI about the steps in your scenario. If we never reach that code, we'll never be
+  told about them.
+
+  There's another scenario to consider, where the exception occurs after the steps
+  have been run. How would we want to report in that case?
+
+  Scenario: Exception before the test case is run
+    Given the standard step definitions
+    And a file named "features/support/env.rb" with:
+      """
+      Around do |scenario, block|
+        fail "this should be reported"
+        block.call
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step passes
+      """
+    When I run `cucumber -q`
+    Then it should fail with exactly:
+      """
+      Feature: 
+
+        Scenario: 
+        this should be reported (RuntimeError)
+        ./features/support/env.rb:2:in `Around'
+      
+      Failing Scenarios:
+      cucumber features/test.feature:2
+      
+      1 scenario (1 failed)
+      0 steps
+      0m0.012s
+
+      """
+
+  Scenario: Exception after the test case is run
+    Given the standard step definitions
+    And a file named "features/support/env.rb" with:
+      """
+      Around do |scenario, block|
+        block.call
+        fail "this should be reported"
+      end
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given this step passes
+      """
+    When I run `cucumber -q`
+    Then it should fail with exactly:
+      """
+      Feature: 
+
+        Scenario: 
+          Given this step passes
+            this should be reported (RuntimeError)
+            ./features/support/env.rb:3:in `Around'
+      
+      Failing Scenarios:
+      cucumber features/test.feature:2
+      
+      1 scenario (1 failed)
+      1 step (1 passed)
+      0m0.012s
+
+      """

--- a/features/docs/wire_protocol/handle_unexpected_response.feature
+++ b/features/docs/wire_protocol/handle_unexpected_response.feature
@@ -24,7 +24,7 @@ Feature: Handle unexpected response
       | ["begin_scenario"]                                   | ["yikes"]                           |
       | ["step_matches",{"name_to_match":"we're all wired"}] | ["success",[{"id":"1", "args":[]}]] |
     When I run `cucumber -f pretty`
-    Then the stdout should contain:
+    Then the output should contain:
       """
       undefined method `handle_yikes'
       """

--- a/features/docs/writing_support_code/around_hooks.feature
+++ b/features/docs/writing_support_code/around_hooks.feature
@@ -227,3 +227,34 @@ Feature: Around hooks
       2 steps (2 passed)
 
       """
+
+  Scenario: Around Hooks and the Custom World
+    Given a file named "features/step_definitions/steps.rb" with:
+      """
+      Then /^the world should be available in the hook$/ do
+        $previous_world = self
+        expect($hook_world).to eq(self)
+      end
+
+      Then /^what$/ do
+        expect($hook_world).not_to eq($previous_world)
+      end
+      """
+    And a file named "features/support/hooks.rb" with:
+      """
+      Around do |scenario, block|
+        $hook_world = self
+        block.call
+      end
+      """
+    And a file named "features/f.feature" with:
+      """
+      Feature: Around hooks
+        Scenario: using hook
+          Then the world should be available in the hook
+
+        Scenario: using the same hook
+          Then what
+      """
+    When I run `cucumber features/f.feature`
+    Then it should pass

--- a/lib/cucumber/filters/prepare_world.rb
+++ b/lib/cucumber/filters/prepare_world.rb
@@ -17,11 +17,18 @@ module Cucumber
         end
 
         def test_case
-          init_scenario = Cucumber::Hooks.before_hook(@original_test_case.source) do
+          init_scenario = Cucumber::Hooks.around_hook(@original_test_case.source) do |continue|
             @runtime.begin_scenario(scenario)
+            continue.call
           end
-          steps = [init_scenario] + @original_test_case.test_steps
-          @original_test_case.with_steps(steps)
+          around_hooks = [init_scenario] + @original_test_case.around_hooks
+
+          default_hook = Cucumber::Hooks.before_hook(@original_test_case.source) do
+            #no op - legacy format adapter expects a before hooks
+          end
+          steps = [default_hook] + @original_test_case.test_steps
+
+          @original_test_case.with_around_hooks(around_hooks).with_steps(steps)
         end
 
         private

--- a/spec/cucumber/formatter/pretty_spec.rb
+++ b/spec/cucumber/formatter/pretty_spec.rb
@@ -21,6 +21,19 @@ module Cucumber
             run_defined_feature
           end
 
+          describe "with a scenario with no steps" do
+            define_feature <<-FEATURE
+          Feature: Banana party
+
+            Scenario: Monkey eats banana
+            FEATURE
+
+            it "outputs the scenario name" do
+              expect(@out.string).to include "Scenario: Monkey eats banana"
+            end
+          end
+
+
           describe "with a scenario" do
             define_feature <<-FEATURE
           Feature: Banana party


### PR DESCRIPTION
This supersedes #640.

Based on @maxlinc's example this scenario demonstrates that the world an around hook is being instance_exec'd on is not quite right.

For the first scenario, self is nil, and the next scenario the world is remembered from the previous scenario.