### PR TITLE
Make the scenario object available in hooks compatible with v1.3.x

### DIFF
--- a/features/docs/writing_support_code/before_hook.feature
+++ b/features/docs/writing_support_code/before_hook.feature
@@ -58,8 +58,8 @@ Feature: Before Hook
       """
             NAMES:
             Feature name
-            Scenario Outline name, Examples Table name (#1)
-            Scenario Outline name, Examples Table name (#1)
+            Scenario Outline name
+            | step |
 
       """
 


### PR DESCRIPTION
#768 identified that the `scenario.name` of the scenario object available in hooks includes the keyword, which makes it different compared to the case in v1.3.x. Unfortunately, also after the changes triggered by #768, the keyword is still included in `scenario.name` (see the [before_hook.feature](https://github.com/cucumber/cucumber/blob/f5f8ae0635cbca28afc7b9841bec3019229c2a15/features/docs/writing_support_code/before_hook.feature#L25-L60)).

In case of Scenario Outlines, achieving full compatibility with v1.3.x is rather complicated as in that case `scenario.name` is cell values for the example row, and `scenario.scenario_outline.name` is the name of the Scenario Outline. The name of the `test_case` is neither, it is `<scenario outline name>, <examples table name> (row <nr>)`.

The name of the `test_case` is in a sense quite informative, so it raises the question of how important backward compatibility is in this specific case.