### PR TITLE
World reset in after hooks

### DIFF
--- a/features/docs/writing_support_code/after_hooks.feature
+++ b/features/docs/writing_support_code/after_hooks.feature
@@ -54,3 +54,24 @@ Feature: After Hooks
             ./features/support/bad_hook.rb:2:in `After'
       """
 
+  Scenario: The World still exists in an After hook
+    Given a file named "features/support/after_hook.rb" with:
+      """
+      After do
+        expect(@set_in_step).to be(true)
+      end
+      """
+    And a file named "feautures/step_definitions/steps.rb" with:
+      """
+      Given(/we set a world variable/) do
+        @set_in_step = true
+      end
+      """
+    And a file named "features/feature.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given we set a world variable
+      """
+    When I run `cucumber -q`
+    Then it should pass

--- a/features/docs/writing_support_code/after_hooks.feature
+++ b/features/docs/writing_support_code/after_hooks.feature
@@ -61,7 +61,7 @@ Feature: After Hooks
         expect(@set_in_step).to be(true)
       end
       """
-    And a file named "feautures/step_definitions/steps.rb" with:
+    And a file named "features/step_definitions/steps.rb" with:
       """
       Given(/we set a world variable/) do
         @set_in_step = true


### PR DESCRIPTION
@mattwynne just noticed this problem as capybara session was getting
reset in after hook, so this no longer works.

I don't think we should pull this feature in - its more a test than
documentation :) but was a quick way for me to show the problem.

```ruby
After do |scenario|
  save_and_open_page if scenario.failed?
end
```

Possibly related to fix for #807.