### PR TITLE
don't print the duration in quiet mode

### DIFF
--- a/features/docs/cli/dry_run.feature
+++ b/features/docs/cli/dry_run.feature
@@ -23,7 +23,6 @@ Feature: Dry Run
 
       1 scenario (1 skipped)
       1 step (1 skipped)
-      0m0.012s
 
       """
 
@@ -45,7 +44,6 @@ Feature: Dry Run
 
       1 scenario (1 skipped)
       1 step (1 skipped)
-      0m0.012s
 
       """
 
@@ -68,6 +66,5 @@ Feature: Dry Run
 
       1 scenario (1 undefined)
       1 step (1 undefined)
-      0m0.012s
 
       """

--- a/features/docs/cli/run_specific_scenarios.feature
+++ b/features/docs/cli/run_specific_scenarios.feature
@@ -24,7 +24,7 @@ Feature: Run specific scenarios
           Given this step passes
       """
     When I run `cucumber features/test.feature:7 --format pretty --quiet`
-    Then it should pass with:
+    Then it should pass with exactly:
       """
       Feature: 
 
@@ -32,6 +32,8 @@ Feature: Run specific scenarios
           Given this step passes
 
       1 scenario (1 passed)
+      1 step (1 passed)
+      
       """
 
   Scenario: Use @-notation to specify a file containing feature file list

--- a/features/docs/defining_steps/nested_steps.feature
+++ b/features/docs/defining_steps/nested_steps.feature
@@ -173,6 +173,5 @@ Feature: Nested Steps
 
       2 scenarios (2 failed)
       2 steps (2 failed)
-      0m0.012s
 
       """

--- a/features/docs/defining_steps/skip_scenario.feature
+++ b/features/docs/defining_steps/skip_scenario.feature
@@ -26,7 +26,6 @@ Feature: Skip Scenario
 
       1 scenario (1 skipped)
       2 steps (2 skipped)
-      0m0.012s
 
       """
 
@@ -56,7 +55,6 @@ Feature: Skip Scenario
 
       1 scenario (1 skipped)
       2 steps (2 skipped)
-      0m0.012s
 
       """
 

--- a/features/docs/exception_in_around_hook.feature
+++ b/features/docs/exception_in_around_hook.feature
@@ -41,8 +41,7 @@ Feature: Exceptions in Around Hooks
       
       1 scenario (1 failed)
       0 steps
-      0m0.012s
-
+      
       """
 
   Scenario: Exception after the test case is run
@@ -75,6 +74,5 @@ Feature: Exceptions in Around Hooks
       
       1 scenario (1 failed)
       1 step (1 passed)
-      0m0.012s
 
       """

--- a/features/docs/formatters/usage_formatter.feature
+++ b/features/docs/formatters/usage_formatter.feature
@@ -79,7 +79,6 @@ Feature: Usage formatter
       
       4 scenarios (4 skipped)
       11 steps (11 skipped)
-      0m0.012s
 
       """
 
@@ -97,6 +96,5 @@ Feature: Usage formatter
         
         4 scenarios (4 skipped)
         11 steps (11 skipped)
-        0m0.012s
 
         """

--- a/features/docs/gherkin/background.feature
+++ b/features/docs/gherkin/background.feature
@@ -222,7 +222,6 @@ Feature: Background
 
     1 scenario (1 passed)
     2 steps (2 passed)
-    0m0.012s
 
     """
   
@@ -243,7 +242,6 @@ Feature: Background
 
     2 scenarios (2 passed)
     4 steps (4 passed)
-    0m0.012s
 
     """
 
@@ -272,7 +270,6 @@ Feature: Background
 
     2 scenarios (2 passed)
     4 steps (4 passed)
-    0m0.012s
 
     """
 
@@ -295,7 +292,6 @@ Feature: Background
 
     1 scenario (1 passed)
     2 steps (2 passed)
-    0m0.012s
 
     """
 
@@ -325,7 +321,6 @@ Feature: Background
     
     2 scenarios (2 failed)
     6 steps (2 failed, 4 skipped)
-    0m0.012s
     
     """
 
@@ -362,7 +357,6 @@ Feature: Background
 
     2 scenarios (2 failed)
     4 steps (2 failed, 2 skipped)
-    0m0.012s
     
     """
 
@@ -386,7 +380,6 @@ Feature: Background
 
     2 scenarios (2 pending)
     4 steps (2 skipped, 2 pending)
-    0m0.012s
     
     """
 
@@ -416,7 +409,6 @@ Feature: Background
 
     2 scenarios (1 failed, 1 passed)
     6 steps (1 failed, 1 skipped, 4 passed)
-    0m0.012s
     
     """
 
@@ -453,7 +445,6 @@ Feature: Background
 
     2 scenarios (1 failed, 1 passed)
     6 steps (1 failed, 1 skipped, 4 passed)
-    0m0.012s
     
     """
 
@@ -493,7 +484,6 @@ Feature: Background
 
     2 scenarios (1 failed, 1 passed)
     6 steps (1 failed, 1 skipped, 4 passed)
-    0m0.012s
     
     """
 
@@ -553,7 +543,6 @@ Feature: Background
 
       2 scenarios (2 passed)
       8 steps (8 passed)
-      0m0.012s
     
       """
 

--- a/features/docs/gherkin/outlines.feature
+++ b/features/docs/gherkin/outlines.feature
@@ -152,7 +152,6 @@ Feature: Scenario outlines
 
       5 scenarios (1 failed, 1 undefined, 3 passed)
       8 steps (1 failed, 2 skipped, 1 undefined, 4 passed)
-      0m0.012s
 
       """
 

--- a/features/docs/gherkin/using_descriptions.feature
+++ b/features/docs/gherkin/using_descriptions.feature
@@ -83,6 +83,5 @@ Feature: Using descriptions to give features context
 
     2 scenarios (2 passed)
     4 steps (4 passed)
-    0m0.012s
 
     """

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -65,7 +65,7 @@ module Cucumber
         @profile_loader = options[:profile_loader]
         @options[:skip_profile_information] = options[:skip_profile_information]
 
-        @quiet = @disable_profile_loading = nil
+        @disable_profile_loading = nil
       end
 
       def [](key)
@@ -207,7 +207,9 @@ module Cucumber
           end
 
           opts.on("-q", "--quiet", "Alias for --no-snippets --no-source.") do
-            @quiet = true
+            @options[:snippets] = false
+            @options[:source] = false
+            @options[:duration] = false
           end
           opts.on("-b", "--backtrace", "Show full backtrace for all errors.") do
             Cucumber.use_full_backtrace = true
@@ -252,12 +254,6 @@ TEXT
           end
         end.parse!
 
-        if @quiet
-          @options[:snippets] = @options[:source] = false
-        else
-          @options[:snippets] = true if @options[:snippets].nil?
-          @options[:source]   = true if @options[:source].nil?
-        end
         @args.map! { |a| "#{a}:#{@options[:lines]}" } if @options[:lines]
 
         extract_environment_variables
@@ -353,6 +349,7 @@ TEXT
         end
         @options[:source] &= other_options[:source]
         @options[:snippets] &= other_options[:snippets]
+        @options[:duration] &= other_options[:duration]
         @options[:strict] |= other_options[:strict]
         @options[:dry_run] |= other_options[:dry_run]
 
@@ -391,7 +388,10 @@ TEXT
           :tag_expressions  => [],
           :name_regexps => [],
           :env_vars     => {},
-          :diff_enabled => true
+          :diff_enabled => true,
+          :snippets     => true,
+          :source       => true,
+          :duration     => true
         }
       end
     end

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -188,6 +188,7 @@ module Cucumber
           opts.on("-d", "--dry-run", "Invokes formatters without executing the steps.",
             "This also omits the loading of your support/env.rb file if it exists.") do
             @options[:dry_run] = true
+            @options[:duration] = false
           end
           opts.on("-m", "--no-multiline",
             "Don't print multiline strings and tables under steps.") do
@@ -209,6 +210,9 @@ module Cucumber
           opts.on("-q", "--quiet", "Alias for --no-snippets --no-source.") do
             @options[:snippets] = false
             @options[:source] = false
+            @options[:duration] = false
+          end
+          opts.on("--no-duration", "Don't print the duration at the end of the summary") do
             @options[:duration] = false
           end
           opts.on("-b", "--backtrace", "Show full backtrace for all errors.") do

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -85,8 +85,8 @@ module Cucumber
         @io.puts scenario_summary(runtime) {|status_count, status| format_string(status_count, status)}
         @io.puts step_summary(runtime) {|status_count, status| format_string(status_count, status)}
 
-        @io.puts(format_duration(features.duration)) if features && features.duration
-
+        @io.puts(format_duration(features.duration)) if features && features.duration && options[:duration]
+        
         if runtime.configuration.randomize?
           @io.puts
           @io.puts "Randomized with seed #{runtime.configuration.seed}"

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -265,11 +265,12 @@ END_OF_MESSAGE
       expect(config.options[:snippets]).to be false
     end
 
-    it "sets snippets and source to false with --quiet option" do
+    it "sets snippets and source and duration to false with --quiet option" do
       config.parse!(%w{--quiet})
 
       expect(config.options[:snippets]).to be false
       expect(config.options[:source]).to be false
+      expect(config.options[:duration]).to be false
     end
 
     it "accepts --verbose option" do

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -252,6 +252,12 @@ END_OF_MESSAGE
 
       expect(config.options[:dry_run]).to be true
     end
+    
+    it "implies --no-duration with --dry-run option" do
+      config.parse!(%w{--dry-run})
+      
+      expect(config.options[:duration]).to be false
+    end
 
     it "accepts --no-source option" do
       config.parse!(%w{--no-source})
@@ -270,6 +276,12 @@ END_OF_MESSAGE
 
       expect(config.options[:snippets]).to be false
       expect(config.options[:source]).to be false
+      expect(config.options[:duration]).to be false
+    end
+    
+    it "sets duration to false with --no-duration" do
+      config.parse!(%w{--no-duration})
+      
       expect(config.options[:duration]).to be false
     end
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -238,6 +238,7 @@ module Cucumber
 
             expect(options[:snippets]).to be false
             expect(options[:source]).to be false
+            expect(options[:duration]).to be false
           end
         end
 

--- a/spec/cucumber/cli/options_spec.rb
+++ b/spec/cucumber/cli/options_spec.rb
@@ -240,6 +240,13 @@ module Cucumber
             expect(options[:source]).to be false
             expect(options[:duration]).to be false
           end
+          
+          it "uses --no-duration when defined in the profile" do
+            given_cucumber_yml_defined_as('foo' => '--no-duration')
+            options.parse!(%w[-p foo])
+
+            expect(options[:duration]).to be false
+          end
         end
 
         context '-P or --no-profile' do


### PR DESCRIPTION
This attempts to resolve #816 
I'm not able to remove the [referenced hack](https://github.com/cucumber/cucumber/blob/master/features/lib/support/normalise_output.rb#L11) just yet, but I'll keep working on it.