### PR TITLE
The check for multiple formatters using stdout is disabled when using profiles

### DIFF
--- a/features/docs/cli/specifying_multiple_formatters.feature
+++ b/features/docs/cli/specifying_multiple_formatters.feature
@@ -3,8 +3,9 @@ Feature: Running multiple formatters
 
   When running cucumber, you are able to using multiple different
   formatters and redirect the output to text files.
+  Two formatters cannot both print to the same file (or to STDOUT)
 
-  Scenario: Multiple formatters and outputs
+  Background:
     Given a file named "features/test.feature" with:
     """
     Feature: Lots of undefined
@@ -16,6 +17,8 @@ Feature: Running multiple formatters
         When I stop procrastinating
         And there is world peace
     """
+
+  Scenario: Multiple formatters and outputs
     When I run `cucumber --no-color --format progress --out progress.txt --format pretty --out pretty.txt --no-source --dry-run --no-snippets features/test.feature`
     Then the stderr should not contain anything
     Then the file "progress.txt" should contain:
@@ -40,5 +43,23 @@ Feature: Running multiple formatters
       1 scenario (1 undefined)
       5 steps (5 undefined)
 
+      """
+
+  Scenario: Two formatters to stdout
+    When I run `cucumber -f progress -f pretty features/test.feature`
+    Then it should fail with:
+      """
+      All but one formatter must use --out, only one can print to each stream (or STDOUT) (RuntimeError)
+      """
+
+  Scenario: Two formatters to stdout when using a profile
+    Given the following profiles are defined:
+      """
+      default: -q
+      """
+    When I run `cucumber -f progress -f pretty features/test.feature`
+    Then it should fail with:
+      """
+      All but one formatter must use --out, only one can print to each stream (or STDOUT) (RuntimeError)
       """
 

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -201,10 +201,7 @@ module Cucumber
         @options[:formats] << ['pretty', @out_stream] if @options[:formats].empty?
         @options[:formats] = @options[:formats].sort_by{|f| f[1] == @out_stream ? -1 : 1}
         @options[:formats].uniq!
-        streams = @options[:formats].map { |(_, stream)| stream }
-        if streams != streams.uniq
-          raise "All but one formatter must use --out, only one can print to each stream (or STDOUT)"
-        end
+        @options.check_formatter_stream_conflicts()
       end
 
       def remove_excluded_files_from(files)

--- a/lib/cucumber/cli/options.rb
+++ b/lib/cucumber/cli/options.rb
@@ -263,6 +263,8 @@ TEXT
         extract_environment_variables
         @options[:paths] = @args.dup #whatver is left over
 
+        check_formatter_stream_conflicts()
+
         merge_profiles
 
         self
@@ -274,6 +276,13 @@ TEXT
 
       def filters
         @options[:filters] ||= []
+      end
+
+      def check_formatter_stream_conflicts()
+        streams = @options[:formats].uniq.map { |(_, stream)| stream }
+        if streams != streams.uniq
+          raise "All but one formatter must use --out, only one can print to each stream (or STDOUT)"
+        end
       end
 
     protected

--- a/spec/cucumber/cli/configuration_spec.rb
+++ b/spec/cucumber/cli/configuration_spec.rb
@@ -300,6 +300,11 @@ END_OF_MESSAGE
       expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
     end
 
+    it "does not accept multiple --format options when both use implicit STDOUT (using profile with no formatters)" do
+      given_cucumber_yml_defined_as({'default' => ['-q']})
+      expect(-> { config.parse!(%w{--format pretty --format progress}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+    end
+
     it "accepts same --format options with implicit STDOUT, and keep only one" do
       config.parse!(%w{--format pretty --format pretty})
 
@@ -308,6 +313,11 @@ END_OF_MESSAGE
 
     it "does not accept multiple --out streams pointing to the same place" do
       expect(-> { config.parse!(%w{--format pretty --out file1 --format progress --out file1}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
+    end
+
+    it "does not accept multiple --out streams pointing to the same place (one from profile, one from command line)" do
+      given_cucumber_yml_defined_as({'default' => ['-f','progress', '--out', 'file1']})
+      expect(-> { config.parse!(%w{--format pretty --out file1}) }).to raise_error("All but one formatter must use --out, only one can print to each stream (or STDOUT)")
     end
 
     it "associates --out to previous --format" do


### PR DESCRIPTION
Somehow the check for multiple formatters using stdout is disabled when using profiles (even when the profile does not define any formatter). See failing scenario.

The root cause of this behaviour is the [logic for replacing the stdout formatter form the profile with the stdout formatter from the command line options](https://github.com/cucumber/cucumber/blob/13c621d2ea30733ddffdbfac42e2db0b39694f07/lib/cucumber/cli/options.rb#L366). Since the code remove all but the first stdout formatters, you can define several stdout formatters on the command line without getting an error when using profiles, but only the first one will actually be used. This behaviour cased some confusion [in this mailing list thread](https://groups.google.com/forum/#!topic/cukes/F2MM0pB9KTI).

To cover all cases, the check for multiple formatters needs to be performed multiple times:
* for the profile options and command line options individually, to catch multiple stdout formatters either in a profile or on the command line
* after merging the profile and command line options, to catch formatters from the profile and from the command line using the same file or directory for their output.