### PR TITLE
Bugfix: #278 Cucumber::Ast::Table.diff! is broken when using no headers

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -563,32 +563,25 @@ module Cucumber
         cols = cell_matrix.transpose
         unmapped_cols = other_cell_matrix.transpose
 
+
+        header_values = cols.map(&:first)
         mapped_cols = []
 
-        cols.each_with_index do |col, col_index|
-          header = col[0]
-          candidate_cols, unmapped_cols = unmapped_cols.partition do |other_col|
-            other_col[0] == header
-          end
-          raise "More than one column has the header #{header}" if candidate_cols.size > 2
-
-          other_padded_col = if candidate_cols.size == 1
-            # Found a matching column
-            candidate_cols[0]
+        header_values.each_with_index do |v, i|
+          mapped_index = unmapped_cols.index{|unmapped_col| unmapped_col.first == v}
+          if (mapped_index)
+            mapped_cols << unmapped_cols.delete_at(mapped_index)
           else
-            mark_as_missing(cols[col_index])
-            (0...other_cell_matrix.length).map do |row|
-              val = row == 0 ? header.value : nil
-              SurplusCell.new(val, self, -1)
-            end
+            mark_as_missing(cols[i])
+            empty_col = other_cell_matrix.collect {SurplusCell.new(nil, self, -1)}
+            empty_col.first.value = v
+            mapped_cols << empty_col
           end
-          mapped_cols.insert(col_index, other_padded_col)
         end
 
-        unmapped_cols.each_with_index do |col, col_index|
-          empty_col = (0...cell_matrix.length).map do |row|
-            SurplusCell.new(nil, self, -1)
-          end
+
+        empty_col = cell_matrix.collect {SurplusCell.new(nil, self, -1)}
+        unmapped_cols.each do
           cols << empty_col
         end
 

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -316,6 +316,20 @@ module Cucumber
           }
         end
 
+        it "raises no error for two identical tables with duplicate header values" do
+          t = DataTable.from(%{
+            |a|a|c|
+            |d|e|f|
+            |g|h|i|
+          })
+          t.diff!(t.dup)
+          expect( t.to_s(:indent => 12, :color => false) ).to eq %{
+            |     a |     a |     c |
+            |     d |     e |     f |
+            |     g |     h |     i |
+          }
+        end
+
         it "should inspect missing and surplus cells" do
           t1 = DataTable.from([
             ['name',  'male', 'lastname', 'swedish'],


### PR DESCRIPTION
Summary:

1. Bugfix: The former (intended) behaviour was to raise an error if more than one header column matches. 
Quickfix: ```raise ... if candidate_cols.size > 2``` ->```raise ... if candidate_cols.size > 1``` 

2. Change: From my point of view, duplicate header values are no problem, just match one after another. 
