### PR TITLE
Cucumber::MultilineArgument::DataTable#symbolic_hashes

### DIFF
--- a/lib/cucumber/multiline_argument/data_table.rb
+++ b/lib/cucumber/multiline_argument/data_table.rb
@@ -148,6 +148,22 @@ module Cucumber
         @hashes ||= build_hashes
       end
 
+      # Converts this table into an Array of Hashes where the keys are symbols.
+      # For example, a Table built from the following plain text:
+      #
+      #   | foo | Bar | Foo Bar |
+      #   | 2   | 3   | 5       |
+      #   | 7   | 9   | 16      |
+      #
+      # Gets converted into the following:
+      #
+      #   [{:foo => '2', :bar => '3', :foo_bar => '5'}, {:foo => '7', :bar => '9', :foo_bar => '16'}]
+      #
+      def symbolic_hashes
+        @header_conversion_proc = lambda { |h| symbolize_key(h) }
+        @symbolic_hashes ||= build_hashes
+      end
+
       # Converts this table into a Hash where the first column is
       # used as keys and the second column is used as values
       #
@@ -614,6 +630,10 @@ module Cucumber
         col.each do |cell|
           cell.status = :undefined
         end
+      end
+
+      def symbolize_key(key)
+        key.downcase.tr(' ', '_').to_sym
       end
 
       # Represents a row of cells or columns of cells

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -39,6 +39,19 @@ module Cucumber
         expect( @table.rows.first ).to eq %w{4444 55555 666666}
       end
 
+      describe '#symbolic_hashes' do
+
+        it 'should covert data table to an array of hashes with symbols as keys' do
+          expect(@table.symbolic_hashes).to eq([{:one => '4444', :four => '55555', :seven => '666666'}])
+        end
+
+        it 'should be able to be accessed multiple times' do
+          @table.symbolic_hashes
+          expect{@table.symbolic_hashes}.to_not raise_error
+        end
+
+      end
+
       describe '#map_column!' do
         it "should allow mapping columns" do
           @table.map_column!('one') { |v| v.to_i }

--- a/spec/cucumber/multiline_argument/data_table_spec.rb
+++ b/spec/cucumber/multiline_argument/data_table_spec.rb
@@ -42,7 +42,9 @@ module Cucumber
       describe '#symbolic_hashes' do
 
         it 'should covert data table to an array of hashes with symbols as keys' do
-          expect(@table.symbolic_hashes).to eq([{:one => '4444', :four => '55555', :seven => '666666'}])
+          ast_table = Cucumber::Core::Ast::DataTable.new([['foo', 'Bar', 'Foo Bar'], %w{1 22 333}], nil)
+          data_table = DataTable.new(ast_table)
+          expect(data_table.symbolic_hashes).to eq([{:foo => '1', :bar => '22', :foo_bar => '333'}])
         end
 
         it 'should be able to be accessed multiple times' do


### PR DESCRIPTION
New method allows data table to be accessed as an Array of Hashes with symbols as keys in step definitions. #840 