### PR TITLE
Default require path to features unless specified explicitly.

### DIFF
--- a/features/docs/cli/finding_steps.feature
+++ b/features/docs/cli/finding_steps.feature
@@ -1,0 +1,28 @@
+Feature: Loading the steps users expect
+  As a User
+  In order to run features in subdirectories without having to pass extra options
+  I want cucumber to load all step files
+
+  Scenario:
+    Given a file named "features/nesting/test.feature" with:
+      """
+      Feature: Feature in Subdirectory
+        Scenario: A step not in the subdirectory
+          Given not found in subdirectory
+      """
+    And a file named "features/step_definitions/steps_no_in_subdirectory.rb" with:
+      """
+      Given(/^not found in subdirectory$/) { }
+      """
+    When I run `cucumber -q features/nesting/test.feature`
+    Then it should pass with:
+      """
+      Feature: Feature in Subdirectory
+
+        Scenario: A step not in the subdirectory
+          Given not found in subdirectory
+
+      1 scenario (1 passed)
+      1 step (1 passed)
+      """
+

--- a/lib/cucumber/cli/configuration.rb
+++ b/lib/cucumber/cli/configuration.rb
@@ -75,8 +75,7 @@ module Cucumber
       end
 
       def all_files_to_load
-        requires = @options[:require].empty? ? require_dirs : @options[:require]
-        files = requires.map do |path|
+        files = require_dirs.map do |path|
           path = path.gsub(/\\/, '/') # In case we're on windows. Globs don't work with backslashes.
           path = path.gsub(/\/$/, '') # Strip trailing slash.
           File.directory?(path) ? Dir["#{path}/**/*"] : path
@@ -180,8 +179,12 @@ module Cucumber
 
       private
 
+      def default_features_paths
+        ["features"]
+      end
+
       def with_default_features_path(paths)
-        return ['features'] if paths.empty?
+        return default_features_paths if paths.empty?
         paths
       end
 
@@ -209,10 +212,12 @@ module Cucumber
       end
 
       def require_dirs
-        feature_dirs + Dir['vendor/{gems,plugins}/*/cucumber']
+        if @options[:require].empty?
+          default_features_paths + Dir['vendor/{gems,plugins}/*/cucumber']
+        else
+          @options[:require]
+        end
       end
-
     end
-
   end
 end


### PR DESCRIPTION
In general there seem to be some weird dependencies (or lack there of) between
configuration options and information in `Cucumber::Cli::Configuration#feature_files`
that could probably be clarified with a little refactoring.

One example that this feature exposed directly is that
`Cucumber::Cli::Configuration#feature_files` does not
depend on `Cucumber::Cli::Configuration#feature_dirs` though their names
certainly imply dependence.

I had deleted `Cucumber::Cli::Configuration#feature_dirs` to eliminate
the confusion, but added it back in when I realized it was used in
`features/docs/post_configuration_hook.feature`.

I took a stab at re-architecting the configuration code awhile back, but got mired and gave up. Just realized I never submitted this pull request.

Looks like there's plans to give the configuration some attention for 2.1, but maybe this is still a useful step.