### PR TITLE
Make the result arguments of the new formatter api produce the proper backtrace

### DIFF
--- a/features/docs/formatters/junit_formatter.feature
+++ b/features/docs/formatters/junit_formatter.feature
@@ -335,6 +335,9 @@ You *must* specify --out DIR for the junit formatter
         <failure message="pending Using scenario outlines (outline example : | is pending |)" type="pending">
           <![CDATA[Scenario Outline: Using scenario outlines
 
+      Example row: | is pending |
+
+      Message:
       ]]>
           <![CDATA[TODO (Cucumber::Pending)
       ./features/step_definitions/steps.rb:3:in `/^this step is pending$/'
@@ -348,8 +351,11 @@ You *must* specify --out DIR for the junit formatter
         <failure message="undefined Using scenario outlines (outline example : | is undefined |)" type="undefined">
           <![CDATA[Scenario Outline: Using scenario outlines
 
+      Example row: | is undefined |
+
+      Message:
       ]]>
-          <![CDATA[Undefined step: "this step is undefined" (Cucumber::Undefined)
+          <![CDATA[Undefined step: "this step is undefined" (Cucumber::Core::Test::Result::Undefined)
       features/scenario_outline.feature:11:in `Given this step is undefined'
       features/scenario_outline.feature:4:in `Given this step <type>']]>
         </failure>

--- a/lib/cucumber/formatter/backtrace_filter.rb
+++ b/lib/cucumber/formatter/backtrace_filter.rb
@@ -1,0 +1,40 @@
+require 'cucumber/platform'
+
+
+module Cucumber
+  module Formatter
+
+    class BacktraceFilter
+      BACKTRACE_FILTER_PATTERNS = \
+      [/vendor\/rails|lib\/cucumber|bin\/cucumber:|lib\/rspec|gems\/|minitest|test\/unit|.gem\/ruby|lib\/ruby/]
+      if(::Cucumber::JRUBY)
+        BACKTRACE_FILTER_PATTERNS << /org\/jruby/
+      end
+      PWD_PATTERN = /#{::Regexp.escape(::Dir.pwd)}\//m
+
+      def initialize(exception)
+        @exception = exception
+      end
+
+      def exception
+        return @exception if ::Cucumber.use_full_backtrace
+        @exception.backtrace.each{|line| line.gsub!(PWD_PATTERN, "./")}
+
+        filtered = (@exception.backtrace || []).reject do |line|
+          BACKTRACE_FILTER_PATTERNS.detect { |p| line =~ p }
+        end
+
+        if ::ENV['CUCUMBER_TRUNCATE_OUTPUT']
+          # Strip off file locations
+          filtered = filtered.map do |line|
+            line =~ /(.*):in `/ ? $1 : line
+          end
+        end
+
+        @exception.set_backtrace(filtered)
+        @exception
+      end
+    end
+
+  end
+end

--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -129,26 +129,18 @@ module Cucumber
         @header_row = false if @header_row
       end
 
-      def before_test_case(test_case)
-        if @options[:expand] and test_case.keyword == "Scenario Outline"
-          @exception = nil
-        end
-      end
-
-      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background, file_colon_line)
-        if @options[:expand] and @in_examples
-          if not @exception and exception
-            @exception = exception
-          end
-        end
-      end
-
       def after_test_case(test_case, result)
         if @options[:expand] and test_case.keyword == "Scenario Outline"
           test_case_name = NameBuilder.new(test_case)
           @scenario = test_case_name.outline_name
           @output = "#{test_case.keyword}: #{@scenario}\n\n"
-          if result.failed?
+          @exception = nil
+          if result.failed? or (@options[:strict] and (result.pending? or result.undefined?))
+            if result.failed?
+              @exception = result.exception
+            elsif result.backtrace
+              @exception = result
+            end
             @output += "Example row: #{test_case_name.row_name}\n"
             @output += "\nMessage:\n"
           end


### PR DESCRIPTION
To make the result object of the new formatter api directly usable in the formatters (and not rely on classes in the LegacyApi module):
* move the BacktraceFilter class to the Cucumber::Formatter module
* move the appending of the step backtrace line to Cucumber-ruby-core (cucumber/cucumber-ruby-core#88)
* apply the backtrace filter on the result in the call to the new formatter api methods

Depends on cucumber/cucumber-ruby-core#88

Fixes #833.