### PR TITLE
[cleanup] Nowadays, DocString compares to Strings

### DIFF
--- a/features/lib/step_definitions/junit_steps.rb
+++ b/features/lib/step_definitions/junit_steps.rb
@@ -1,7 +1,7 @@
 Then(/^the junit output file "(.*?)" should contain:$/) do |actual_file, text|
   actual = IO.read(current_dir + '/' + actual_file)
   actual = replace_junit_time(actual)
-  expect(actual).to eq text.to_s
+  expect(actual).to eq text
 end
 
 module JUnitHelper


### PR DESCRIPTION
  - In 2014, this was a trouble https://github.com/cucumber/cucumber/pull/669 but nowadays, String and DocStrings compare fine.