### PR TITLE
Rewrite the Progress, Usage, Stepdefs formatters to the new formatter api

### DIFF
--- a/features/docs/defining_steps/printing_messages.feature
+++ b/features/docs/defining_steps/printing_messages.feature
@@ -137,12 +137,12 @@ Feature: Pretty formatter - Printing messages
         Announce
         
         Me
-        ..-UUUUUU
+        ..UUU
         Announce with fail
-        F--
+        F-
         Line: 1: anno1
-        FFF
+        F
         Line: 2: anno2
-        ...
+        .
         """
 

--- a/features/docs/formatters/usage_formatter.feature
+++ b/features/docs/formatters/usage_formatter.feature
@@ -61,7 +61,7 @@ Feature: Usage formatter
     When I run `cucumber -x -f usage --dry-run`
     Then it should pass with exactly:
       """
-      ----------
+      -----------
       
       /A/       # features/step_definitions/steps.rb:1
         Given A # features/f.feature:3
@@ -87,7 +87,7 @@ Feature: Usage formatter
       When I run `cucumber -f stepdefs --dry-run`
       Then it should pass with exactly:
         """
-        --------
+        -----------
         
         /A/   # features/step_definitions/steps.rb:1
         /B/   # features/step_definitions/steps.rb:2

--- a/features/docs/gherkin/outlines.feature
+++ b/features/docs/gherkin/outlines.feature
@@ -138,7 +138,7 @@ Feature: Scenario outlines
     When I run `cucumber -q --format progress features/outline_sample.feature`
     Then it should fail with exactly:
       """
-      --UU..FF..
+      U-..F-..
 
       (::) failed steps (::)
 
@@ -155,4 +155,3 @@ Feature: Scenario outlines
       0m0.012s
 
       """
-

--- a/lib/cucumber/formatter/console.rb
+++ b/lib/cucumber/formatter/console.rb
@@ -76,7 +76,7 @@ module Cucumber
         end
       end
 
-      def print_stats(features, options)
+      def print_stats(duration, options)
         failures = collect_failing_scenarios(runtime)
         if !failures.empty?
           print_failing_scenarios(failures, options.custom_profiles, options[:source])
@@ -85,7 +85,7 @@ module Cucumber
         @io.puts scenario_summary(runtime) {|status_count, status| format_string(status_count, status)}
         @io.puts step_summary(runtime) {|status_count, status| format_string(status_count, status)}
 
-        @io.puts(format_duration(features.duration)) if features && features.duration
+        @io.puts(format_duration(duration)) if duration
 
         if runtime.configuration.randomize?
           @io.puts

--- a/lib/cucumber/formatter/duration_extractor.rb
+++ b/lib/cucumber/formatter/duration_extractor.rb
@@ -1,0 +1,28 @@
+module Cucumber
+  module Formatter
+
+    class DurationExtractor
+      attr_reader :result_duration
+      def initialize(result)
+        @result_duration = 0
+        result.describe_to(self)
+      end
+
+      def passed(*) end
+
+      def failed(*) end
+
+      def undefined(*) end
+
+      def skipped(*) end
+
+      def pending(*) end
+
+      def exception(*) end
+
+      def duration(duration, *)
+        duration.tap { |duration| @result_duration = duration.nanoseconds / 10**9.0 }
+      end
+    end
+  end
+end

--- a/lib/cucumber/formatter/legacy_api/runtime_facade.rb
+++ b/lib/cucumber/formatter/legacy_api/runtime_facade.rb
@@ -23,6 +23,10 @@ module Cucumber
         def steps(status = nil)
           results.steps(status)
         end
+
+        def step_match(step_name, name_to_report=nil)
+          support_code.step_match(step_name, name_to_report)
+        end
       end
 
     end

--- a/lib/cucumber/formatter/pretty.rb
+++ b/lib/cucumber/formatter/pretty.rb
@@ -240,7 +240,8 @@ module Cucumber
       end
 
       def print_summary(features)
-        print_stats(features, @options)
+        duration = features ? features.duration : nil
+        print_stats(duration, @options)
         print_snippets(@options)
         print_passing_wip(@options)
       end


### PR DESCRIPTION
Since these formatters are related through inheritance they are modified together. Since the Stepdef formatter neither defined any method of the old formatter api, nor defines any methods of the new formatter api, it is updated to the new formatter api by the changes in the Progress and Usage formatters.

Also some deficiencies of the Progress formatter are fixed, both that outline steps were printed as skipped (fixes #316), and some cases where the printed progress characters did not match the step count in the summary ([here only 8 '-' were printed, but the step count says 11 skipped](https://github.com/cucumber/cucumber/blob/09b0ae424233e5c429bdeb0b9d29f34846d52e09/features/docs/formatters/usage_formatter.feature#L38-L55)).

Related to #839.