### PR TITLE
Failing spec for html formatter scenario-level comment

### DIFF
--- a/spec/cucumber/formatter/html_spec.rb
+++ b/spec/cucumber/formatter/html_spec.rb
@@ -90,6 +90,17 @@ module Cucumber
           it { expect(@doc).to have_css_node('.feature .comment', /Healthy/) }
         end
 
+        describe "with a comment at scenario level" do
+          define_feature <<-FEATURE
+            Feature: Foo
+              # Healthy Scenario
+              Scenario:
+                Given passing
+          FEATURE
+
+          it { expect(@doc).to have_css_node('.scenario .comment', /Healthy Scenario/) }
+        end
+
         describe "with a tag" do
           define_feature <<-FEATURE
             @foo


### PR DESCRIPTION
Between 1.3.19 and 2.0.0, if you have a comment in a feature file at the scenario level, the html formatter does not include it in the output.  This failing spec demonstrates that behaviour.