### PR TITLE
Avoid writing JUnit results that have no testcases

### DIFF
--- a/lib/cucumber/formatter/junit.rb
+++ b/lib/cucumber/formatter/junit.rb
@@ -162,6 +162,8 @@ module Cucumber
       end
 
       def write_file(feature_filename, data)
+        return unless @tests > 0
+
         File.open(feature_filename, 'w') { |file| file.write(data) }
       end
 


### PR DESCRIPTION
Jenkins chokes on JUnit XML results that contain no `testcase` elements, a scenario that can arise due to issue #124. Backporting the fix to the latter proved to be insanely difficult so I wrote this expedient workaround that avoids writing out XML where no test results were actually handled.