### PR TITLE
DOC: Installation page additions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,9 @@
 * [About this Documentation](docs/about-this-documentation.md)
 * [Installation](docs/installation.md)
   * [Pick your Flavour](#)
+    * [Ruby](docs/installation.md#ruby)
+    * [Java](docs/installation.md#java)
+    * [Javascript](docs/installation.md#javascript)
     * [Unofficial Cucumbers](#)
 * [10 minute tutorial](docs/10-minute-tutorial.md)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ $ gem install cucumber
 
 Before you can use the generator, add the gem to your project's Gemfile as follows:
 
-``` shell
+``` ruby
     group :test do
       gem 'cucumber-rails', :require => false
       # database_cleaner is not required, but highly recommended

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,13 +2,51 @@
 
 Cucumber exists for different platforms such as Java, JavaScript, Ruby etc. Cucumber is a command-line tool, and how you install it depends on your platform.
 
-## Java
+## Ruby {#ruby}
+
+### Gem {#gem}
+
+Cucumber for Ruby is a ruby gem, and can be installed from the command line. After you have installed Ruby and RubyGems, install Cucumber with the following command:
+
+``` shell
+$ gem install cucumber
+```
+### Ruby on Rails {#rails}
+
+Before you can use the generator, add the gem to your project's Gemfile as follows:
+
+``` shell
+    group :test do
+      gem 'cucumber-rails', :require => false
+      # database_cleaner is not required, but highly recommended
+      gem 'database_cleaner'
+    end
+```
+Then install it by running:
+
+``` shell
+    bundle install
+```
+
+Learn about the various options:
+
+``` shell
+    rails generate cucumber:install --help
+```
+
+Finally, bootstrap your Rails app, for example:
+
+``` shell
+    rails generate cucumber:install
+```
+
+## Java {#java}
 Cucumber is published as several jar files in the central Maven repository. Installation is simply a matter of adding a dependency in your build file:
 
-### Maven
+### Maven {#maven}
 
 Add these dependencies to your project:
-
+``` java
     <dependency>
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-java</artifactId>
@@ -22,9 +60,14 @@ Add these dependencies to your project:
         <version>1.2.4</version>
         <scope>test</scope>
     </dependency>
+```
 
+### Gradle {#gradle}
 
-### Gradle
+## JavaScript {#javascript}
 
-## JavaScript
+Cucumber.js is available as an npm module.
 
+``` shell
+$ npm install cucumber
+```


### PR DESCRIPTION
Using installation instructions from the https://cucumber.io/docs#installation pages to add Javascript and Ruby instructions. Adding some structure to the installation part of the SUMMARY.md menu.