### PR TITLE
[docs] gherkin.md: Fix invalid link

### DIFF
--- a/docs/gherkin.md
+++ b/docs/gherkin.md
@@ -39,7 +39,7 @@ Given <I'm a placeholder and I'm ok>
 
 The placeholders indicate that when the Examples row is run they should be substituted with real values from the `Examples` table. If a placeholder name is the same as a column title in the `Examples` table then this is the value that will replace it.
 
-You can also use placeholders in [Multiline Step Arguments](docs/gherkin.md#doc-strings).
+You can also use placeholders in [Multiline Step Arguments](gherkin.md#doc-strings).
 
 **IMPORTANT:** *Your step definitions will never have to match a placeholder. They will need to match the values that will replace the placeholder*
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Fixed a link in the document that points to invalid url.

## Details
Previously the link points to `https://github.com/cucumber/cucumber/blob/master/docs/docs/gherkin.md#doc-strings` because the markdown is `docs/gherkin.md#doc-strings`.

Removed the `docs`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The invalid link creates inconvenience for new learners.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Clicked and the link now works.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

