### PR TITLE
cucumber-react: Add gutterFn optional property

### DIFF
--- a/cucumber-react/lib/cucumber_react.jsx
+++ b/cucumber-react/lib/cucumber_react.jsx
@@ -4,35 +4,45 @@ import Immutable from "immutable"
 const EMPTY_LIST = new Immutable.List()
 const EMPTY_MAP = new Immutable.Map()
 
-const Cucumber = ({sources}) =>
+const Cucumber = ({sources, gutterFn}) =>
   <div>
     <h1>Cucumber HTML</h1>
-    {Array.from(sources.keys()).map(uri => <GherkinDocument node={sources.get(uri)} uri={uri} key={uri}/>)}
+    {Array.from(sources.keys()).map(uri => <GherkinDocument node={sources.get(uri)}
+                                                            uri={uri}
+                                                            key={uri}
+                                                            gutterFn={gutterFn}/>)}
   </div>
 
 Cucumber.propTypes = {
-  sources: React.PropTypes.instanceOf(Immutable.Map).isRequired
+  sources: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+  gutterFn: React.PropTypes.func
 }
 
-const GherkinDocument = ({node, uri}) =>
+const GherkinDocument = ({node, uri, gutterFn}) =>
   <div>
-    <Feature node={node.get('feature')} uri={uri} attachmentsByLine={node.get('attachments', EMPTY_MAP)}/>
+    <Feature node={node.get('feature')}
+             uri={uri}
+             attachmentsByLine={node.get('attachments', EMPTY_MAP)}
+             gutterFn={gutterFn}/>
   </div>
 
 GherkinDocument.propTypes = {
   node: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-  uri: React.PropTypes.string.isRequired
+  uri: React.PropTypes.string.isRequired,
+  gutterFn: React.PropTypes.func
 }
 
-const Feature = ({node, uri, attachmentsByLine}) =>
+const Feature = ({node, uri, attachmentsByLine, gutterFn}) =>
   <div>
+    {gutterFn && gutterFn(uri, node.getIn(['location', 'line']), node.getIn(['location', 'column']))}
     <h2 className="feature"><span>{node.get('keyword')}: </span><span className="name">{node.get('name')}</span></h2>
     {Array.from(node.get('children')).map(child => {
       const line = child.getIn(['location', 'line'])
       const key = `${uri}:${line}`
       return <Scenario node={child}
-                       attachmentsByLine={attachmentsByLine}
                        uri={uri}
+                       attachmentsByLine={attachmentsByLine}
+                       gutterFn={gutterFn}
                        key={key}/>
     })}
   </div>
@@ -40,11 +50,13 @@ const Feature = ({node, uri, attachmentsByLine}) =>
 Feature.propTypes = {
   node: React.PropTypes.instanceOf(Immutable.Map).isRequired,
   uri: React.PropTypes.string.isRequired,
-  attachmentsByLine: React.PropTypes.instanceOf(Immutable.Map).isRequired
+  attachmentsByLine: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+  gutterFn: React.PropTypes.func
 }
 
-const Scenario = ({node, uri, attachmentsByLine}) =>
+const Scenario = ({node, uri, attachmentsByLine, gutterFn}) =>
   <div>
+    {gutterFn && gutterFn(uri, node.getIn(['location', 'line']), node.getIn(['location', 'column']))}
     <h3 className="scenario"><span>{node.get('keyword')}: </span><span className="name">{node.get('name')}</span></h3>
     <ol>
       {Array.from(node.get('steps')).map(step => {
@@ -53,8 +65,9 @@ const Scenario = ({node, uri, attachmentsByLine}) =>
         const attachments = attachmentsByLine.get(line, EMPTY_LIST)
         return <Step
           node={step}
-          attachments={attachments}
           uri={uri}
+          attachments={attachments}
+          gutterFn={gutterFn}
           key={key}/>
       })}
     </ol>
@@ -64,11 +77,13 @@ const Scenario = ({node, uri, attachmentsByLine}) =>
 Scenario.propTypes = {
   node: React.PropTypes.instanceOf(Immutable.Map).isRequired,
   uri: React.PropTypes.string.isRequired,
-  attachmentsByLine: React.PropTypes.instanceOf(Immutable.Map).isRequired
+  attachmentsByLine: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+  gutterFn: React.PropTypes.func
 }
 
-const Step = ({node, uri, attachments}) =>
+const Step = ({node, uri, attachments, gutterFn}) =>
   <li>
+    {gutterFn && gutterFn(uri, node.getIn(['location', 'line']), node.getIn(['location', 'column']))}
     <span className="step"><span>{node.get('keyword')}</span><span className="text">{node.get('text')}</span></span>
     {Array.from(attachments).map((attachment, n) => <Attachment
       attachment={attachment}
@@ -78,7 +93,8 @@ const Step = ({node, uri, attachments}) =>
 Step.propTypes = {
   node: React.PropTypes.instanceOf(Immutable.Map).isRequired,
   uri: React.PropTypes.string.isRequired,
-  attachments: React.PropTypes.instanceOf(Immutable.List).isRequired
+  attachments: React.PropTypes.instanceOf(Immutable.List).isRequired,
+  gutterFn: React.PropTypes.func
 }
 
 const Attachment = ({attachment}) => {

--- a/cucumber-react/test/cucumber_react_test.js
+++ b/cucumber-react/test/cucumber_react_test.js
@@ -120,6 +120,17 @@ describe('Cucumber React', () => {
       const component = shallow(<Step node={node} uri={uri} attachments={attachments}/>)
       assert.equal(component.find(Attachment).length, 2)
     })
+
+    it("renders a gutter element", () => {
+      const uri = 'features/hello.feature'
+      const node = state.getIn(['sources', uri, 'feature', 'children', 0, 'steps', 0])
+      const attachments = state.getIn(['sources', uri, 'attachments', 3])
+
+      const gutterFn = (uri, line, column) => <div className="gutter">{uri}:{line}:{column}</div>
+
+      const component = shallow(<Step node={node} uri={uri} attachments={attachments} gutterFn={gutterFn}/>)
+      assert.equal(component.find('.gutter').text(), 'features/hello.feature:3:5')
+    })
   })
 
   describe(Attachment.name, () => {

--- a/cucumber-react/test/cucumber_react_test.js
+++ b/cucumber-react/test/cucumber_react_test.js
@@ -72,7 +72,7 @@ describe('Cucumber React', () => {
       assert.equal(component.find('.name').text(), 'Hello')
     })
 
-    it("renders the scenario", () => {
+    it("renders scenarios", () => {
       const uri = 'features/hello.feature'
       const node = state.getIn(['sources', uri, 'feature'])
       const attachmentsByLine = state.getIn(['sources', uri, 'attachments'])
@@ -92,7 +92,7 @@ describe('Cucumber React', () => {
       assert.equal(component.find('.name').text(), 'World')
     })
 
-    it("renders the step", () => {
+    it("renders steps", () => {
       const uri = 'features/hello.feature'
       const node = events.reduce(reducer, reducer()).getIn(['sources', uri, 'feature', 'children', 0])
       const attachmentsByLine = state.getIn(['sources', uri, 'attachments'])
@@ -103,9 +103,18 @@ describe('Cucumber React', () => {
   })
 
   describe(Step.name, () => {
+    it("renders the text", () => {
+      const uri = 'features/hello.feature'
+      const node = state.getIn(['sources', uri, 'feature', 'children', 0, 'steps', 0])
+      const attachments = state.getIn(['sources', uri, 'attachments', 3])
+
+      const component = shallow(<Step node={node} uri={uri} attachments={attachments}/>)
+      assert.equal(component.find('.text').text(), 'hello')
+    })
+
     it("renders attachments", () => {
       const uri = 'features/hello.feature'
-      const node = state.getIn(['sources', uri, 'feature', 'children', 0])
+      const node = state.getIn(['sources', uri, 'feature', 'children', 0, 'steps', 0])
       const attachments = state.getIn(['sources', uri, 'attachments', 3])
 
       const component = shallow(<Step node={node} uri={uri} attachments={attachments}/>)

--- a/cucumber-react/test/reducer_test.js
+++ b/cucumber-react/test/reducer_test.js
@@ -70,8 +70,8 @@ describe(reducer.name, () => {
 
     const attachments = state.getIn(['sources', 'features/hello.feature', 'attachments', 22])
     assert.deepEqual(attachments.toJS(), [
-      { uri: 'build/screenshots/hello.png', data: undefined, media: undefined },
-      { uri: 'build/screenshots/world.png', data: undefined, media: undefined }
+      {uri: 'build/screenshots/hello.png', data: undefined, media: undefined},
+      {uri: 'build/screenshots/world.png', data: undefined, media: undefined}
     ])
   })
 })

--- a/html-formatter/nodejs/lib/react/html_formatter_app.jsx
+++ b/html-formatter/nodejs/lib/react/html_formatter_app.jsx
@@ -15,9 +15,11 @@ const mapStateToProps = (state) => {
 }
 
 const ConnectedCucumber = connect(mapStateToProps)(Cucumber)
+const gutterFn = (uri, line, column) => <button style={{float: 'right'}}>Comment on {uri}:{line}:{column}</button>
 
 const provider = <Provider store={store}>
-  <ConnectedCucumber sources={store.getState().get('sources')}/>
+  <ConnectedCucumber sources={store.getState().get('sources')}
+                     gutterFn={gutterFn}/>
 </Provider>
 
 render(provider, document.getElementById('app'))


### PR DESCRIPTION
## Summary

Customisable gutter element for React-rendered Gherkin nodes
## Details

This adds an optional `gutterFn(uri, line, column) => React.Component` property to Cucumber React components.
## Motivation and Context

This provides a simple plugin mechanism that allows users to render custom widgets next to each Gherkin node. These widgets can be anything, and the current need is commenting functionality in Cucumber Pro.
## How Has This Been Tested?

Enzyme tests
## Screenshots (if appropriate):

The screenshot is from the Cucumber HTML Formatter running in server mode.

![screen shot 2016-09-16 at 12 51 12](https://cloud.githubusercontent.com/assets/1000/18585165/303da350-7c0d-11e6-8e77-7ba20deb67e8.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
