### PR TITLE
update javascript cucumber-tag-expressions

### DIFF
--- a/tag-expressions/javascript/README.md
+++ b/tag-expressions/javascript/README.md
@@ -3,3 +3,15 @@
 [![Build Status](https://travis-ci.org/cucumber/tag-expressions-javascript.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-javascript)
 
 [The docs are here](http://docs.cucumber.io/tag-expressions/).
+
+## Example
+
+```js
+var TagExpressionParser = require('cucumber-tag-expressions').TagExpressionParser;
+var tagExpressionParser = new TagExpressionParser();
+
+var expressionNode = tagExpressionParser.parse('@tagA and @tagB');
+
+expressionNode.evaluate(["@tagA", "@tagB"]); # => true
+expressionNode.evaluate(["@tagA", "@tagC"]); # => false
+```

--- a/tag-expressions/javascript/README.md
+++ b/tag-expressions/javascript/README.md
@@ -7,11 +7,11 @@
 ## Example
 
 ```js
-var TagExpressionParser = require('cucumber-tag-expressions').TagExpressionParser;
-var parser = new TagExpressionParser();
+import {TagExpressionParser} from 'cucumber-tag-expressions'
+const parser = new TagExpressionParser()
 
-var expressionNode = parser.parse('@tagA and @tagB');
+const expressionNode = parser.parse('@tagA and @tagB')
 
-expressionNode.evaluate(["@tagA", "@tagB"]); # => true
-expressionNode.evaluate(["@tagA", "@tagC"]); # => false
+expressionNode.evaluate(["@tagA", "@tagB"]) // => true
+expressionNode.evaluate(["@tagA", "@tagC"]) // => false
 ```

--- a/tag-expressions/javascript/README.md
+++ b/tag-expressions/javascript/README.md
@@ -8,9 +8,9 @@
 
 ```js
 var TagExpressionParser = require('cucumber-tag-expressions').TagExpressionParser;
-var tagExpressionParser = new TagExpressionParser();
+var parser = new TagExpressionParser();
 
-var expressionNode = tagExpressionParser.parse('@tagA and @tagB');
+var expressionNode = parser.parse('@tagA and @tagB');
 
 expressionNode.evaluate(["@tagA", "@tagB"]); # => true
 expressionNode.evaluate(["@tagA", "@tagC"]); # => false

--- a/tag-expressions/javascript/index.js
+++ b/tag-expressions/javascript/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TagExpressionParser: require('lib/tag_expression_parser')
+};

--- a/tag-expressions/javascript/index.js
+++ b/tag-expressions/javascript/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  TagExpressionParser: require('lib/tag_expression_parser')
+  TagExpressionParser: require('./lib/tag_expression_parser')
 };


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Integrated this with a feature branch and would like some updates. Currently you cannot do `require('cucumber-tag-expressions')` because it does not have an `index.js` in the project directory or a `main` file specificed in the `package.json` 

## Details

This adds `index.js` to the javascript module so it can be required.  You can then access the `TagExpressionParser` property on the result.

## Motivation and Context

Currently `require('cucumber-tag-expressions')` throws cannot find module.
Using `require('cucumber-tag-expressions/lib/tag_expression_parser')` feels wrong and likely to break
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code 
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

This type of file isn't typically tested. I added it manually to my installed node module locally and it was working