### PR TITLE
[cucumber-expressions] handle optional groups in regexp.

### DIFF
--- a/cucumber-expressions/examples.txt
+++ b/cucumber-expressions/examples.txt
@@ -13,3 +13,7 @@ I have 22 cukes in my belly now
 /I have (-?\d+) cukes? in my (.*) now/
 I have 1 cuke in my belly now
 [1,"belly"]
+---
+/^Something( with an optional argument)?$/
+Something
+[null]

--- a/cucumber-expressions/java/examples.txt
+++ b/cucumber-expressions/java/examples.txt
@@ -13,3 +13,7 @@ I have 22 cukes in my belly now
 /I have (-?\d+) cukes? in my (.*) now/
 I have 1 cuke in my belly now
 [1,"belly"]
+---
+/^Something( with an optional argument)?$/
+Something
+[null]

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ConstructorTransform.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ConstructorTransform.java
@@ -20,6 +20,9 @@ public class ConstructorTransform<T> extends AbstractTransform<T> {
 
     @Override
     public T transform(String value) {
+        if (value == null) {
+            return (T)null;
+        }
         try {
             return constructor.newInstance(value);
         } catch (Exception e) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ConstructorTransformTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ConstructorTransformTest.java
@@ -3,6 +3,7 @@ package io.cucumber.cucumberexpressions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class ConstructorTransformTest {
@@ -50,5 +51,10 @@ public class ConstructorTransformTest {
             assertEquals("Failed to invoke `new Abstract(\"hello\")`", expected.getMessage());
             assertEquals(InstantiationException.class, expected.getCause().getClass());
         }
+    }
+
+    @Test
+    public void returns_null_for_value_null() {
+        assertNull(new ConstructorTransform<>(Abstract.class).transform(null));
     }
 }

--- a/cucumber-expressions/javascript/examples.txt
+++ b/cucumber-expressions/javascript/examples.txt
@@ -13,3 +13,7 @@ I have 22 cukes in my belly now
 /I have (-?\d+) cukes? in my (.*) now/
 I have 1 cuke in my belly now
 [1,"belly"]
+---
+/^Something( with an optional argument)?$/
+Something
+[null]

--- a/cucumber-expressions/ruby/examples.txt
+++ b/cucumber-expressions/ruby/examples.txt
@@ -13,3 +13,7 @@ I have 22 cukes in my belly now
 /I have (-?\d+) cukes? in my (.*) now/
 I have 1 cuke in my belly now
 [1,"belly"]
+---
+/^Something( with an optional argument)?$/
+Something
+[null]


### PR DESCRIPTION
## Summary

To be able to handle optional groups in regexp, null should be transformed to null.

## Details

[Java] When performing a constructor transform on the value null, the transformed object should also be null.

## Motivation and Context

To be able to use cucumber-expressions in Cucumber-JVM optional groups in regexps ([like this](https://github.com/cucumber/cucumber-jvm/blob/master/jruby/src/test/resources/cucumber/runtime/jrubytest/stepdefs.rb#L33-L35)) need to be handled. Currently the Java implementation throws a "Failed to invoke `new String("null")`" instead.

## How Has This Been Tested?

- [X] Tests are included
- [X] Has been tested with Cucumber-JVM (the stepdef linked above)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [X] I've added tests for my code.
- [X] My change does not requires a change to the documentation.
