### PR TITLE
tag-expressions: (Java) Make the jar a bundle to support osgi.

### DIFF
--- a/tag-expressions/java/pom.xml
+++ b/tag-expressions/java/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.cucumber</groupId>
     <artifactId>tag-expressions</artifactId>
     <version>1.0.0</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Cucumber Tag Expressions</name>
     <description>Parses boolean infix expressions</description>
     <url>https://github.com/cucumber/tag-expressions-java</url>
@@ -70,6 +70,17 @@
                 <version>2.5.2</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>io.cucumber.tagexpressions.*</Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Summary

Build the tag-expressions jar as a OSGi bundle.

## Details

* Declare the packaging type as `bundle`
* Use the `maven-bundle-plugin` to create the manifest according to the OSGi requirement.
 
## Motivation and Context

cucumber/cucumber-jvm#873 added support to execute Cucumber-JVM in OSGi containers. To not lose that ability when using the tag-expression library in Cucumber-JVM, the tag-expressions jar need to be built as an OSGi bundle.

## How Has This Been Tested?

I have locally run the [pax-exam example of Cucumber-JVM](https://github.com/cucumber/cucumber-jvm/tree/master/examples/pax-exam), which exemplifies testing OSGi bundles, successfully with these changes.

## Types of changes

- [X] New feature (non-breaking change which adds functionality).
