### PR TITLE
[cucumber-expressions] Handle multiple capture group regexps for matching

### DIFF
--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -41,7 +41,7 @@ class CucumberExpression {
       this._transforms.push(transform)
 
       const text = expression.slice(matchOffset, match.index)
-      const captureRegexp = `(${transform.captureGroupRegexps[0]})`
+      const captureRegexp = getCaptureRegexp(transform.captureGroupRegexps)
       matchOffset = parameterPattern.lastIndex
       regexp += text
       regexp += captureRegexp
@@ -58,6 +58,18 @@ class CucumberExpression {
   get source() {
     return this._expression
   }
+}
+
+function getCaptureRegexp(captureGroupRegexps) {
+  if (captureGroupRegexps.length === 1) {
+    return `(${captureGroupRegexps[0]})`
+  }
+
+  const captureGroups = captureGroupRegexps.map(group => {
+    return `(?:${group})`
+  })
+
+  return `(${captureGroups.join('|')})`
 }
 
 export default CucumberExpression

--- a/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
@@ -22,7 +22,7 @@ describe(CucumberExpression.name, () => {
     it("translates three typed arguments", () => {
       assertRegexp(
         "I have {n:float} cukes in my {bodypart} at {time:int} o'clock",
-        /^I have (-?\d*\.?\d+) cukes in my (.+) at (-?\d+) o'clock$/
+        /^I have (-?\d*\.?\d+) cukes in my (.+) at ((?:-?\d+)|(?:\d+)) o'clock$/
       )
     })
 

--- a/cucumber-expressions/javascript/test/custom_transform_test.js
+++ b/cucumber-expressions/javascript/test/custom_transform_test.js
@@ -22,7 +22,7 @@ describe('Custom transform', () => {
     transformLookup.addTransform(new Transform(
       'color',
       Color,
-      'red|blue|yellow',
+      ['red|blue|yellow', '(?:dark|light) (?:red|blue|yellow)'],
       s => new Color(s)
     ))
     /// [add-color-transform]
@@ -33,6 +33,12 @@ describe('Custom transform', () => {
       const expression = new CucumberExpression("I have a {color:color} ball", [], transformLookup)
       const transformedArgumentValue = expression.match("I have a red ball")[0].transformedValue
       assert.equal(transformedArgumentValue.name, "red")
+    })
+
+    it("transforms arguments with expression type", () => {
+      const expression = new CucumberExpression("I have a {color:color} ball", [], transformLookup)
+      const transformedArgumentValue = expression.match("I have a dark red ball")[0].transformedValue
+      assert.equal(transformedArgumentValue.name, "dark red")
     })
 
     it("transforms arguments with explicit type", () => {


### PR DESCRIPTION
## Summary

When creating a new transform with multiple capture group regexps, cucumber fail to match expressions that are not using the first capturing regexp.

For instance, a transform with the captureGroupRegexps with the value ['red', 'yellow'] would fail to match an expression containing yellow.

## Details
The matching expression is now a disjonction of all the capturing regexps using non capturing group (with `(?:...)`).

## Motivation and Context

I had an issue when using multiple regexps for the same transform as it was only matching the first one. This commit fix it.

## How Has This Been Tested?

I added one test that use the second regexp of the `captureGroupRegexps` option of a transform (and that is not matching a subset of the first regexp).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
