### PR TITLE
users can now directly require the npm module

### DIFF
--- a/tag-expressions/javascript/package.json
+++ b/tag-expressions/javascript/package.json
@@ -2,6 +2,7 @@
   "name": "cucumber-tag-expressions",
   "version": "1.0.0",
   "description": "Cucumber Tag Expression parser",
+  "main": "./lib/tag_expression_parser.js",
   "scripts": {
     "test": "ISTANBUL=true istanbul cover _mocha -- --recursive",
     "posttest": "istanbul check-coverage --statements 100 --branches 94",


### PR DESCRIPTION
## Summary
Currently a user has to traverse to the folder containing the lib after installing the npm module. Adding a main property to the package.json removes the need for this. Closes #104 

## How Has This Been Tested?
Linked locally as an npm module and required in project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
