### PR TITLE
cucumber-expressions: Untyped GeneratedExpression

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
@@ -1,26 +1,50 @@
 package io.cucumber.cucumberexpressions;
 
+import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CucumberExpressionGenerator {
+    private static final Collator ENGLISH_COLLATOR = Collator.getInstance(Locale.ENGLISH);
+    private static final String JAVA_KEYWORDS[] = {
+            "abstract", "assert", "boolean", "break", "byte", "case",
+            "catch", "char", "class", "const", "continue",
+            "default", "do", "double", "else", "extends",
+            "false", "final", "finally", "float", "for",
+            "goto", "if", "implements", "import", "instanceof",
+            "int", "interface", "long", "native", "new",
+            "null", "package", "private", "protected", "public",
+            "return", "short", "static", "strictfp", "super",
+            "switch", "synchronized", "this", "throw", "throws",
+            "transient", "true", "try", "void", "volatile",
+            "while"
+    };
+
+    private static boolean isJavaKeyword(String keyword) {
+        return (Arrays.binarySearch(JAVA_KEYWORDS, keyword, ENGLISH_COLLATOR) >= 0);
+    }
+
     private final TransformLookup transformLookup;
 
     public CucumberExpressionGenerator(TransformLookup transformLookup) {
         this.transformLookup = transformLookup;
     }
 
-    public GeneratedExpression generateExpression(String text, boolean typed) {
+    public GeneratedExpression generateExpression(String text) {
         List<String> argumentNames = new ArrayList<>();
         List<TransformMatcher> transformMatchers = createTransformMatchers(text);
         List<Transform<?>> transforms = new ArrayList<>();
+        Map<String, Integer> usageByTypeName = new HashMap<>();
 
         StringBuilder expression = new StringBuilder();
-        int argCounter = 0;
         int pos = 0;
         while (true) {
             List<TransformMatcher> matchingTransformMatchers = new ArrayList<>();
@@ -33,22 +57,19 @@ public class CucumberExpressionGenerator {
             }
 
             if (!matchingTransformMatchers.isEmpty()) {
-                String argumentName = "arg" + (++argCounter);
-                argumentNames.add(argumentName);
                 Collections.sort(matchingTransformMatchers);
                 TransformMatcher bestTransformMatcher = matchingTransformMatchers.get(0);
-                transforms.add(bestTransformMatcher.getTransform());
+                Transform<?> transform = bestTransformMatcher.getTransform();
+                transforms.add(transform);
+
+                String argumentName = getArgumentName(transform.getTypeName(), usageByTypeName);
+                argumentNames.add(argumentName);
 
                 expression
                         .append(text.substring(pos, bestTransformMatcher.start()))
                         .append("{")
-                        .append(argumentName);
-                if (typed) {
-                    expression
-                            .append(":")
-                            .append(bestTransformMatcher.getTransform().getTypeName());
-                }
-                expression.append("}");
+                        .append(transform.getTypeName())
+                        .append("}");
                 pos = bestTransformMatcher.start() + bestTransformMatcher.group().length();
             } else {
                 break;
@@ -60,6 +81,14 @@ public class CucumberExpressionGenerator {
         }
         expression.append(text.substring(pos));
         return new GeneratedExpression(expression.toString(), argumentNames, transforms);
+    }
+
+    private String getArgumentName(String typeName, Map<String, Integer> usageByTypeName) {
+        Integer count = usageByTypeName.get(typeName);
+        count = count != null ? count + 1 : 1;
+        usageByTypeName.put(typeName, count);
+
+        return count == 1 && !isJavaKeyword(typeName) ? typeName : typeName + count;
     }
 
     private List<TransformMatcher> createTransformMatchers(String text) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
@@ -2,10 +2,14 @@ package io.cucumber.cucumberexpressions;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 public class CucumberExpressionGeneratorTest {
@@ -15,54 +19,52 @@ public class CucumberExpressionGeneratorTest {
 
     @Test
     public void documents_expression_generation() {
-        TransformLookup transformLookup = new TransformLookup(Locale.ENGLISH);
         /// [generate-expression]
         CucumberExpressionGenerator generator = new CucumberExpressionGenerator(transformLookup);
         String undefinedStepText = "I have 2 cucumbers and 1.5 tomato";
-        GeneratedExpression generatedExpression = generator.generateExpression(undefinedStepText, true);
-        assertEquals("I have {arg1:int} cucumbers and {arg2:double} tomato", generatedExpression.getSource());
-        assertEquals("arg1", generatedExpression.getArgumentNames().get(0));
+        GeneratedExpression generatedExpression = generator.generateExpression(undefinedStepText);
+        assertEquals("I have {int} cucumbers and {double} tomato", generatedExpression.getSource());
         assertEquals(Double.TYPE, generatedExpression.getTransforms().get(1).getType());
         /// [generate-expression]
     }
 
     @Test
     public void generates_expression_for_no_args() {
-        assertTypedExpression("hello", "hello");
+        assertExpression("hello", Collections.<String>emptyList(), "hello");
     }
 
     @Test
     public void generates_expression_for_int_double_arg() {
-        assertTypedExpression(
-                "I have {arg1:int} cukes and {arg2:double} euro",
+        assertExpression(
+                "I have {int} cukes and {double} euro", asList("int1", "double1"),
                 "I have 2 cukes and 1.5 euro");
     }
 
     @Test
     public void generates_expression_for_just_int() {
-        assertTypedExpression(
-                "{arg1:int}",
+        assertExpression(
+                "{int}", singletonList("int1"),
                 "99999");
     }
 
     @Test
-    public void generates_expression_without_expression_type() {
-        assertUntypedExpression(
-                "I have {arg1} cukes and {arg2} euro",
-                "I have 2 cukes and 1.5 euro");
+    public void numbers_all_arguments_when_type_is_reserved_keyword() {
+        assertExpression(
+                "I have {int} cukes and {int} euro", asList("int1", "int2"),
+                "I have 2 cukes and 5 euro");
     }
 
     @Test
-    public void generates_expression_for_custom_type() {
+    public void numbers_only_second_argument_when_type_is_not_reserved_keyword() {
         transformLookup.addTransform(new SimpleTransform<>(
                 "currency",
                 Currency.class,
                 "[A-Z]{3}",
                 null
         ));
-        assertTypedExpression(
-                "I have a {arg1:currency} account",
-                "I have a EUR account");
+        assertExpression(
+                "I have a {currency} account and a {currency} account", asList("currency", "currency2"),
+                "I have a EUR account and a GBP account");
     }
 
     @Test
@@ -79,8 +81,8 @@ public class CucumberExpressionGeneratorTest {
                 "bc",
                 null
         ));
-        assertTypedExpression(
-                "a{arg1:date}defg",
+        assertExpression(
+                "a{date}defg", singletonList("date"),
                 "abcdefg");
     }
 
@@ -98,23 +100,21 @@ public class CucumberExpressionGeneratorTest {
                 "cde",
                 null
         ));
-        assertTypedExpression(
-                "ab{arg1:date}fg",
+        assertExpression(
+                "ab{date}fg", singletonList("date"),
                 "abcdefg");
     }
 
     @Test
     public void exposes_transforms_in_generated_expression() {
-        GeneratedExpression snippet = generator.generateExpression("I have 2 cukes and 1.5 euro", true);
-        assertEquals(int.class, snippet.getTransforms().get(0).getType());
-        assertEquals(double.class, snippet.getTransforms().get(1).getType());
+        GeneratedExpression generatedExpression = generator.generateExpression("I have 2 cukes and 1.5 euro");
+        assertEquals(int.class, generatedExpression.getTransforms().get(0).getType());
+        assertEquals(double.class, generatedExpression.getTransforms().get(1).getType());
     }
 
-    private void assertTypedExpression(String expected, String text) {
-        assertEquals(expected, generator.generateExpression(text, true).getSource());
-    }
-
-    private void assertUntypedExpression(String expected, String text) {
-        assertEquals(expected, generator.generateExpression(text, false).getSource());
+    private void assertExpression(String expectedExpression, List<String> expectedArgumentNames, String text) {
+        GeneratedExpression generatedExpression = generator.generateExpression(text);
+        assertEquals(expectedArgumentNames, generatedExpression.getArgumentNames());
+        assertEquals(expectedExpression, generatedExpression.getSource());
     }
 }

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/generated_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/generated_expression.rb
@@ -1,10 +1,10 @@
 module Cucumber
   module CucumberExpressions
     class GeneratedExpression
-      attr_reader :source, :argumentNames, :transforms
+      attr_reader :source, :argument_names, :transforms
 
-      def initialize(source, argumentNames, transforms)
-        @source, @argumentNames, @transforms = source, argumentNames, transforms
+      def initialize(source, argument_names, transforms)
+        @source, @argument_names, @transforms = source, argument_names, transforms
       end
     end
   end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
@@ -18,36 +18,35 @@ module Cucumber
         ### [generate-expression]
         generator = CucumberExpressionGenerator.new(transform_lookup)
         undefined_step_text = "I have 2 cucumbers and 1.5 tomato"
-        generated_expression = generator.generate_expression(undefined_step_text, true)
-        expect(generated_expression.source).to eq("I have {arg1:int} cucumbers and {arg2:float} tomato")
-        expect(generated_expression.argumentNames[0]).to eq("arg1")
+        generated_expression = generator.generate_expression(undefined_step_text)
+        expect(generated_expression.source).to eq("I have {int} cucumbers and {float} tomato")
         expect(generated_expression.transforms[1].type).to eq(Float)
         ### [generate-expression]
       end
 
       it "generates expression for no args" do
-        assert_typed_expression("hello", "hello")
+        assert_expression("hello", [], "hello")
       end
 
-      it "generates expression for int double arg" do
-        assert_typed_expression(
-          "I have {arg1:int} cukes and {arg2:float} euro",
+      it "generates expression for int float arg" do
+        assert_expression(
+          "I have {int} cukes and {float} euro", ["int", "float"],
           "I have 2 cukes and 1.5 euro")
       end
 
       it "generates expression for just int" do
-        assert_typed_expression(
-          "{arg1:int}",
+        assert_expression(
+          "{int}", ["int"],
           "99999")
       end
 
-      it "generates expression without expression type" do
-        assert_untyped_expression(
-          "I have {arg1} cukes and {arg2} euro",
-          "I have 2 cukes and 1.5 euro")
+      it "numbers only second argument when builtin type is not reserved keyword" do
+        assert_expression(
+          "I have {int} cukes and {int} euro", ["int", "int2"],
+          "I have 2 cukes and 5 euro")
       end
 
-      it "generates expression for custom type" do
+      it "numbers only second argument when type is not reserved keyword" do
         @transform_lookup.add_transform(Transform.new(
           'currency',
           Currency,
@@ -55,23 +54,21 @@ module Cucumber
           nil
         ))
 
-        assert_typed_expression(
-          "I have a {arg1:currency} account",
-          "I have a EUR account")
+        assert_expression(
+          "I have a {currency} account and a {currency} account", ["currency", "currency2"],
+          "I have a EUR account and a GBP account")
       end
 
       it "exposes transforms in generated expression" do
-        expression = @generator.generate_expression("I have 2 cukes and 1.5 euro", true)
+        expression = @generator.generate_expression("I have 2 cukes and 1.5 euro")
         types = expression.transforms.map(&:type)
         expect(types).to eq([Integer, Float])
       end
 
-      def assert_typed_expression(expected, text)
-        expect(@generator.generate_expression(text, true).source).to eq(expected)
-      end
-
-      def assert_untyped_expression(expected, text)
-        expect(@generator.generate_expression(text, false).source).to eq(expected)
+      def assert_expression(expected_expression, expected_argument_names, text)
+        generated_expression = @generator.generate_expression(text)
+        expect(generated_expression.argument_names).to eq(expected_argument_names)
+        expect(generated_expression.source).to eq(expected_expression)
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR generates untyped CucumberExpression snippets

## Motivation and Context

Untyped parameters in a CucumberExpression become typed if their name match a registered type.
In other words, the type name can always be used as a parameter name. This improves the readability of a CucumberExpression.

This fixes #110

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
