### PR TITLE
Deprecate {name:type} syntax in favoud of just {type}

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -25,19 +25,23 @@ public class CucumberExpression implements Expression {
         regexp.append("^");
         int typeIndex = 0;
         while (matcher.find()) {
-            Type type = types.size() <= typeIndex ? null : types.get(typeIndex++);
             String parameterName = matcher.group(1);
             String typeName = matcher.group(3);
+            if (typeName != null) {
+                System.err.println(String.format("Cucumber expression parameter syntax {%s:%s} is deprecated. Please use {%s} instead.", parameterName, typeName, typeName));
+            }
+
+            Type type = types.size() <= typeIndex ? null : types.get(typeIndex++);
 
             Parameter<?> parameter = null;
             if (type != null) {
                 parameter = parameterRegistry.lookupByType(type);
             }
             if (parameter == null && typeName != null) {
-                parameter = parameterRegistry.lookupByTypeName(typeName, false);
+                parameter = parameterRegistry.lookupByTypeName(typeName);
             }
             if (parameter == null) {
-                parameter = parameterRegistry.lookupByTypeName(parameterName, true);
+                parameter = parameterRegistry.lookupByTypeName(parameterName);
             }
             if (parameter == null && type != null && type instanceof Class) {
                 parameter = new ClassParameter<>((Class) type);
@@ -58,12 +62,12 @@ public class CucumberExpression implements Expression {
     private String getCaptureGroupRegexp(List<String> captureGroupRegexps) {
         StringBuilder sb = new StringBuilder("(");
 
-        if(captureGroupRegexps.size() == 1) {
+        if (captureGroupRegexps.size() == 1) {
             sb.append(captureGroupRegexps.get(0));
         } else {
             boolean bar = false;
             for (String captureGroupRegexp : captureGroupRegexps) {
-                if(bar) sb.append("|");
+                if (bar) sb.append("|");
                 sb.append("(?:").append(captureGroupRegexp).append(")");
                 bar = true;
             }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterRegistry.java
@@ -110,20 +110,12 @@ public class ParameterRegistry {
         return (Parameter<T>) parametersByType.get(type);
     }
 
-    public Parameter<?> lookupByTypeName(String typeName, boolean ignoreUnknownTypeName) {
-        Parameter<?> parameter = parametersByTypeName.get(typeName);
-        if (parameter == null) {
-            if (ignoreUnknownTypeName) {
-                return null;
-            } else {
-                throw new CucumberExpressionException(String.format("No parameter type for type name \"%s\"", typeName));
-            }
-        }
-        return parameter;
+    public <T> Parameter<T> lookupByTypeName(String typeName) {
+        return (Parameter<T>) parametersByTypeName.get(typeName);
     }
 
-    public Parameter lookupByCaptureGroupRegexp(String captureGroupPattern) {
-        return parametersByCaptureGroupRegexp.get(captureGroupPattern);
+    public <T> Parameter<T> lookupByCaptureGroupRegexp(String captureGroupPattern) {
+        return (Parameter<T>) parametersByCaptureGroupRegexp.get(captureGroupPattern);
     }
 
     public Collection<Parameter<?>> getParameters() {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
@@ -45,7 +45,7 @@ public class CucumberExpressionPatternTest {
     @Test
     public void translates_expression_types() {
         assertPattern(
-                "I have {n:int} cukes in my {bodyPart}",
+                "I have {int} cukes in my {bodyPart}",
                 "^I have ((?:-?\\d+)|(?:\\d+)) cukes in my (.+)$",
                 Collections.<Type>emptyList()
         );
@@ -57,7 +57,7 @@ public class CucumberExpressionPatternTest {
         types.add(Integer.class);
         types.add(String.class);
         assertPattern(
-                "I have {n:int} cukes in my {bodyPart}",
+                "I have {int} cukes in my {bodyPart}",
                 "^I have ((?:-?\\d+)|(?:\\d+)) cukes in my (.+)$",
                 types
         );

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -35,7 +35,7 @@ public class CucumberExpressionTest {
 
     @Test
     public void transforms_to_int_by_expression_type() {
-        assertEquals(singletonList(22), match("{what:int}", "22"));
+        assertEquals(singletonList(22), match("{int}", "22"));
     }
 
     @Test
@@ -45,13 +45,13 @@ public class CucumberExpressionTest {
 
     @Test
     public void doesnt_match_a_float_to_an_int() {
-        assertEquals(null, match("{what:int}", "1.22"));
+        assertEquals(null, match("{int}", "1.22"));
     }
 
     @Test
     public void transforms_to_float_by_expression_type() {
-        assertEquals(singletonList(0.22f), match("{what:float}", "0.22"));
-        assertEquals(singletonList(0.22f), match("{what:float}", ".22"));
+        assertEquals(singletonList(0.22f), match("{float}", "0.22"));
+        assertEquals(singletonList(0.22f), match("{float}", ".22"));
     }
 
     @Test
@@ -61,24 +61,24 @@ public class CucumberExpressionTest {
     }
 
     @Test
-    public void doesnt_transform_unknown_type() {
-        try {
-            match("{what:unknown}", "something");
-            fail();
-        } catch (CucumberExpressionException expected) {
-            assertEquals("No parameter type for type name \"unknown\"", expected.getMessage());
-        }
+    public void leaves_unknown_type_untransformed() {
+        assertEquals(singletonList("something"), match("{unknown}", "something"));
+    }
+
+    @Test
+    public void supports_deprecated_name_colon_type_syntax_for_now() {
+        assertEquals(singletonList("something"), match("{param:unknown}", "something"));
     }
 
     @Test
     public void exposes_source() {
-        String expr = "I have {n:int} cuke(s) in my {bodypart} now";
+        String expr = "I have {int} cuke(s) in my {bodypart} now";
         assertEquals(expr, new CucumberExpression(expr, Collections.<Type>emptyList(), new ParameterRegistry(Locale.ENGLISH)).getSource());
     }
 
     @Test
     public void exposes_offset_and_value() {
-        String expr = "I have {n:int} cuke(s) in my {bodypart} now";
+        String expr = "I have {int} cuke(s) in my {bodypart} now";
         Expression expression = new CucumberExpression(expr, Collections.<Type>emptyList(), new ParameterRegistry(Locale.ENGLISH));
         Argument arg1 = expression.match("I have 800 cukes in my brain now").get(0);
         assertEquals(7, arg1.getOffset());

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTest.java
@@ -53,14 +53,14 @@ public class CustomParameterTest {
 
     @Test
     public void transforms_CucumberExpression_arguments_with_expression_type_I() {
-        Expression expression = new CucumberExpression("I have a {color:color} ball", Collections.<Type>emptyList(), parameterRegistry);
+        Expression expression = new CucumberExpression("I have a {color} ball", Collections.<Type>emptyList(), parameterRegistry);
         Object transformedArgumentValue = expression.match("I have a red ball").get(0).getTransformedValue();
         assertEquals(new Color("red"), transformedArgumentValue);
     }
 
     @Test
     public void transforms_CucumberExpression_arguments_with_expression_type_II() {
-        Expression expression = new CucumberExpression("I have a {color:color} ball", Collections.<Type>emptyList(), parameterRegistry);
+        Expression expression = new CucumberExpression("I have a {color} ball", Collections.<Type>emptyList(), parameterRegistry);
         Object transformedArgumentValue = expression.match("I have a dark red ball").get(0).getTransformedValue();
         assertEquals(new Color("dark red"), transformedArgumentValue);
     }

--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -26,6 +26,10 @@ class CucumberExpression {
     while ((match = parameterPattern.exec(expression)) !== null) {
       const parameterName = match[1]
       const typeName = match[3]
+      if (typeName && (typeof console !== 'undefined') && (typeof console.error == 'function')) {
+        console.error(`Cucumber expression parameter syntax {${parameterName}:${typeName}} is deprecated. Please use {${typeName}} instead.`);
+      }
+
       const type = types.length <= typeIndex ? null : types[typeIndex++]
 
       let parameter;
@@ -33,10 +37,10 @@ class CucumberExpression {
         parameter = parameterRegistry.lookupByType(type)
       }
       if (!parameter && typeName) {
-        parameter = parameterRegistry.lookupByTypeName(typeName, false)
+        parameter = parameterRegistry.lookupByTypeName(typeName)
       }
       if (!parameter) {
-        parameter = parameterRegistry.lookupByTypeName(parameterName, true)
+        parameter = parameterRegistry.lookupByTypeName(parameterName)
       }
       if (!parameter) {
         parameter = parameterRegistry.createAnonymousLookup(s => s)

--- a/cucumber-expressions/javascript/src/parameter_registry.js
+++ b/cucumber-expressions/javascript/src/parameter_registry.js
@@ -21,7 +21,7 @@ class ParameterRegistry {
     if (typeof type === 'function') {
       return this.lookupByFunction(type)
     } else if (typeof type === 'string') {
-      return this.lookupByTypeName(type, false)
+      return this.lookupByTypeName(type)
     } else {
       throw new Error(`Type must be string or function, but was ${type} of type ${typeof type}`)
     }
@@ -53,17 +53,8 @@ class ParameterRegistry {
     }
   }
 
-  lookupByTypeName(typeName, ignoreUnknownTypeName) {
-    const parameter = this._parametersByTypeName.get(typeName)
-    if (!parameter) {
-      if (ignoreUnknownTypeName) {
-        return null
-      } else {
-        throw new Error(`No parameter for type name "${typeName}". Registered parameters: ${Object.keys(this._parametersByTypeName)}`)
-      }
-    } else {
-      return parameter
-    }
+  lookupByTypeName(typeName) {
+    return this._parametersByTypeName.get(typeName)
   }
 
   lookupByCaptureGroupRegexp(captureGroupRegexp) {

--- a/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
@@ -21,7 +21,7 @@ describe(CucumberExpression.name, () => {
 
     it("translates three typed arguments", () => {
       assertRegexp(
-        "I have {n:float} cukes in my {bodypart} at {time:int} o'clock",
+        "I have {float} cukes in my {bodypart} at {int} o'clock",
         /^I have (-?\d*\.?\d+) cukes in my (.+) at ((?:-?\d+)|(?:\d+)) o'clock$/
       )
     })

--- a/cucumber-expressions/javascript/test/cucumber_expression_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_test.js
@@ -21,7 +21,7 @@ describe(CucumberExpression.name, () => {
   })
 
   it("transforms to int by parameter type", () => {
-    assert.deepEqual(match("{what:int}", "22"), [22])
+    assert.deepEqual(match("{int}", "22"), [22])
   })
 
   it("transforms to int by explicit type", () => {
@@ -29,12 +29,12 @@ describe(CucumberExpression.name, () => {
   })
 
   it("doesn't match a float with an int parameter", () => {
-    assert.deepEqual(match("{what:int}", "1.22"), null)
+    assert.deepEqual(match("{int}", "1.22"), null)
   })
 
   it("transforms to float by parameter type", () => {
-    assert.deepEqual(match("{what:float}", "0.22"), [0.22])
-    assert.deepEqual(match("{what:float}", ".22"), [0.22])
+    assert.deepEqual(match("{float}", "0.22"), [0.22])
+    assert.deepEqual(match("{float}", ".22"), [0.22])
   })
 
   it("transforms to float by explicit type", () => {
@@ -42,20 +42,21 @@ describe(CucumberExpression.name, () => {
     assert.deepEqual(match("{what}", ".22", ['float']), [0.22])
   })
 
-  it("doesn't match unknown parameter type", () => {
-    assert.throws(
-      () => match("{what:unknown}", "something"),
-      /No parameter for type name "unknown"/
-    )
+  it("leaves unknown type untransformed", () => {
+    assert.deepEqual(match("{unknown}", "something"), ['something'])
+  })
+
+  it("supports deprecated {name:type} syntax for now", () => {
+    assert.deepEqual(match("{param:unknown}", "something"), ['something'])
   })
 
   it("exposes source", () => {
-    const expr = "I have {n:int} cuke(s) in my {bodypart} now";
+    const expr = "I have {int} cuke(s) in my {bodypart} now";
     assert.equal(new CucumberExpression(expr, [], new ParameterRegistry()).source, expr)
   })
 
   it("exposes offset and value", () => {
-    const expr = "I have {n:int} cuke(s) in my {bodypart} now";
+    const expr = "I have {int} cuke(s) in my {bodypart} now";
     const expression = new CucumberExpression(expr, [], new ParameterRegistry())
     const arg1 = expression.match("I have 800 cukes in my brain now")[0]
     assert.equal(arg1.offset, 7)
@@ -74,7 +75,7 @@ describe(CucumberExpression.name, () => {
     })
 
     it(`escapes .`, () => {
-      const expr = `I have {n:int} cuke(s) and .`
+      const expr = `I have {int} cuke(s) and .`
       const expression = new CucumberExpression(expr, [], new ParameterRegistry())
       assert.equal(expression.match(`I have 800 cukes and 3`), null)
       const arg1 = expression.match(`I have 800 cukes and .`)[0]
@@ -83,7 +84,7 @@ describe(CucumberExpression.name, () => {
     })
 
     it(`escapes |`, () => {
-      const expr = `I have {n:int} cuke(s) and a|b`
+      const expr = `I have {int} cuke(s) and a|b`
       const expression = new CucumberExpression(expr, [], new ParameterRegistry())
       assert.equal(expression.match(`I have 800 cukes and a`), null)
       assert.equal(expression.match(`I have 800 cukes and b`), null)

--- a/cucumber-expressions/javascript/test/custom_parameter_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_test.js
@@ -32,13 +32,13 @@ describe('Custom parameter', () => {
 
   describe(CucumberExpression.name, () => {
     it("matches typed parameters", () => {
-      const expression = new CucumberExpression("I have a {color:color} ball", [], parameterRegistry)
+      const expression = new CucumberExpression("I have a {color} ball", [], parameterRegistry)
       const transformedValue = expression.match("I have a red ball")[0].transformedValue
       assert.equal(transformedValue.name, "red")
     })
 
     it("matches typed parameters with optional group", () => {
-      const expression = new CucumberExpression("I have a {color:color} ball", [], parameterRegistry)
+      const expression = new CucumberExpression("I have a {color} ball", [], parameterRegistry)
       const transformedValue = expression.match("I have a dark red ball")[0].transformedValue
       assert.equal(transformedValue.name, "dark red")
     })

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -29,6 +29,10 @@ module Cucumber
 
           parameter_name = match[1]
           type_name = match[3]
+          if type_name
+            $stderr.puts("Cucumber expression parameter syntax {#{parameter_name}:#{type_name}} is deprecated. Please use {#{type_name}} instead.")
+          end
+
           type = types.length <= type_index ? nil : types[type_index]
           type_index += 1
 
@@ -37,10 +41,10 @@ module Cucumber
             parameter = parameter_registry.lookup_by_type(type)
           end
           if parameter.nil? && type_name
-            parameter = parameter_registry.lookup_by_type_name(type_name, false)
+            parameter = parameter_registry.lookup_by_type_name(type_name)
           end
           if parameter.nil?
-            parameter = parameter_registry.lookup_by_type_name(parameter_name, true)
+            parameter = parameter_registry.lookup_by_type_name(parameter_name)
           end
           if parameter.nil?
             parameter = parameter_registry.create_anonymous_lookup(lambda {|s| s})

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_registry.rb
@@ -19,7 +19,7 @@ module Cucumber
         if type.is_a?(Class)
           lookup_by_class(type)
         elsif type.is_a?(String)
-          lookup_by_type_name(type, false)
+          lookup_by_type_name(type)
         else
           raise Exception.new("Type must be string or class, but was #{type} of type #{type.class}")
         end
@@ -34,14 +34,8 @@ module Cucumber
         end
       end
 
-      def lookup_by_type_name(type_name, ignore_unknown_type_name)
-        parameter = @parameters_by_type_name[type_name]
-        if parameter.nil?
-          return nil if ignore_unknown_type_name
-          raise Exception.new("No parameter for type name \"#{type_name}\"")
-        else
-          parameter
-        end
+      def lookup_by_type_name(type_name)
+        @parameters_by_type_name[type_name]
       end
 
       def lookup_by_capture_group_regexp(capture_group_regexp)

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
@@ -26,7 +26,7 @@ module Cucumber
 
         it "translates three typed arguments" do
           assert_regexp(
-            "I have {n:float} cukes in my {bodypart} at {time:int} o'clock",
+            "I have {float} cukes in my {bodypart} at {int} o'clock",
             /^I have (-?\d*\.?\d+) cukes in my (.+) at ((?:-?\d+)|(?:\d+)) o'clock$/
           )
         end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -22,7 +22,7 @@ module Cucumber
       end
 
       it "transforms to int by parameter type" do
-        expect( match("{what:int}", "22") ).to eq([22])
+        expect( match("{int}", "22") ).to eq([22])
       end
 
       it "transforms to int by explicit type" do
@@ -35,12 +35,12 @@ module Cucumber
       end
 
       it "doesn't match a float with an int parameter" do
-        expect( match("{what:int}", "1.22") ).to be_nil
+        expect( match("{int}", "1.22") ).to be_nil
       end
 
       it "transforms to float by parameter type" do
-        expect( match("{what:float}", "0.22") ).to eq([0.22])
-        expect( match("{what:float}",  ".22") ).to eq([0.22])
+        expect( match("{float}", "0.22") ).to eq([0.22])
+        expect( match("{float}",  ".22") ).to eq([0.22])
       end
 
       it "transforms to float by explicit type" do
@@ -48,18 +48,21 @@ module Cucumber
         expect( match("{what}",  ".22", ['float']) ).to eq([0.22])
       end
 
-      it "doesn't match unknown parameter type" do
-        expect { match("{what:unknown}", "something") }.to raise_error(
-          'No parameter for type name "unknown"')
+      it "leaves unknown type untransformed" do
+        expect( match("{unknown}", "something") ).to eq(["something"])
+      end
+
+      it "supports deprecated {name:type} syntax for now" do
+        expect( match("{param:unknown}", "something") ).to eq(["something"])
       end
 
       it "exposes source" do
-        expr = "I have {n:int} cuke(s) in my {bodypart} now"
+        expr = "I have {int} cuke(s) in my {bodypart} now"
         expect(CucumberExpression.new(expr, [], ParameterRegistry.new).source).to eq(expr)
       end
 
       it "exposes offset and value" do
-        expr = "I have {n:int} cuke(s) in my {bodypart} now"
+        expr = "I have {int} cuke(s) in my {bodypart} now"
         expression = CucumberExpression.new(expr, [], ParameterRegistry.new)
         arg1 = expression.match("I have 800 cukes in my brain now")[0]
         expect(arg1.offset).to eq(7)

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_spec.rb
@@ -33,13 +33,13 @@ module Cucumber
 
       describe CucumberExpression do
         it "matches typed parameters" do
-          expression = CucumberExpression.new("I have a {color:color} ball", [], @parameter_registry)
+          expression = CucumberExpression.new("I have a {color} ball", [], @parameter_registry)
           parametered_argument_value = expression.match("I have a red ball")[0].transformed_value
           expect( parametered_argument_value ).to eq(Color.new('red'))
         end
 
         it "matches typed parameters with optional group" do
-          expression = CucumberExpression.new("I have a {color:color} ball", [], @parameter_registry)
+          expression = CucumberExpression.new("I have a {color} ball", [], @parameter_registry)
           parametered_argument_value = expression.match("I have a dark red ball")[0].transformed_value
           expect( parametered_argument_value ).to eq(Color.new('dark red'))
         end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

After having used Cucumber expressions daily for a few weeks I have realised that:
* The `{name:type}` syntax is usually redundant for both built-in and custom parameters (previously called transforms, see #114)
*The `{name:type}` syntax is never needed, not even for expressions with multiple parameters of the same type. It is sufficient to give different names to the function/method parameters of the stepdef. 
* The `{name:type}` syntax is ugly and causes more visual/cognitive strain

So let's get rid of it! This PR prints a deprecation warning with a recommendation to `STDERR` if the `{name:type}` syntax is used. In a future release we can remove support for it altogether.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
