### PR TITLE
Defer parameter transformation until after the match

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Argument.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Argument.java
@@ -3,12 +3,12 @@ package io.cucumber.cucumberexpressions;
 public class Argument {
     private final int offset;
     private final String value;
-    private final Object transformedValue;
+    private final Parameter parameter;
 
-    public Argument(Integer offset, String value, Object transformedValue) {
+    public Argument(Integer offset, String value, Parameter parameter) {
         this.offset = offset;
         this.value = value;
-        this.transformedValue = transformedValue;
+        this.parameter = parameter;
     }
 
     public int getOffset() {
@@ -20,6 +20,6 @@ public class Argument {
     }
 
     public Object getTransformedValue() {
-        return transformedValue;
+        return parameter.transform(value);
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ArgumentBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ArgumentBuilder.java
@@ -16,11 +16,9 @@ class ArgumentBuilder {
             for (int i = 0; i < matcher.groupCount(); i++) {
                 int startIndex = matcher.start(i + 1);
                 String value = matcher.group(i + 1);
-
                 Parameter parameter = parameters.get(i);
-                Object transformedValue = parameter == null ? value : parameter.transform(value);
 
-                arguments.add(new Argument(startIndex, value, transformedValue));
+                arguments.add(new Argument(startIndex, value, parameter));
             }
             return arguments;
         } else {

--- a/cucumber-expressions/javascript/src/argument.js
+++ b/cucumber-expressions/javascript/src/argument.js
@@ -1,8 +1,8 @@
 class Argument {
-  constructor(offset, value, transformedValue) {
+  constructor(offset, value, parameter) {
     this._offset = offset
     this._value = value
-    this._transformedValue = transformedValue
+    this._parameter = parameter
   }
 
   get offset() {
@@ -14,7 +14,7 @@ class Argument {
   }
 
   get transformedValue() {
-    return this._transformedValue
+    return this._parameter.transform(this._value)
   }
 }
 

--- a/cucumber-expressions/javascript/src/build_arguments.js
+++ b/cucumber-expressions/javascript/src/build_arguments.js
@@ -7,8 +7,8 @@ const buildArguments = (regexp, text, parameters) => {
   let offset = 0
   return m.slice(1).map(value => {
     offset = text.indexOf(value, offset)
-    const transformedValue = parameters[parameterIndex++].transform(value)
-    return new Argument(offset, value, transformedValue)
+    const parameter = parameters[parameterIndex++]
+    return new Argument(offset, value, parameter)
   })
 }
 

--- a/cucumber-expressions/javascript/test/custom_parameter_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_test.js
@@ -55,6 +55,19 @@ describe('Custom parameter', () => {
       assert.equal(transformedValue.name, "red")
     })
 
+    it("defers transformation until queried from argument", () => {
+      parameterRegistry.addParameter(new Parameter(
+        'throwing',
+        () => null,
+        /bad/,
+        s => { throw new Error(`Can't transform [${s}]`) }
+      ))
+
+      const expression = new CucumberExpression("I have a {throwing} parameter", [], parameterRegistry)
+      const args = expression.match("I have a bad parameter")
+      assert.throws(() => args[0].transformedValue, Error, "Can't transform [bad]")
+    })
+
     // JavaScript-specific
     it("matches untyped parameters with explicit type name", () => {
       const expression = new CucumberExpression("I have a {color} ball", ['color'], parameterRegistry)

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
@@ -1,10 +1,14 @@
 module Cucumber
   module CucumberExpressions
     class Argument
-      attr_reader :offset, :value, :transformed_value
+      attr_reader :offset, :value
 
-      def initialize(offset, value, transformed_value)
-        @offset, @value, @transformed_value = offset, value, transformed_value
+      def initialize(offset, value, parameter)
+        @offset, @value, @parameter = offset, value, parameter
+      end
+
+      def transformed_value
+        @parameter.transform(@value)
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument_builder.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument_builder.rb
@@ -9,8 +9,7 @@ module Cucumber
         (1...m.length).map do |index|
           value = m[index]
           parameter = parameters[index-1]
-          transformed_value = parameter.transform(value)
-          Argument.new(m.offset(index)[0], value, transformed_value)
+          Argument.new(m.offset(index)[0], value, parameter)
         end
       end
     end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_spec.rb
@@ -61,6 +61,18 @@ module Cucumber
           parametered_argument_value = expression.match("I have a red ball")[0].transformed_value
           expect( parametered_argument_value ).to eq(Color.new('red'))
         end
+
+        it("defers transformation until queried from argument") do
+          @parameter_registry.add_parameter(Parameter.new(
+              'throwing',
+              String,
+              /bad/,
+              lambda { |s| raise "Can't transform [#{s}]" }
+          ))
+          expression = CucumberExpression.new("I have a {throwing} parameter", [], @parameter_registry)
+          args = expression.match("I have a bad parameter")
+          expect { args[0].transformed_value }.to raise_error("Can't transform [bad]")
+        end
       end
 
       describe RegularExpression do


### PR DESCRIPTION
## Summary

Fix for #118 

## Details

Inject `Parameter` into `Argument` so that transformation can be deferred. 

## Motivation and Context

Cucumber needs to match expressions without performing a transform. See cucumber/cucumber-js#765

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
