### PR TITLE
Detect conflicts before a new parameter is added

### DIFF
--- a/cucumber-expressions/java/pom.xml
+++ b/cucumber-expressions/java/pom.xml
@@ -61,8 +61,8 @@
                 <version>3.6.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -3,6 +3,8 @@ package io.cucumber.cucumberexpressions;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,7 +13,6 @@ import java.util.Locale;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class CucumberExpressionTest {
     @Test
@@ -95,6 +96,31 @@ public class CucumberExpressionTest {
     }
 
     // Java-specific
+
+    @Test
+    public void transforms_to_byte_by_expression_type() {
+        assertEquals(singletonList((byte) 15), match("{byte}", "0x0F"));
+    }
+
+    @Test
+    public void transforms_to_short_by_expression_type() {
+        assertEquals(singletonList(Short.MAX_VALUE), match("{short}", String.valueOf(Short.MAX_VALUE)));
+    }
+
+    @Test
+    public void transforms_to_long_by_expression_type() {
+        assertEquals(singletonList(Long.MAX_VALUE), match("{long}", String.valueOf(Long.MAX_VALUE)));
+    }
+
+    @Test
+    public void transforms_to_bigint_by_expression_type() {
+        assertEquals(singletonList(BigInteger.ONE), match("{bigint}", BigInteger.ONE.toString()));
+    }
+
+    @Test
+    public void transforms_to_bigdecimal_by_expression_type() {
+        assertEquals(singletonList(BigDecimal.ONE), match("{bigdecimal}", BigDecimal.ONE.toString()));
+    }
 
     @Test
     public void transforms_to_double_with_comma_for_locale_using_comma() {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -40,8 +40,9 @@ public class RegularExpressionTest {
     }
 
     @Test
-    public void transforms_to_double_using_capture_group_pattern() {
-        assertEquals(singletonList(22L), match(compile("(\\d+)"), "22"));
+    public void transforms_to_long_using_capture_group_pattern() {
+        List<?> match = match(compile("(\\d+)"), "22");
+        assertEquals(singletonList(22L), match);
     }
 
     @Test
@@ -57,11 +58,6 @@ public class RegularExpressionTest {
     @Test
     public void transforms_double_with_sign() {
         assertEquals(singletonList(-1.22), match(compile("(.*)"), "-1.22", Collections.<Type>singletonList(Double.class)));
-    }
-
-    @Test
-    public void rounds_double_to_integer() {
-        assertEquals(singletonList(1), match(compile("(.*)"), "1.22", Collections.<Type>singletonList(Integer.class)));
     }
 
     @Test

--- a/cucumber-expressions/javascript/src/parameter_registry.js
+++ b/cucumber-expressions/javascript/src/parameter_registry.js
@@ -7,10 +7,10 @@ class ParameterRegistry {
     this._parametersByConstructorName = new Map()
 
     const INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-    const FLOAT_REGEXPS = [/-?\d*\.?\d+/]
+    const FLOAT_REGEXP = /-?\d*\.?\d+/
 
-    this.addParameter(new Parameter('int', Number, INTEGER_REGEXPS, parseInt))
-    this.addParameter(new Parameter('float', Number, FLOAT_REGEXPS, parseFloat))
+    this._addPredefinedParameter(new Parameter('int', Number, INTEGER_REGEXPS, parseInt))
+    this._addPredefinedParameter(new Parameter('float', Number, FLOAT_REGEXP, parseFloat))
   }
 
   get parameters() {
@@ -66,14 +66,27 @@ class ParameterRegistry {
   }
 
   addParameter(parameter) {
-    this._parametersByConstructorName.set(parameter.constructorFunction.name, parameter)
+    this._addParameter(parameter, true)
+  }
 
-    this._parametersByTypeName.set(parameter.typeName, parameter)
+  _addPredefinedParameter(parameter) {
+    this._addParameter(parameter, false)
+  }
+
+  _addParameter(parameter, checkConflicts) {
+    set(this._parametersByConstructorName, parameter.constructorFunction.name, parameter, 'constructor', checkConflicts)
+    set(this._parametersByTypeName, parameter.typeName, parameter, 'type name', checkConflicts)
 
     for (let captureGroupRegexp of parameter.captureGroupRegexps) {
-      this._parametersByCaptureGroupRegexp.set(captureGroupRegexp, parameter)
+      set(this._parametersByCaptureGroupRegexp, captureGroupRegexp, parameter, 'regexp', checkConflicts)
     }
   }
+}
+
+function set(map, key, value, prop, checkConflicts) {
+  if(checkConflicts && map.has(key))
+    throw new Error(`There is already a parameter with ${prop} ${key}`)
+  map.set(key, value)
 }
 
 module.exports = ParameterRegistry

--- a/cucumber-expressions/javascript/test/assert_throws.js
+++ b/cucumber-expressions/javascript/test/assert_throws.js
@@ -1,0 +1,7 @@
+const assert = require('assert')
+
+// A better assert.error that allows an exact error message
+module.exports = (fn, message) => {
+  const regexp = new RegExp(message.replace(/[\-\[\]\/{}()*+?.\\\^$|]/g, "\\$&"))
+  assert.throws(fn, regexp)
+}

--- a/cucumber-expressions/javascript/test/regular_expression_test.js
+++ b/cucumber-expressions/javascript/test/regular_expression_test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 const assert = require('assert')
+const assertThrows = require('./assert_throws')
 const RegularExpression = require('../src/regular_expression')
 const TransformLookup = require('../src/parameter_registry')
 
@@ -58,9 +59,9 @@ describe(RegularExpression.name, () => {
   })
 
   it("fails when type is not type name or function", () => {
-    assert.throws(
+    assertThrows(
       () => match(/(.*)/, "-1.22", [99]),
-      /Type must be string or function, but was 99 of type number/
+      'Type must be string or function, but was 99 of type number'
     )
   })
 

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_registry.rb
@@ -4,15 +4,15 @@ module Cucumber
   module CucumberExpressions
     class ParameterRegistry
       INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-      FLOAT_REGEXPS = [/-?\d*\.?\d+/]
+      FLOAT_REGEXP = /-?\d*\.?\d+/
 
       def initialize
         @parameters_by_type_name = {}
         @parameters_by_capture_group_regexp = {}
         @parameters_by_class = {}
 
-        add_parameter(Parameter.new('int', Integer, INTEGER_REGEXPS, lambda {|s| s.to_i}))
-        add_parameter(Parameter.new('float', Float, FLOAT_REGEXPS, lambda {|s| s.to_f}))
+        add_predefined_parameter(Parameter.new('int', Integer, INTEGER_REGEXPS, lambda { |s| s.to_i }))
+        add_predefined_parameter(Parameter.new('float', Float, FLOAT_REGEXP, lambda { |s| s.to_f }))
       end
 
       def lookup_by_type(type)
@@ -28,7 +28,7 @@ module Cucumber
       def lookup_by_class(clazz)
         parameter = @parameters_by_class[clazz]
         if parameter.nil?
-          create_anonymous_lookup(lambda {|s| clazz.new(s)})
+          create_anonymous_lookup(lambda { |s| clazz.new(s) })
         else
           parameter
         end
@@ -46,19 +46,35 @@ module Cucumber
         Parameter.new(nil, nil, ['.+'], proc)
       end
 
-      def add_parameter(parameter)
-        @parameters_by_type_name[parameter.type_name] = parameter
-        @parameters_by_class[parameter.type] = parameter
-
-        parameter.capture_group_regexps.each do |capture_group_regexp|
-          @parameters_by_capture_group_regexp[capture_group_regexp] = parameter
-        end
-      end
-
       def parameters
         @parameters_by_type_name.values
       end
 
+      def add_parameter(parameter)
+        add_parameter0(parameter, true)
+      end
+
+      private
+
+      def add_predefined_parameter(parameter)
+        add_parameter0(parameter, false)
+      end
+
+      def add_parameter0(parameter, check_conflicts)
+        put(@parameters_by_type_name, parameter.type_name, parameter, "type name", check_conflicts)
+        put(@parameters_by_class, parameter.type, parameter, "type", check_conflicts)
+
+        parameter.capture_group_regexps.each do |capture_group_regexp|
+          put(@parameters_by_capture_group_regexp, capture_group_regexp, parameter, "regexp", check_conflicts)
+        end
+      end
+
+      def put(map, key, parameter, prop, check_conflicts)
+        if check_conflicts && map.has_key?(key)
+          raise "There is already a parameter with #{prop} #{key}"
+        end
+        map[key] = parameter
+      end
     end
   end
 end


### PR DESCRIPTION
The main reason for this is better UX for end users: They'll get better error messages and stricter rules for defining new parameter types. This should help catch a whole class of errors when a parameter type is defined rather than when a step has ambiguous matches.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
