### PR TITLE
cucumber-expressions: Add support for alternative text

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 N/A
 
 ### Added
-N/A
+* Alternative text: `I have a cat/dog/fish`
+  (by [aslakhellesoy])
 
 ### Changed
-* Stricter conflict checks when defining parameters.
+* Stricter conflict checks when defining parameters
   ([#121](https://github.com/cucumber/cucumber/pull/121)
    by [aslakhellesoy])
 

--- a/cucumber-expressions/README.md
+++ b/cucumber-expressions/README.md
@@ -37,7 +37,7 @@ Let's change the parameter to a `float` instead:
 
 Now the expression will match the text, and the number `42.5` is extracted.
 
-## Optional Text
+## Optional text
 
 It's grammatically incorrect to say *1 cucumbers*, so we should make that `s`
 optional. That can be done by surrounding the optional text with parenthesis:
@@ -52,15 +52,27 @@ It would also match this text:
 
     I have 42 cucumbers in my belly
 
+## Alternative text
+
+Sometimes you want to relax your language, to make it flow better. For example:
+
+    I have {int} cucumber(s) in my belly/stomach
+
+This would match either of those texts:
+
+    I have 42 cucumbers in my belly
+    I have 42 cucumbers in my stomach
+
 ## Custom Parameters {#custom-parameters}
 
 Cucumber Expressions have built-in support for `int` and `float` parameter types
 as well as other numeric types available in your programming language.
 
-Defining your own parameter types is useful for two reasons:
+Defining your own parameter types is useful for several reasons:
 
 1. Enforce certain patterns
 1. Convert to custom types
+1. Document and evolve your ubiquitous domain language
 
 Imagine we want our parameter to match the colors `red`, `blue` or `yellow`
 (but nothing else). Let's assume a `Color` class is already defined.

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
@@ -25,6 +25,15 @@ public class CucumberExpressionPatternTest {
     }
 
     @Test
+    public void translates_alternation() {
+        assertPattern(
+                "I had/have a great/nice/charming friend",
+                "^I (?:had|have) a (?:great|nice|charming) friend$",
+                Collections.<Type>emptyList()
+        );
+    }
+
+    @Test
     public void translates_an_int_arg() {
         assertPattern(
                 "I have {n} cukes",

--- a/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_regexp_test.js
@@ -12,6 +12,13 @@ describe(CucumberExpression.name, () => {
       )
     })
 
+    it("translates alternation", () => {
+      assertRegexp(
+        "I had/have a great/nice/charming friend",
+        /^I (?:had|have) a (?:great|nice|charming) friend$/
+      )
+    })
+
     it("translates two untyped arguments", () => {
       assertRegexp(
         "I have {n} cukes in my {bodypart} now",

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
@@ -17,6 +17,13 @@ module Cucumber
           )
         end
 
+        it "translates alternation" do
+          assert_regexp(
+            "I had/have a great/nice/charming friend",
+            /^I (?:had|have) a (?:great|nice|charming) friend$/
+          )
+        end
+
         it "translates two untyped arguments" do
           assert_regexp(
             "I have {n} cukes in my {bodypart} now",


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Implement alternative text, inspired from [turnip alternative words](https://github.com/jnicklas/turnip#placeholders).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
