### PR TITLE
event-protocol: Use $ref to reduce duplication in schemas

### DIFF
--- a/event-protocol/schemas/attachment.json
+++ b/event-protocol/schemas/attachment.json
@@ -1,19 +1,13 @@
 {
+  "id": "https://raw.github.com/cucumber/cucumber/master/event-protocol/schemas/attachment.json#",
   "title": "source",
   "type": "object",
   "properties": {
     "type": {
       "type": "string"
     },
-    "timestamp": {
-      "description": "Milliseconds since epoch",
-      "type": "integer",
-      "minimum": 0
-    },
-    "series": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    },
+    "timestamp": { "$ref": "defs.json#/timestamp" },
+    "series": { "$ref": "defs.json#/series" },
     "source": {
       "type": "object",
       "properties": {

--- a/event-protocol/schemas/defs.json
+++ b/event-protocol/schemas/defs.json
@@ -1,0 +1,14 @@
+{
+  "id": "https://raw.github.com/cucumber/cucumber/master/event-protocol/schemas/defs.json#",
+  "title": "definitions",
+  "description": "re-usable parts of the schema",
+  "timestamp": {
+    "description": "Milliseconds since epoch",
+    "type": "integer",
+    "minimum": 0
+  },
+  "series": {
+    "type": "string",
+    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  }
+}

--- a/event-protocol/schemas/source.json
+++ b/event-protocol/schemas/source.json
@@ -1,19 +1,13 @@
 {
+  "id": "https://raw.github.com/cucumber/cucumber/master/event-protocol/schemas/source.json#",
   "title": "source",
   "type": "object",
   "properties": {
     "type": {
       "type": "string"
     },
-    "timestamp": {
-      "description": "Milliseconds since epoch",
-      "type": "integer",
-      "minimum": 0
-    },
-    "series": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    },
+    "timestamp": { "$ref": "defs.json#/timestamp" },
+    "series": { "$ref": "defs.json#/series" },
     "uri": {
       "type": "string"
     },

--- a/event-protocol/schemas/start.json
+++ b/event-protocol/schemas/start.json
@@ -1,19 +1,13 @@
 {
+  "id": "https://raw.github.com/cucumber/cucumber/master/event-protocol/schemas/start.json#",
   "title": "start",
   "type": "object",
   "properties": {
     "type": {
       "type": "string"
     },
-    "timestamp": {
-      "description": "Milliseconds since epoch",
-      "type": "integer",
-      "minimum": 0
-    },
-    "series": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    }
+    "timestamp": { "$ref": "defs.json#/timestamp" },
+    "series": { "$ref": "defs.json#/series" }
   },
   "required": [
     "type",


### PR DESCRIPTION
## Summary

In JSON schemas, you can [use refs to other files to re-use parts of your schema](https://code.tutsplus.com/tutorials/validating-data-with-json-schema-part-2--cms-25640). This PR demonstrates how it can be done, though it doesn't do it everywhere yet.

## Details

I extracted the definitions for the `timestamp` and `series` properties into a separate `defs.json` file and referenced that.

I also cleaned up the validate.js code a bit, based on some examples I was reading about using `ajv`.

## Motivation and Context

As the schema grows, we need to be able to easily maintain it. Keeping duplication down will be important in this.

## How Has This Been Tested?

I ran `make` and everything is still green.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Refactoring
