### PR TITLE
event-protocol: extract location schema ref

### DIFF
--- a/event-protocol/schemas/attachment.json
+++ b/event-protocol/schemas/attachment.json
@@ -14,23 +14,7 @@
         "uri": {
           "type": "string"
         },
-        "start": {
-          "type": "object",
-          "properties": {
-            "line": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "column": {
-              "type": "integer",
-              "minimum": 1
-            }
-          },
-          "required": [
-            "line"
-          ],
-          "additionalProperties": false
-        }
+        "start": { "$ref": "defs.json#/location" }
       },
       "required": [
         "uri",

--- a/event-protocol/schemas/defs.json
+++ b/event-protocol/schemas/defs.json
@@ -10,5 +10,25 @@
   "series": {
     "type": "string",
     "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  },
+  "location": {
+    "type": "object",
+    "properties": {
+      "line": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "column": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "uri": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "line"
+    ],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
This will make it easier to add other events that use a location.

I've added the uri so you *can* specify the file if you need to, otherwise we can infer the uri from the parent.