### PR TITLE
event-protocol: add some optional metadata in `start` event

### DIFF
--- a/event-protocol/schemas/start.json
+++ b/event-protocol/schemas/start.json
@@ -6,6 +6,12 @@
   "properties": {
     "type": {
       "type": "string"
+    },
+    "workingDirectory": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "number"
     }
   },
   "required": [


### PR DESCRIPTION
This allows the GUI to:

1) Identify (and display) the project that the results it's receiving
are coming from.
2) Display an accurate start time for the test run.

I've specified these attributes in the schema, but made them
non-required. I think this is better than just turning on
`additionalProperties` which would be too flexible.

I'd like to work towards a point where all emitters send out these
attributes (and we can then make them mandatory), but this flexibility
allows for some growth and development within the protocol.

An alternative would be to have a grab-bag `metadata` property of type
`object` and not specify the shape of that object.
