### PR TITLE
gherkin-perl: Change MetaResources to point to official location

### DIFF
--- a/gherkin/perl/dist.ini
+++ b/gherkin/perl/dist.ini
@@ -8,9 +8,9 @@ perl      = 5.14
 copyright_holder = Peter Sergeant, Cucumber Ltd, Gaspar Nagy
 
 [MetaResources]
-bugtracker.web    = https://github.com/pjlsergeant/gherkin/issues
-repository.url    = https://github.com/pjlsergeant/gherkin.git
-repository.web    = https://github.com/pjlsergeant/gherkin
+bugtracker.web    = https://github.com/cucumber/cucumber/issues
+repository.url    = https://github.com/cucumber/gherkin-perl.git
+repository.web    = https://github.com/cucumber/gherkin-perl
 repository.type   = git
 
 [GatherDir]


### PR DESCRIPTION
## Summary

Fix meta information

## Details

This changes the `[MetaResources]` section in `dist.ini` to point to the official issue tracker. It points the repository to the `cucumber/gherkin-perl` subrepo mirror.

## Motivation and Context

We want users and contributors to use the official issue tracker and repos.

