### PR TITLE
gherkin: (Python) Fix handling of error messages and newline encodings

### DIFF
--- a/gherkin/python/gherkin-python.razor
+++ b/gherkin/python/gherkin-python.razor
@@ -26,6 +26,7 @@
 @helper MatchToken(TokenType tokenType)
 {<text>match_@(tokenType)(context, token)</text>}
 # This file is generated. Do not edit! Edit gherkin-python.razor instead.
+import sys
 from collections import deque
 from .ast_builder import AstBuilder
 from .token_matcher import TokenMatcher
@@ -54,7 +55,10 @@ class @(Model.ParserClassName)(object):
         self.stop_at_first_error = False
 
     def parse(self, token_scanner_or_str, token_matcher=TokenMatcher()):
-        token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, str) else token_scanner_or_str
+        if sys.version_info < (3, 0):
+            token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, basestring) else token_scanner_or_str
+        else:
+            token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, str) else token_scanner_or_str
         self.ast_builder.reset()
         token_matcher.reset()
         context = ParserContext(

--- a/gherkin/python/gherkin/parser.py
+++ b/gherkin/python/gherkin/parser.py
@@ -1,4 +1,5 @@
 # This file is generated. Do not edit! Edit gherkin-python.razor instead.
+import sys
 from collections import deque
 from .ast_builder import AstBuilder
 from .token_matcher import TokenMatcher
@@ -62,7 +63,10 @@ class Parser(object):
         self.stop_at_first_error = False
 
     def parse(self, token_scanner_or_str, token_matcher=TokenMatcher()):
-        token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, str) else token_scanner_or_str
+        if sys.version_info < (3, 0):
+            token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, basestring) else token_scanner_or_str
+        else:
+            token_scanner = TokenScanner(token_scanner_or_str) if isinstance(token_scanner_or_str, str) else token_scanner_or_str
         self.ast_builder.reset()
         token_matcher.reset()
         context = ParserContext(

--- a/gherkin/python/gherkin/stream/gherkin_events.py
+++ b/gherkin/python/gherkin/stream/gherkin_events.py
@@ -13,7 +13,7 @@ def add_errors(events, errors, uri):
                     'column': error.location['column']
                 }
             },
-            'data': error.message,
+            'data': str(error),
             'media': {
                 'encoding': 'utf-8',
                 'type': 'text/vnd.cucumber.stacktrace+plain'

--- a/gherkin/python/gherkin/stream/source_events.py
+++ b/gherkin/python/gherkin/stream/source_events.py
@@ -1,8 +1,10 @@
+import io
+
 def source_event(path):
     event = {
         'type': 'source',
         'uri': path,
-        'data': open(path, 'r').read(),
+        'data': io.open(path, 'rU', encoding='utf8', newline='').read(),
         'media': {
             'encoding': 'utf-8',
             'type': 'text/vnd.cucumber.gherkin+plain'


### PR DESCRIPTION
## Summary

Fix #138 'gherkin: Fix build on python 3.4'

## Details

The first fix was to extract the message from the exception in a way that works in both Python 2 and Python 3 (`str(error)`).

This reviled that on Python 3 the newline encodings was not preserved (the [datatable.feature](https://github.com/cucumber/cucumber/blob/master/gherkin/testdata/good/datatables.feature#L5) contains a few lines the use `\r\n` as newline/line ending). To fix I had to make changes in how the files are read into the source events, which includes reading them into unicode strings. This rippled to some changes in the Parser since Python 2 differentiate between strings, `str`, and unicode-strings, `unicode`, (which both are subtypes to `basestring`), whereas Python 3 tread both string and unicode-strings as `str`. 

## Motivation and Context

Make Gherkin work also in Python 3

## How Has This Been Tested?

Acceptance test has been executed both on Python 2 and Python 3.
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
