### PR TITLE
[gherkin-ruby] Add ruby-head as a allow failures in .travis.yml.

### DIFF
--- a/gherkin/ruby/.travis.yml
+++ b/gherkin/ruby/.travis.yml
@@ -1,10 +1,16 @@
 language: ruby
 
 rvm:
+  - ruby-head
   - 2.4.0
   - 2.3.3
   - 2.2.6
   - jruby-9.1.7.0
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 
 script: make
 


### PR DESCRIPTION
## Summary
## Details
## Motivation and Context

I want to add  ruby-head to Travis as a allow failures for `gherkin-ruby`.
The motivation and the detail is same with cucumber/cucumber-ruby#1087

## How Has This Been Tested?

When I send this PR here, below Travis will test my `.travis.yml` right?
https://travis-ci.org/cucumber/gherkin-ruby

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
