### PR TITLE
event-protocol: Make binary command executable and add hashbang

### DIFF
--- a/event-protocol/bin/cucumber-event-validator.js
+++ b/event-protocol/bin/cucumber-event-validator.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const readline = require('readline')
 const validateEvent = require('../lib/validateEvent')
 const RED = '\033[0;31m'


### PR DESCRIPTION
I might have missed something, but I couldn't work out to run it (from
another directory) anymore since it moved into the bin directory in
3dbafa2e4a327a4251038a97063b7de5e0da3f88