### PR TITLE
gherkin-go: missing error handling

### DIFF
--- a/gherkin/go/cli/main.go
+++ b/gherkin/go/cli/main.go
@@ -23,8 +23,13 @@ func main() {
 	flag.Parse()
 
 	paths := flag.Args()
+	events, err := gherkin.GherkinEvents(paths...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to produce events: %+v\n", err)
+		os.Exit(1)
+	}
 
-	for ev := range gherkin.GherkinEvents(paths...) {
+	for _, ev := range events {
 		if _, ok := ev.(*gherkin.SourceEvent); ok && *noSource {
 			continue
 		}
@@ -40,7 +45,7 @@ func main() {
 		data, err := json.Marshal(ev)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to marshal event: %+v\n", err)
-			continue
+			os.Exit(1)
 		}
 
 		fmt.Fprintln(os.Stdout, string(data))


### PR DESCRIPTION
## Summary

Adds error handling as discussed in previous PR

## Details

`gherkin.GherkinEvents(paths ...string)` now returns a list of events and an unexpected error.
The error might be due to:

- failure to open feature file for reading
- unexpected gherkin token
- unexpected gherkin parser error

The **cli** exits with status code **1** in case of such error and prints it to **stderr**, errors expected from parser are interpreted as events.
