### PR TITLE
cucumber-expressions: #131 Cucumber Expressions: Non Capture Group

### DIFF
--- a/cucumber-expressions/javascript/examples.txt
+++ b/cucumber-expressions/javascript/examples.txt
@@ -6,10 +6,6 @@ I have {int} cuke(s) in my {bodypart} now
 I have 1 cuke in my belly now
 [1,"belly"]
 ---
-I have {int} cuke(s) and some \[]^$.|?*+ {something}
-I have 1 cuke and some \[]^$.|?*+ characters
-[1,"characters"]
----
 /I have (\d+) cukes? in my (.+) now/
 I have 22 cukes in my belly now
 [22,"belly"]

--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -1,87 +1,106 @@
-const matchPattern = require('./build_arguments')
+"use strict";
 
-class CucumberExpression {
-  /**
-   * @param expression
-   * @param types Array of type name (String) or types (function). Functions can be a regular function or a constructor
-   * @param parameterTypeRegistry
-   */
-  constructor (expression, types, parameterTypeRegistry) {
-    const PARAMETER_REGEXP = /\{([^}:]+)(:([^}]+))?}/g
-    const OPTIONAL_REGEXP = /\(([^)]+)\)/g
-    const ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/g
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-    this._expression = expression
-    this._parameterTypes = []
-    let regexp = "^"
-    let typeIndex = 0
-    let match
-    let matchOffset = 0
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-    // Does not include (){} because they have special meaning
-    expression = expression.replace(/([\\\^\[$.|?*+])/g, "\\$1")
+var matchPattern = require('./build_arguments');
 
-    // Create non-capturing, optional capture groups from parenthesis
-    expression = expression.replace(OPTIONAL_REGEXP, '(?:$1)?')
+var CucumberExpression = function () {
+    /**
+     * @param expression
+     * @param types Array of type name (String) or types (function). Functions can be a regular function or a constructor
+     * @param parameterTypeRegistry
+     */
+    function CucumberExpression(expression, types, parameterTypeRegistry) {
+        _classCallCheck(this, CucumberExpression);
 
-    expression = expression.replace(ALTERNATIVE_WORD_REGEXP, (_, p1, p2) => `(?:${p1}${p2.replace(/\//g, '|')})`)
+        var PARAMETER_REGEXP = /[{\[]([^}\]:]+)(:([^}\]]+))?[}\]]/g;
+        var OPTIONAL_REGEXP = /\(([^)]+)\)/g;
+        var ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/g;
 
-    while ((match = PARAMETER_REGEXP.exec(expression)) !== null) {
-      const parameterName = match[1]
-      const parameterTypeName = match[3]
-      // eslint-disable-next-line no-console
-      if (parameterTypeName && (typeof console !== 'undefined') && (typeof console.error == 'function')) {
-        // eslint-disable-next-line no-console
-        console.error(`Cucumber expression parameter syntax {${parameterName}:${parameterTypeName}} is deprecated. Please use {${parameterTypeName}} instead.`)
-      }
+        this._expression = expression;
+        this._parameterTypes = [];
+        var regexp = "^";
+        var typeIndex = 0;
+        var match = void 0;
+        var matchOffset = 0;
 
-      const type = types.length <= typeIndex ? null : types[typeIndex++]
+        // Does not include (){}[] because they have special meaning
+        expression = expression.replace(/([\\\^$.|?*+])/g, "\\$1");
 
-      let parameter
-      if (type) {
-        parameter = parameterTypeRegistry.lookupByType(type)
-      }
-      if (!parameter && parameterTypeName) {
-        parameter = parameterTypeRegistry.lookupByTypeName(parameterTypeName)
-      }
-      if (!parameter) {
-        parameter = parameterTypeRegistry.lookupByTypeName(parameterName)
-      }
-      if (!parameter) {
-        parameter = parameterTypeRegistry.createAnonymousLookup(s => s)
-      }
-      this._parameterTypes.push(parameter)
+        // Create non-capturing, optional capture groups from parenthesis
+        expression = expression.replace(OPTIONAL_REGEXP, '(?:$1)?');
 
-      const text = expression.slice(matchOffset, match.index)
-      const captureRegexp = getCaptureRegexp(parameter.regexps)
-      matchOffset = PARAMETER_REGEXP.lastIndex
-      regexp += text
-      regexp += captureRegexp
+        expression = expression.replace(ALTERNATIVE_WORD_REGEXP, function (_, p1, p2) {
+            return "(?:" + p1 + p2.replace(/\//g, '|') + ")";
+        });
+
+        while ((match = PARAMETER_REGEXP.exec(expression)) !== null) {
+            var parameterName = match[1];
+            var parameterTypeName = match[3];
+            // eslint-disable-next-line no-console
+            if (parameterTypeName && typeof console !== 'undefined' && typeof console.error == 'function') {
+                // eslint-disable-next-line no-console
+                console.error("Cucumber expression parameter syntax {" + parameterName + ":" + parameterTypeName + "} is deprecated. Please use {" + parameterTypeName + "} instead.");
+            }
+
+            var type = types.length <= typeIndex ? null : types[typeIndex++];
+
+            var parameter = void 0;
+            if (type) {
+                parameter = parameterTypeRegistry.lookupByType(type);
+            }
+            if (!parameter && parameterTypeName) {
+                parameter = parameterTypeRegistry.lookupByTypeName(parameterTypeName);
+            }
+            if (!parameter) {
+                parameter = parameterTypeRegistry.lookupByTypeName(parameterName);
+            }
+            if (!parameter) {
+                parameter = parameterTypeRegistry.createAnonymousLookup(function (s) {
+                    return s;
+                });
+            }
+            parameter.matchType = match[0].split("")[0] === "{" ? "capture" : "non-capture";
+            this._parameterTypes.push(parameter);
+
+            var text = expression.slice(matchOffset, match.index);
+            var captureRegexp = getCaptureRegexp(parameter.regexps, parameter.matchType);
+            matchOffset = PARAMETER_REGEXP.lastIndex;
+            regexp += text;
+            regexp += captureRegexp;
+        }
+        regexp += expression.slice(matchOffset);
+        regexp += "$";
+        this._regexp = new RegExp(regexp);
     }
-    regexp += expression.slice(matchOffset)
-    regexp += "$"
-    this._regexp = new RegExp(regexp)
-  }
 
-  match (text) {
-    return matchPattern(this._regexp, text, this._parameterTypes)
-  }
+    _createClass(CucumberExpression, [{
+        key: "match",
+        value: function match(text) {
+            return matchPattern(this._regexp, text, this._parameterTypes);
+        }
+    }, {
+        key: "source",
+        get: function get() {
+            return this._expression;
+        }
+    }]);
 
-  get source () {
-    return this._expression
-  }
+    return CucumberExpression;
+}();
+
+function getCaptureRegexp(regexps, matchType) {
+    if (regexps.length === 1) {
+        return matchType === "capture" ? "(" + regexps[0] + ")" : "(?:" + regexps[0] + ")";
+    }
+
+    var captureGroups = regexps.map(function (group) {
+        return "(?:" + group + ")";
+    });
+
+    return "(" + captureGroups.join('|') + ")";
 }
 
-function getCaptureRegexp (regexps) {
-  if (regexps.length === 1) {
-    return `(${regexps[0]})`
-  }
-
-  const captureGroups = regexps.map(group => {
-    return `(?:${group})`
-  })
-
-  return `(${captureGroups.join('|')})`
-}
-
-module.exports = CucumberExpression
+module.exports = CucumberExpression;

--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -1,106 +1,88 @@
-"use strict";
+const matchPattern = require('./build_arguments')
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+class CucumberExpression {
+  /**
+   * @param expression
+   * @param types Array of type name (String) or types (function). Functions can be a regular function or a constructor
+   * @param parameterTypeRegistry
+   */
+  constructor (expression, types, parameterTypeRegistry) {
+      var PARAMETER_REGEXP = /[{\[]([^}\]:]+)(:([^}\]]+))?[}\]]/g;
+    const OPTIONAL_REGEXP = /\(([^)]+)\)/g
+    const ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/g
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+    this._expression = expression
+    this._parameterTypes = []
+    let regexp = "^"
+    let typeIndex = 0
+    let match
+    let matchOffset = 0
 
-var matchPattern = require('./build_arguments');
+    // Does not include (){}[] because they have special meaning
+      expression = expression.replace(/([\\\^$.|?*+])/g, "\\$1");
 
-var CucumberExpression = function () {
-    /**
-     * @param expression
-     * @param types Array of type name (String) or types (function). Functions can be a regular function or a constructor
-     * @param parameterTypeRegistry
-     */
-    function CucumberExpression(expression, types, parameterTypeRegistry) {
-        _classCallCheck(this, CucumberExpression);
+    // Create non-capturing, optional capture groups from parenthesis
+    expression = expression.replace(OPTIONAL_REGEXP, '(?:$1)?')
 
-        var PARAMETER_REGEXP = /[{\[]([^}\]:]+)(:([^}\]]+))?[}\]]/g;
-        var OPTIONAL_REGEXP = /\(([^)]+)\)/g;
-        var ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/g;
+    expression = expression.replace(ALTERNATIVE_WORD_REGEXP, (_, p1, p2) => `(?:${p1}${p2.replace(/\//g, '|')})`)
 
-        this._expression = expression;
-        this._parameterTypes = [];
-        var regexp = "^";
-        var typeIndex = 0;
-        var match = void 0;
-        var matchOffset = 0;
+    while ((match = PARAMETER_REGEXP.exec(expression)) !== null) {
+      const parameterName = match[1]
+      const parameterTypeName = match[3]
+      // eslint-disable-next-line no-console
+      if (parameterTypeName && (typeof console !== 'undefined') && (typeof console.error == 'function')) {
+        // eslint-disable-next-line no-console
+        console.error(`Cucumber expression parameter syntax {${parameterName}:${parameterTypeName}} is deprecated. Please use {${parameterTypeName}} instead.`)
+      }
 
-        // Does not include (){}[] because they have special meaning
-        expression = expression.replace(/([\\\^$.|?*+])/g, "\\$1");
+      const type = types.length <= typeIndex ? null : types[typeIndex++]
 
-        // Create non-capturing, optional capture groups from parenthesis
-        expression = expression.replace(OPTIONAL_REGEXP, '(?:$1)?');
+      let parameter
+      if (type) {
+        parameter = parameterTypeRegistry.lookupByType(type)
+      }
+      if (!parameter && parameterTypeName) {
+        parameter = parameterTypeRegistry.lookupByTypeName(parameterTypeName)
+      }
+      if (!parameter) {
+        parameter = parameterTypeRegistry.lookupByTypeName(parameterName)
+      }
+      if (!parameter) {
+        parameter = parameterTypeRegistry.createAnonymousLookup(s => s)
+      }
+        parameter.matchType = match[0].split("")[0] === "{" ? "capture" : "non-capture";
+        this._parameterTypes.push(parameter)
 
-        expression = expression.replace(ALTERNATIVE_WORD_REGEXP, function (_, p1, p2) {
-            return "(?:" + p1 + p2.replace(/\//g, '|') + ")";
-        });
-
-        while ((match = PARAMETER_REGEXP.exec(expression)) !== null) {
-            var parameterName = match[1];
-            var parameterTypeName = match[3];
-            // eslint-disable-next-line no-console
-            if (parameterTypeName && typeof console !== 'undefined' && typeof console.error == 'function') {
-                // eslint-disable-next-line no-console
-                console.error("Cucumber expression parameter syntax {" + parameterName + ":" + parameterTypeName + "} is deprecated. Please use {" + parameterTypeName + "} instead.");
-            }
-
-            var type = types.length <= typeIndex ? null : types[typeIndex++];
-
-            var parameter = void 0;
-            if (type) {
-                parameter = parameterTypeRegistry.lookupByType(type);
-            }
-            if (!parameter && parameterTypeName) {
-                parameter = parameterTypeRegistry.lookupByTypeName(parameterTypeName);
-            }
-            if (!parameter) {
-                parameter = parameterTypeRegistry.lookupByTypeName(parameterName);
-            }
-            if (!parameter) {
-                parameter = parameterTypeRegistry.createAnonymousLookup(function (s) {
-                    return s;
-                });
-            }
-            parameter.matchType = match[0].split("")[0] === "{" ? "capture" : "non-capture";
-            this._parameterTypes.push(parameter);
-
-            var text = expression.slice(matchOffset, match.index);
-            var captureRegexp = getCaptureRegexp(parameter.regexps, parameter.matchType);
-            matchOffset = PARAMETER_REGEXP.lastIndex;
-            regexp += text;
-            regexp += captureRegexp;
-        }
-        regexp += expression.slice(matchOffset);
-        regexp += "$";
-        this._regexp = new RegExp(regexp);
+      const text = expression.slice(matchOffset, match.index)
+      const captureRegexp = getCaptureRegexp(parameter.regexps, parameter.matchType)
+      matchOffset = PARAMETER_REGEXP.lastIndex
+      regexp += text
+      regexp += captureRegexp
     }
+    regexp += expression.slice(matchOffset)
+    regexp += "$"
+    this._regexp = new RegExp(regexp)
+  }
 
-    _createClass(CucumberExpression, [{
-        key: "match",
-        value: function match(text) {
-            return matchPattern(this._regexp, text, this._parameterTypes);
-        }
-    }, {
-        key: "source",
-        get: function get() {
-            return this._expression;
-        }
-    }]);
+  match (text) {
+    return matchPattern(this._regexp, text, this._parameterTypes)
+  }
 
-    return CucumberExpression;
-}();
-
-function getCaptureRegexp(regexps, matchType) {
-    if (regexps.length === 1) {
-        return matchType === "capture" ? "(" + regexps[0] + ")" : "(?:" + regexps[0] + ")";
-    }
-
-    var captureGroups = regexps.map(function (group) {
-        return "(?:" + group + ")";
-    });
-
-    return "(" + captureGroups.join('|') + ")";
+  get source () {
+    return this._expression
+  }
 }
 
-module.exports = CucumberExpression;
+function getCaptureRegexp (regexps, matchType) {
+  if (regexps.length === 1) {
+      return matchType === "capture" ? "(" + regexps[0] + ")" : "(?:" + regexps[0] + ")";
+  }
+
+  const captureGroups = regexps.map(group => {
+    return `(?:${group})`
+  })
+
+  return `(${captureGroups.join('|')})`
+}
+
+module.exports = CucumberExpression

--- a/cucumber-expressions/javascript/test/cucumber_expression_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_test.js
@@ -64,7 +64,7 @@ describe(CucumberExpression.name, () => {
   })
 
   describe('RegExp special characters', () => {
-    ['\\', '[', ']', '^', '$', '.', '|', '?', '*', '+'].forEach((character) => {
+    ['\\', '^', '$', '.', '|', '?', '*', '+'].forEach((character) => {
       it(`escapes ${character}`, () => {
         const expr = `I have {int} cuke(s) and ${character}`
         const expression = new CucumberExpression(expr, [], new ParameterTypeRegistry())


### PR DESCRIPTION
## Summary
I'm linking to the issue that I created over in the cucumber-js repo [here](https://github.com/cucumber/cucumber-js/issues/784) and the change that this relates to in the cucumber parent project repo [here](https://github.com/cucumber/cucumber/issues/131) in order to trace back the whole conversation.

There are many cases in our step definitions where we have _a varity of repeated groups that don't change the steps functionality, but does do quite a bit for readablilty_ in the feature files:

* "must"/"should"
* optional words like "the", "I" etc that would match `Given I fill in "Foo"` & `And fill in "Bar"`
* lists of interchangable words

Say that you are using these alternatives across a large set of step definitions and you wish to change them all. This is where the problem (and the solution) both appear.


## Details

Changed the regex that matches parameter groups to include square brackets as well as curly braces.
Later on, a line to differentiate between the two types of braces - naming curly as capture and square as non-capture.
Later still, an edit to the line that adds to the Regex, to make sure curly has capture group regex, and square has non-capture group regex.

Removed 3 tests that check that cucumber escapes square brackets - it now doesn't, as these are now special characters in cucumber-expressions. 

## Motivation and Context

We will be working with cucumber on a wide variety of projects in our company and I can guarantee that many of them will require a large number of declaratively written step definitions that require many alternatives that won't be captured for use within the step definitions.

This would make it easier for us to keep track of all of the alternatives that we will be using, and will mean that we wont have to search through the many step definition files for all of the uses..

And I am certain that others in the cucumber community will be in the same situation as I.

## How Has This Been Tested?

I've done a set of tests for this, by checking the number of parameters needed in an example cucumber suite (I can load this to a repository on request). The square brackets now match with the transforms that we set, but do not pass a parameter, as they are optional.

## Screenshots (if appropriate):
![cucumber_code](https://cloud.githubusercontent.com/assets/18209178/24831009/0386d0c6-1c89-11e7-8827-2000b36da2c9.png)

Note: The two failures are intentional, to show that the code actually works
![cucumber_running](https://cloud.githubusercontent.com/assets/18209178/24831011/06df942e-1c89-11e7-905a-90e0d9221a09.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
