### PR TITLE
cucumber-expressions: Remove named params (already deprecated)

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 public class CucumberExpression implements Expression {
     private static final Pattern ESCAPE_PATTERN = Pattern.compile("([\\\\\\^\\[$.|?*+\\]])");
-    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\{([^}:]+)(:([^}]+))?}");
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\{([^}]+)}");
     private static final Pattern OPTIONAL_PATTERN = Pattern.compile("\\(([^)]+)\\)");
     private static final Pattern ALTERNATIVE_WORD_REGEXP = Pattern.compile("([\\p{IsAlphabetic}]+)((/[\\p{IsAlphabetic}]+)+)");
 
@@ -35,19 +35,12 @@ public class CucumberExpression implements Expression {
         int typeIndex = 0;
         while (matcher.find()) {
             String parameterName = matcher.group(1);
-            String parameterTypeName = matcher.group(3);
-            if (parameterTypeName != null) {
-                System.err.println(String.format("Cucumber expression parameter type syntax {%s:%s} is deprecated. Please use {%s} instead.", parameterName, parameterTypeName, parameterTypeName));
-            }
 
             Type type = types.size() <= typeIndex ? null : types.get(typeIndex++);
 
             ParameterType<?> parameterType = null;
             if (type != null) {
                 parameterType = parameterTypeRegistry.lookupByType(type);
-            }
-            if (parameterType == null && parameterTypeName != null) {
-                parameterType = parameterTypeRegistry.lookupByTypeName(parameterTypeName);
             }
             if (parameterType == null) {
                 parameterType = parameterTypeRegistry.lookupByTypeName(parameterName);

--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -7,7 +7,7 @@ class CucumberExpression {
    * @param parameterTypeRegistry
    */
   constructor (expression, types, parameterTypeRegistry) {
-    const PARAMETER_REGEXP = /\{([^}:]+)(:([^}]+))?}/g
+    const PARAMETER_REGEXP = /\{([^}]+)}/g
     const OPTIONAL_REGEXP = /\(([^)]+)\)/g
     const ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/g
 
@@ -28,21 +28,11 @@ class CucumberExpression {
 
     while ((match = PARAMETER_REGEXP.exec(expression)) !== null) {
       const parameterName = match[1]
-      const parameterTypeName = match[3]
-      // eslint-disable-next-line no-console
-      if (parameterTypeName && (typeof console !== 'undefined') && (typeof console.error == 'function')) {
-        // eslint-disable-next-line no-console
-        console.error(`Cucumber expression parameter syntax {${parameterName}:${parameterTypeName}} is deprecated. Please use {${parameterTypeName}} instead.`)
-      }
-
       const type = types.length <= typeIndex ? null : types[typeIndex++]
 
       let parameterType
       if (type) {
         parameterType = parameterTypeRegistry.lookupByType(type)
-      }
-      if (!parameterType && parameterTypeName) {
-        parameterType = parameterTypeRegistry.lookupByTypeName(parameterTypeName)
       }
       if (!parameterType) {
         parameterType = parameterTypeRegistry.lookupByTypeName(parameterName)

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -4,7 +4,7 @@ require 'cucumber/cucumber_expressions/parameter_type'
 module Cucumber
   module CucumberExpressions
     class CucumberExpression
-      PARAMETER_REGEXP = /\{([^}:]+)(:([^}]+))?}/
+      PARAMETER_REGEXP = /\{([^}]+)}/
       OPTIONAL_REGEXP = /\(([^)]+)\)/
       ALTERNATIVE_WORD_REGEXP = /([[:alpha:]]+)((\/[[:alpha:]]+)+)/
 
@@ -32,10 +32,6 @@ module Cucumber
           break if match.nil?
 
           parameter_name = match[1]
-          parameter_type_name = match[3]
-          if parameter_type_name
-            $stderr.puts("Cucumber expression parameter syntax {#{parameter_name}:#{parameter_type_name}} is deprecated. Please use {#{parameter_type_name}} instead.")
-          end
 
           type = types.length <= type_index ? nil : types[type_index]
           type_index += 1
@@ -43,9 +39,6 @@ module Cucumber
           parameter_type = nil
           if type
             parameter_type = parameter_type_registry.lookup_by_type(type)
-          end
-          if parameter_type.nil? && parameter_type_name
-            parameter_type = parameter_type_registry.lookup_by_name(parameter_type_name)
           end
           if parameter_type.nil?
             parameter_type = parameter_type_registry.lookup_by_name(parameter_name)


### PR DESCRIPTION
## Summary

Remove support for `{foo:int}` style parameters

## Motivation and Context

We realised a couple of releases back that parameters only need to name its type. The name can be set to whatever the user wants in the associated method/function's parameters.

## How Has This Been Tested?

We still have 100% coverage

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
