### PR TITLE
Gherkin-Java: Added female, singular given in Romanian

### DIFF
--- a/gherkin/java/src/main/resources/gherkin/gherkin-languages.json
+++ b/gherkin/java/src/main/resources/gherkin/gherkin-languages.json
@@ -2346,6 +2346,7 @@
       "* ",
       "Date fiind ",
       "Dat fiind ",
+      "Dată fiind",
       "Dati fiind ",
       "Dați fiind ",
       "Daţi fiind "


### PR DESCRIPTION
## Summary

The female, singular form for 'Given' was missing for Romanian.
Added it after suggestion from Bianca (native Romanian)