### PR TITLE
Gherkin: Added female, singular 'Given' in Romanian

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -2346,6 +2346,7 @@
       "* ",
       "Date fiind ",
       "Dat fiind ",
+      "Dată fiind",
       "Dati fiind ",
       "Dați fiind ",
       "Daţi fiind "


### PR DESCRIPTION
## Summary

Added missing female, singular for 'Given' in Romanian supported by a native Romanian speaker (Bianca at Mozaic Works)