### PR TITLE
cucumber-expressions: make CAPTURE_GROUP_PATTERN aware of non-…

### DIFF
--- a/cucumber-expressions/javascript/src/regular_expression.js
+++ b/cucumber-expressions/javascript/src/regular_expression.js
@@ -5,7 +5,7 @@ class RegularExpression {
     this._regexp = regexp
     this._parameterTypes = []
 
-    const CAPTURE_GROUP_PATTERN = /\(([^(]+)\)/g
+    const CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/g
 
     let typeIndex = 0
     let match

--- a/cucumber-expressions/javascript/test/regular_expression_test.js
+++ b/cucumber-expressions/javascript/test/regular_expression_test.js
@@ -54,6 +54,13 @@ describe(RegularExpression.name, () => {
     assert.deepEqual(match(/(.*)/, '-1.22', [s => parseFloat(s)]), [-1.22])
   })
 
+  it('take into account non-capturing group', () => {
+    assert.deepEqual(match(/(?:head) (\d+) (tail)/, 'head 22 tail'), [
+      22,
+      'tail',
+    ])
+  })
+
   it('returns null when there is no match', () => {
     assert.equal(match(/hello/, 'world'), null)
   })

--- a/cucumber-expressions/javascript/test/regular_expression_test.js
+++ b/cucumber-expressions/javascript/test/regular_expression_test.js
@@ -54,7 +54,7 @@ describe(RegularExpression.name, () => {
     assert.deepEqual(match(/(.*)/, '-1.22', [s => parseFloat(s)]), [-1.22])
   })
 
-  it('take into account non-capturing group', () => {
+  it('takes into account non-capturing group', () => {
     assert.deepEqual(match(/(?:head) (\d+) (tail)/, 'head 22 tail'), [
       22,
       'tail',


### PR DESCRIPTION
…capturing group.

<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Before this patch, non-capturing group would be accounted for in the
match count, wrongly shifting the transformation.

## Motivation and Context

Fixes #211 

Using a combination of non-capturing group regexp in combination with regexp matching a registered type would apply transformation to the wrong group, yielding unexpected results.

## How Has This Been Tested?

Tests updated, before the patch we get:
```
  1) RegularExpression take into account non-capturing group:

      AssertionError: [ '22', NaN ] deepEqual [ 22, 'tail' ]
      + expected - actual

       [
      -  "22"
      -  NaN
      +  22
      +  "tail"
       ]

```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

Stricly speaking it is a Breaking change, although the probability that users worked around it are slim.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
