### PR TITLE
cucumber-expressions: Add a {word} parameter type, ref #191

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/AbstractParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/AbstractParameterType.java
@@ -7,13 +7,17 @@ public abstract class AbstractParameterType<T> implements ParameterType<T> {
     private final String name;
     private final Type type;
     private final List<String> regexps;
-    private final boolean isPreferential;
+    private final boolean preferForRegexpMatch;
+    private final boolean useForSnippets;
 
-    public AbstractParameterType(String name, Type type, boolean isPreferential, List<String> regexps) {
+    public AbstractParameterType(String name, List<String> regexps, Type type, boolean useForSnippets, boolean preferForRegexpMatch) {
+        if (name == null) throw new CucumberExpressionException("name cannot be null");
         if (type == null) throw new CucumberExpressionException("type cannot be null");
-        this.isPreferential = isPreferential;
+        if (regexps == null) throw new CucumberExpressionException("regexps cannot be null");
         this.name = name;
         this.type = type;
+        this.preferForRegexpMatch = preferForRegexpMatch;
+        this.useForSnippets = useForSnippets;
         this.regexps = regexps;
     }
 
@@ -33,7 +37,12 @@ public abstract class AbstractParameterType<T> implements ParameterType<T> {
     }
 
     @Override
-    public boolean isPreferential() {
-        return isPreferential;
+    public boolean preferForRegexpMatch() {
+        return preferForRegexpMatch;
+    }
+
+    @Override
+    public boolean useForSnippets() {
+        return useForSnippets;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ClassParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ClassParameterType.java
@@ -6,11 +6,11 @@ import java.util.List;
 public class ClassParameterType<T> implements ParameterType<T> {
     private final ParameterType<T> delegate;
 
-    public ClassParameterType(Class<T> type) {
+    public ClassParameterType(Class<T> type, List<String> regexps) {
         if (type.isEnum()) {
-            delegate = (ParameterType<T>) new EnumParameterType<>((Class<? extends Enum>) type);
+            delegate = (ParameterType<T>) new EnumParameterType<>((Class<? extends Enum>) type, regexps);
         } else {
-            delegate = new ConstructorParameterType<>(type);
+            delegate = new ConstructorParameterType<>(type, regexps);
         }
     }
 
@@ -35,7 +35,12 @@ public class ClassParameterType<T> implements ParameterType<T> {
     }
 
     @Override
-    public boolean isPreferential() {
-        return delegate.isPreferential();
+    public boolean preferForRegexpMatch() {
+        return delegate.preferForRegexpMatch();
+    }
+
+    @Override
+    public boolean useForSnippets() {
+        return delegate.useForSnippets();
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ConstructorParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ConstructorParameterType.java
@@ -2,15 +2,13 @@ package io.cucumber.cucumberexpressions;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
 import java.util.List;
 
 public class ConstructorParameterType<T> extends AbstractParameterType<T> {
-    private static final List<String> ANYTHING_GOES = Collections.singletonList(".+");
     private final Constructor<T> constructor;
 
-    public ConstructorParameterType(Class<T> clazz) {
-        super(clazz.getSimpleName().toLowerCase(), clazz, false, ANYTHING_GOES);
+    public ConstructorParameterType(Class<T> clazz, List<String> regexps) {
+        super(clazz.getSimpleName().toLowerCase(), regexps, clazz, true, false);
         try {
             this.constructor = clazz.getConstructor(String.class);
         } catch (NoSuchMethodException e) {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
@@ -77,7 +77,9 @@ public class CucumberExpressionGenerator {
         Collection<ParameterType<?>> parameterTypes = parameterTypeRegistry.getParameterTypes();
         List<ParameterTypeMatcher> parameterTypeMatchers = new ArrayList<>();
         for (ParameterType<?> parameterType : parameterTypes) {
-            parameterTypeMatchers.addAll(createParameterTypeMatchers(parameterType, text));
+            if(parameterType.useForSnippets()) {
+                parameterTypeMatchers.addAll(createParameterTypeMatchers(parameterType, text));
+            }
         }
         return parameterTypeMatchers;
     }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/EnumParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/EnumParameterType.java
@@ -1,14 +1,12 @@
 package io.cucumber.cucumberexpressions;
 
-import java.util.Collections;
 import java.util.List;
 
 public class EnumParameterType<T extends Enum<T>> extends AbstractParameterType<T> {
-    private static final List<String> ANYTHING_GOES = Collections.singletonList(".+");
     private final Class<T> enumClass;
 
-    public EnumParameterType(Class<T> enumClass) {
-        super(enumClass.getSimpleName().toLowerCase(), enumClass, false, ANYTHING_GOES);
+    public EnumParameterType(Class<T> enumClass, List<String> regexps) {
+        super(enumClass.getSimpleName().toLowerCase(), regexps, enumClass, true, false);
         this.enumClass = enumClass;
     }
 

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -18,5 +18,22 @@ public interface ParameterType<T> {
 
     T transform(String value);
 
-    boolean isPreferential();
+    /**
+     * Indicates whether or not this is a preferential parameter type when matching text
+     * against a {@link RegularExpression}. In case there are multiple parameter types
+     * with a regexp identical to the capture group's regexp, a preferential parameter type will
+     * win. If there are more than 1 preferential ones, an error will be thrown.
+     *
+     * @return true if this is a preferential type
+     */
+    boolean preferForRegexpMatch();
+
+    /**
+     * Indicates whether or not this is a parameter type that should be used for generating
+     * {@link GeneratedExpression}s from text. Typically, parameter types with greedy regexps
+     * should return false.
+     *
+     * @return true is this parameter type is used for expression generation
+     */
+    boolean useForSnippets();
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeComparator.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeComparator.java
@@ -8,8 +8,8 @@ import java.util.Comparator;
 class ParameterTypeComparator implements Comparator<ParameterType> {
     @Override
     public int compare(ParameterType pt1, ParameterType pt2) {
-        if (pt1.isPreferential() && !pt2.isPreferential()) return -1;
-        if (pt2.isPreferential() && !pt1.isPreferential()) return 1;
+        if (pt1.preferForRegexpMatch() && !pt2.preferForRegexpMatch()) return -1;
+        if (pt2.preferForRegexpMatch() && !pt1.preferForRegexpMatch()) return 1;
         return pt1.getName().compareTo(pt2.getName());
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
@@ -31,6 +31,8 @@ class ParameterTypeMatcher implements Comparable<ParameterTypeMatcher> {
 
     @Override
     public int compareTo(ParameterTypeMatcher o) {
+//        int parameterTypeComparison = new ParameterTypeComparator().compare(parameterType, o.getParameterType());
+//        if (parameterTypeComparison != 0) return parameterTypeComparison;
         int posComparison = Integer.compare(start(), o.start());
         if (posComparison != 0) return posComparison;
         int lengthComparison = Integer.compare(o.group().length(), group().length());

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.singletonList;
+
 public class RegularExpression implements Expression {
     private static final Pattern CAPTURE_GROUP_PATTERN = Pattern.compile("\\((?!\\?:)([^(]+)\\)");
 
@@ -34,7 +36,7 @@ public class RegularExpression implements Expression {
 
             ParameterType<?> parameterType = parameterTypeRegistry.lookupByRegexp(parameterTypeRegexp, expressionRegexp, text);
             if (parameterType == null) {
-                parameterType = new ConstructorParameterType<>(String.class);
+                parameterType = new ConstructorParameterType<>(String.class, singletonList(parameterTypeRegexp));
             }
             parameterTypes.add(parameterType);
         }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/SimpleParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/SimpleParameterType.java
@@ -7,22 +7,22 @@ import static java.util.Collections.singletonList;
 public class SimpleParameterType<T> extends AbstractParameterType<T> {
     private final Function<String, T> transformer;
 
-    public SimpleParameterType(String name, Class<T> type, boolean isPreferential, List<String> regexps, Function<String, T> transformer) {
-        super(name, type, isPreferential, regexps);
+    public SimpleParameterType(String name, List<String> regexps, Class<T> type, Function<String, T> transformer, boolean useForSnippets, boolean preferForRegexpMatch) {
+        super(name, regexps, type, useForSnippets, preferForRegexpMatch);
         if (transformer == null) throw new CucumberExpressionException("transformer cannot be null");
         this.transformer = transformer;
     }
 
-    public SimpleParameterType(String name, Class<T> type, boolean isPreferential, String regexp, Function<String, T> transformer) {
-        this(name, type, isPreferential, singletonList(regexp), transformer);
+    public SimpleParameterType(String name, String regexp, Class<T> type, Function<String, T> transformer, boolean useForSnippets, boolean preferForRegexpMatch) {
+        this(name, singletonList(regexp), type, transformer, useForSnippets, preferForRegexpMatch);
     }
 
-    public SimpleParameterType(String name, Class<T> type, String regexp, Function<String, T> transformer) {
-        this(name, type, false, singletonList(regexp), transformer);
+    public SimpleParameterType(String name, String regexp, Class<T> type, Function<String, T> transformer) {
+        this(name, singletonList(regexp), type, transformer, true, false);
     }
 
-    public SimpleParameterType(String name, Class<T> type, List<String> regexps, Function<String, T> transformer) {
-        this(name, type, false, regexps, transformer);
+    public SimpleParameterType(String name, List<String> regexps, Class<T> type, Function<String, T> transformer) {
+        this(name, regexps, type, transformer, true, false);
     }
 
     @Override

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CombinatorialGeneratedExpressionFactoryTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CombinatorialGeneratedExpressionFactoryTest.java
@@ -6,14 +6,24 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 public class CombinatorialGeneratedExpressionFactoryTest {
+    private static final List<String> WORDS = singletonList("\\w+");
+
     @Test
     public void generates_multiple_expressions() {
         List<List<ParameterType<?>>> parameterTypeCombinations = asList(
-                asList(new ClassParameterType<>(Color.class), new ClassParameterType<>(CssColor.class)),
-                asList(new ClassParameterType<>(Date.class), new ClassParameterType<>(DateTime.class), new ClassParameterType<>(Timestamp.class))
+                asList(
+                        new ClassParameterType<>(Color.class, WORDS),
+                        new ClassParameterType<>(CssColor.class, WORDS)
+                ),
+                asList(
+                        new ClassParameterType<>(Date.class, WORDS),
+                        new ClassParameterType<>(DateTime.class, WORDS),
+                        new ClassParameterType<>(Timestamp.class, WORDS)
+                )
         );
         CombinatorialGeneratedExpressionFactory factory = new CombinatorialGeneratedExpressionFactory(
                 "I bought a {%s} ball on {%s}",

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ConstructorParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ConstructorParameterTypeTest.java
@@ -2,13 +2,14 @@ package io.cucumber.cucumberexpressions;
 
 import org.junit.Test;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 
 public class ConstructorParameterTypeTest {
     @Test
     public void requires_string_ctor() {
         try {
-            new ConstructorParameterType<>(NoStringCtor.class);
+            new ConstructorParameterType<>(NoStringCtor.class, singletonList("whatevs"));
             fail();
         } catch (CucumberExpressionException expected) {
             assertEquals("Missing constructor: `public NoStringCtor(String)`", expected.getMessage());
@@ -18,7 +19,7 @@ public class ConstructorParameterTypeTest {
     @Test
     public void reports_ctor_exceptions() {
         try {
-            new ConstructorParameterType<>(FailingCtor.class).transform("hello");
+            new ConstructorParameterType<>(FailingCtor.class, singletonList("whatevs")).transform("hello");
             fail();
         } catch (CucumberExpressionException expected) {
             assertEquals("Failed to invoke `new FailingCtor(\"hello\")`", expected.getMessage());
@@ -29,7 +30,7 @@ public class ConstructorParameterTypeTest {
     @Test
     public void reports_abstract_exceptions() {
         try {
-            new ConstructorParameterType<>(Abstract.class).transform("hello");
+            new ConstructorParameterType<>(Abstract.class, singletonList("whatevs")).transform("hello");
             fail();
         } catch (CucumberExpressionException expected) {
             assertEquals("Failed to invoke `new Abstract(\"hello\")`", expected.getMessage());
@@ -39,7 +40,7 @@ public class ConstructorParameterTypeTest {
 
     @Test
     public void returns_null_for_value_null() {
-        assertNull(new ConstructorParameterType<>(Abstract.class).transform(null));
+        assertNull(new ConstructorParameterType<>(Abstract.class, singletonList("whatevs")).transform(null));
     }
 
     public static class NoStringCtor {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
@@ -55,8 +55,7 @@ public class CucumberExpressionGeneratorTest {
     public void numbers_only_second_argument_when_type_is_not_reserved_keyword() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "currency",
-                Currency.class,
-                "[A-Z]{3}",
+                "[A-Z]{3}", Currency.class,
                 Currency::getInstance
         ));
         assertExpression(
@@ -68,14 +67,12 @@ public class CucumberExpressionGeneratorTest {
     public void prefers_leftmost_match_when_there_is_overlap() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "currency",
-                Currency.class,
-                "cd",
+                "cd", Currency.class,
                 Currency::getInstance
         ));
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "date",
-                Date.class,
-                "bc",
+                "bc", Date.class,
                 Date::new
         ));
         assertExpression(
@@ -87,14 +84,12 @@ public class CucumberExpressionGeneratorTest {
     public void prefers_widest_match_when_pos_is_same() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "currency",
-                Currency.class,
-                "cd",
+                "cd", Currency.class,
                 Currency::getInstance
         ));
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "date",
-                Date.class,
-                "cde",
+                "cde", Date.class,
                 Date::new
         ));
         assertExpression(
@@ -106,15 +101,16 @@ public class CucumberExpressionGeneratorTest {
     public void generates_all_combinations_of_expressions_when_several_parameter_types_match() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "currency",
-                Currency.class,
                 "x",
-                Currency::getInstance
+                Currency.class,
+                Currency::getInstance,
+                true, true
         ));
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "date",
-                Date.class,
-                "x",
-                Date::new
+                "x", Date.class,
+                Date::new,
+                true, false
         ));
 
         List<GeneratedExpression> generatedExpressions = generator.generateExpressions("I have x and x and another x");

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -26,6 +26,11 @@ public class CucumberExpressionTest {
     }
 
     @Test
+    public void matches_word() {
+        assertEquals(singletonList("blind"), match("three {word} mice", "three blind mice"));
+    }
+
+    @Test
     public void matches_int() {
         assertEquals(singletonList(22), match("{int}", "22"));
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
@@ -3,10 +3,12 @@ package io.cucumber.cucumberexpressions;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.compile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -19,8 +21,7 @@ public class CustomParameterTypeTest {
         /// [add-color-parameter-type]
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "color",
-                Color.class,
-                "red|blue|yellow",
+                "red|blue|yellow", Color.class,
                 Color::new
         ));
         /// [add-color-parameter-type]
@@ -38,8 +39,7 @@ public class CustomParameterTypeTest {
         parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "color",
-                Color.class,
-                asList("red|blue|yellow", "(?:dark|light) (?:red|blue|yellow)"),
+                asList("red|blue|yellow", "(?:dark|light) (?:red|blue|yellow)"), Color.class,
                 Color::new
         ));
         Expression expression = new CucumberExpression("I have a {color} ball", parameterTypeRegistry);
@@ -51,8 +51,7 @@ public class CustomParameterTypeTest {
     public void defers_transformation_until_queried_from_argument() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "throwing",
-                String.class,
-                "bad",
+                "bad", CssColor.class,
                 name -> {
                     throw new RuntimeException(String.format("Can't transform [%s]", name));
                 }));
@@ -71,8 +70,7 @@ public class CustomParameterTypeTest {
         try {
             parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                     "color",
-                    CssColor.class,
-                    ".*",
+                    ".*", CssColor.class,
                     CssColor::new));
             fail("should have failed");
         } catch (DuplicateTypeNameException expected) {
@@ -85,8 +83,7 @@ public class CustomParameterTypeTest {
         try {
             parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                     "whatever",
-                    Color.class,
-                    ".*",
+                    ".*", Color.class,
                     Color::new));
             fail("should have failed");
         } catch (CucumberExpressionException expected) {
@@ -100,9 +97,12 @@ public class CustomParameterTypeTest {
     public void conflicting_parameter_type_is_not_detected_for_regexp() {
         parameterTypeRegistry.defineParameterType(new SimpleParameterType<>(
                 "css-color",
+                singletonList("red|blue|yellow"),
                 CssColor.class,
-                "red|blue|yellow",
-                CssColor::new));
+                CssColor::new,
+                false,
+                false
+        ));
 
         assertEquals(new CssColor("blue"), new CucumberExpression("I have a {css-color} ball", parameterTypeRegistry).match("I have a blue ball").get(0).getTransformedValue());
         assertEquals(new Color("blue"), new CucumberExpression("I have a {color} ball", parameterTypeRegistry).match("I have a blue ball").get(0).getTransformedValue());

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/EnumFormatTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/EnumFormatTest.java
@@ -2,12 +2,13 @@ package io.cucumber.cucumberexpressions;
 
 import org.junit.Test;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 public class EnumFormatTest {
     @Test
     public void constructs_enum() {
-        ParameterType<Color> t = new EnumParameterType<>(Color.class);
+        ParameterType<Color> t = new EnumParameterType<>(Color.class, singletonList("\\w+"));
         assertEquals(Color.BLUE, t.transform("BLUE"));
     }
 

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/GenericParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/GenericParameterTypeTest.java
@@ -21,8 +21,8 @@ public class GenericParameterTypeTest {
 
     class ListOfStringParameterType extends AbstractParameterType<List<String>> {
         public ListOfStringParameterType() {
-            super("stringlist", new TypeReference<List<String>>() {
-            }.getType(), false, singletonList(".*"));
+            super("stringlist", singletonList(".*"), new TypeReference<List<String>>() {
+            }.getType(), true, false);
         }
 
         @Override

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeComparatorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeComparatorTest.java
@@ -35,10 +35,10 @@ public class ParameterTypeComparatorTest {
     @Test
     public void sorts_parameter_types_by_preferential_then_name() {
         SortedSet<ParameterType> set = new TreeSet<>(new ParameterTypeComparator());
-        set.add(new SimpleParameterType<>("c", C.class, true, "c", C::new));
-        set.add(new SimpleParameterType<>("a", A.class, false, "a", A::new));
-        set.add(new SimpleParameterType<>("d", D.class, false, "d", D::new));
-        set.add(new SimpleParameterType<>("b", B.class, true, "b", B::new));
+        set.add(new SimpleParameterType<>("c", "c", C.class, C::new, false, true));
+        set.add(new SimpleParameterType<>("a", "a", A.class, A::new, false, false));
+        set.add(new SimpleParameterType<>("d", "d", D.class, D::new, false, false));
+        set.add(new SimpleParameterType<>("b", "b", B.class, B::new, false, true));
 
         List<String> names = new ArrayList<>();
         for (ParameterType parameterType : set) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
@@ -42,10 +42,10 @@ public class ParameterTypeRegistryTest {
 
     @Test
     public void does_not_allow_more_than_one_preferential_parameter_type_for_each_regexp() {
-        registry.defineParameterType(new SimpleParameterType<>("name", Name.class, true, CAPITALISED_WORD, Name::new));
-        registry.defineParameterType(new SimpleParameterType<>("person", Person.class, false, CAPITALISED_WORD, Person::new));
+        registry.defineParameterType(new SimpleParameterType<>("name", CAPITALISED_WORD, Name.class, Name::new, false, true));
+        registry.defineParameterType(new SimpleParameterType<>("person", CAPITALISED_WORD, Person.class, Person::new, false, false));
         try {
-            registry.defineParameterType(new SimpleParameterType<>("place", Place.class, true, CAPITALISED_WORD, Place::new));
+            registry.defineParameterType(new SimpleParameterType<>("place", CAPITALISED_WORD, Place.class, Place::new, false, true));
             fail("Expected an exception");
         } catch (CucumberExpressionException e) {
             assertEquals("There can only be one preferential parameter type per regexp. The regexp /[A-Z]+\\w+/ is used for two preferential parameter types, {name} and {place}", e.getMessage());
@@ -54,9 +54,9 @@ public class ParameterTypeRegistryTest {
 
     @Test
     public void looks_up_preferential_parameter_type_by_regexp() {
-        SimpleParameterType<Name> name = new SimpleParameterType<>("name", Name.class, false, CAPITALISED_WORD, Name::new);
-        SimpleParameterType<Person> person = new SimpleParameterType<>("person", Person.class, true, CAPITALISED_WORD, Person::new);
-        SimpleParameterType<Place> place = new SimpleParameterType<>("place", Place.class, false, CAPITALISED_WORD, Place::new);
+        SimpleParameterType<Name> name = new SimpleParameterType<>("name", CAPITALISED_WORD, Name.class, Name::new, false, false);
+        SimpleParameterType<Person> person = new SimpleParameterType<>("person", CAPITALISED_WORD, Person.class, Person::new, false, true);
+        SimpleParameterType<Place> place = new SimpleParameterType<>("place", CAPITALISED_WORD, Place.class, Place::new, false, false);
         registry.defineParameterType(name);
         registry.defineParameterType(person);
         registry.defineParameterType(place);
@@ -65,9 +65,9 @@ public class ParameterTypeRegistryTest {
 
     @Test
     public void throws_ambiguous_exception_on_lookup_when_no_parameter_types_are_preferential() {
-        SimpleParameterType<Name> name = new SimpleParameterType<>("name", Name.class, false, CAPITALISED_WORD, Name::new);
-        SimpleParameterType<Person> person = new SimpleParameterType<>("person", Person.class, false, CAPITALISED_WORD, Person::new);
-        SimpleParameterType<Place> place = new SimpleParameterType<>("place", Place.class, false, CAPITALISED_WORD, Place::new);
+        SimpleParameterType<Name> name = new SimpleParameterType<>("name", CAPITALISED_WORD, Name.class, Name::new, true, false);
+        SimpleParameterType<Person> person = new SimpleParameterType<>("person", CAPITALISED_WORD, Person.class, Person::new, true, false);
+        SimpleParameterType<Place> place = new SimpleParameterType<>("place", CAPITALISED_WORD, Place.class, Place::new, true, false);
         registry.defineParameterType(name);
         registry.defineParameterType(person);
         registry.defineParameterType(place);

--- a/cucumber-expressions/javascript/src/cucumber_expression_generator.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression_generator.js
@@ -82,9 +82,11 @@ class CucumberExpressionGenerator {
   _createParameterTypeMatchers(text) {
     let parameterMatchers = []
     for (const parameterType of this._parameterTypeRegistry.parameterTypes) {
-      parameterMatchers = parameterMatchers.concat(
-        this._createParameterTypeMatchers2(parameterType, text)
-      )
+      if (parameterType.useForSnippets) {
+        parameterMatchers = parameterMatchers.concat(
+          this._createParameterTypeMatchers2(parameterType, text)
+        )
+      }
     }
     return parameterMatchers
   }

--- a/cucumber-expressions/javascript/src/parameter_type.js
+++ b/cucumber-expressions/javascript/src/parameter_type.js
@@ -1,23 +1,34 @@
 class ParameterType {
   static compare(pt1, pt2) {
-    if (pt1.isPreferential && !pt2.isPreferential) return -1
-    if (pt2.isPreferential && !pt1.isPreferential) return 1
+    if (pt1.preferForRegexpMatch && !pt2.preferForRegexpMatch) return -1
+    if (pt2.preferForRegexpMatch && !pt1.preferForRegexpMatch) return 1
     return pt1.name.localeCompare(pt2.name)
   }
 
   /**
    * @param name {String} the name of the type
-   * @param constructorFunction {Function} the prototype (constructor) of the type. May be null.
    * @param regexps {Array.<RegExp>,RegExp,Array.<String>,String} that matches the type
-   * @param isPreferential {boolean} true if this is a preferential type.
+   * @param constructorFunction {Function} the prototype (constructor) of the type. May be null.
    * @param transform {Function} function transforming string to another type. May be null.
+   * @param preferForRegexpMatch {boolean} true if this is a preferential type.
+   * @param useForSnippets {boolean} true if this should be used for snippets.
    */
-  constructor(name, constructorFunction, regexps, isPreferential, transform) {
+  constructor(
+    name,
+    regexps,
+    constructorFunction,
+    transform,
+    preferForRegexpMatch,
+    useForSnippets
+  ) {
+    if (useForSnippets === undefined)
+      throw new Error('useForSnippets must be specified')
     this._name = name
-    this._constructorFunction = constructorFunction
     this._regexps = stringArray(regexps)
-    this._isPreferential = isPreferential
+    this._constructorFunction = constructorFunction
     this._transform = transform
+    this._preferForRegexpMatch = preferForRegexpMatch
+    this._useForSnippets = useForSnippets
   }
 
   get name() {
@@ -32,8 +43,12 @@ class ParameterType {
     return this._regexps
   }
 
-  get isPreferential() {
-    return this._isPreferential
+  get preferForRegexpMatch() {
+    return this._preferForRegexpMatch
+  }
+
+  get useForSnippets() {
+    return this._useForSnippets
   }
 
   transform(string) {

--- a/cucumber-expressions/javascript/src/regular_expression.js
+++ b/cucumber-expressions/javascript/src/regular_expression.js
@@ -24,10 +24,11 @@ class RegularExpression {
       if (!parameterType) {
         parameterType = new ParameterType(
           '*',
-          String,
           parameterTypeRegexp,
+          String,
+          s => s,
           false,
-          s => s
+          false
         )
       }
       parameterTypes.push(parameterType)

--- a/cucumber-expressions/javascript/test/combinatorial_generated_expression_factory_test.js
+++ b/cucumber-expressions/javascript/test/combinatorial_generated_expression_factory_test.js
@@ -7,13 +7,34 @@ describe('CucumberExpressionGenerator', () => {
   it('generates multiple expressions', () => {
     const parameterTypeCombinations = [
       [
-        new ParameterType('color', null, /red|blue|yellow/, false, null),
-        new ParameterType('csscolor', null, /red|blue|yellow/, false, null),
+        new ParameterType('color', /red|blue|yellow/, null, null, false, true),
+        new ParameterType(
+          'csscolor',
+          /red|blue|yellow/,
+          null,
+          null,
+          false,
+          true
+        ),
       ],
       [
-        new ParameterType('date', null, /\d{4}-\d{2}-\d{2}/, false, null),
-        new ParameterType('datetime', null, /\d{4}-\d{2}-\d{2}/, false, null),
-        new ParameterType('timestamp', null, /\d{4}-\d{2}-\d{2}/, false, null),
+        new ParameterType('date', /\d{4}-\d{2}-\d{2}/, null, null, false, true),
+        new ParameterType(
+          'datetime',
+          /\d{4}-\d{2}-\d{2}/,
+          null,
+          null,
+          false,
+          true
+        ),
+        new ParameterType(
+          'timestamp',
+          /\d{4}-\d{2}-\d{2}/,
+          null,
+          null,
+          false,
+          true
+        ),
       ],
     ]
 

--- a/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
@@ -61,7 +61,7 @@ describe('CucumberExpressionGenerator', () => {
 
   it('generates expression for custom type', () => {
     parameterTypeRegistry.defineParameterType(
-      new ParameterType('currency', Currency, '[A-Z]{3}', false, null)
+      new ParameterType('currency', /[A-Z]{3}/, Currency, null, false, true)
     )
 
     assertExpression(
@@ -73,10 +73,10 @@ describe('CucumberExpressionGenerator', () => {
 
   it('prefers leftmost match when there is overlap', () => {
     parameterTypeRegistry.defineParameterType(
-      new ParameterType('currency', Currency, 'cd', false, null)
+      new ParameterType('currency', /cd/, Currency, null, false, true)
     )
     parameterTypeRegistry.defineParameterType(
-      new ParameterType('date', Date, 'bc', false, null)
+      new ParameterType('date', /bc/, Date, null, false, true)
     )
 
     assertExpression('a{date}defg', ['date'], 'abcdefg')
@@ -86,10 +86,10 @@ describe('CucumberExpressionGenerator', () => {
 
   it('generates all combinations of expressions when several parameter types match', () => {
     parameterTypeRegistry.defineParameterType(
-      new ParameterType('currency', null, 'x', false, null)
+      new ParameterType('currency', /x/, null, null, false, true)
     )
     parameterTypeRegistry.defineParameterType(
-      new ParameterType('date', null, 'x', false, null)
+      new ParameterType('date', /x/, null, null, false, true)
     )
 
     const generatedExpressions = generator.generateExpressions(

--- a/cucumber-expressions/javascript/test/cucumber_expression_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_test.js
@@ -14,6 +14,10 @@ describe('CucumberExpression', () => {
     /// [capture-match-arguments]
   })
 
+  it('matches word', () => {
+    assert.deepEqual(match('three {word} mice', 'three blind mice'), ['blind'])
+  })
+
   it('matches int', () => {
     assert.deepEqual(match('{int}', '22'), [22])
   })

--- a/cucumber-expressions/javascript/test/custom_parameter_type_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_type_test.js
@@ -31,10 +31,11 @@ describe('Custom parameter type', () => {
     parameterTypeRegistry.defineParameterType(
       new ParameterType(
         'color',
-        Color,
         /red|blue|yellow/,
+        Color,
+        s => new Color(s),
         false,
-        s => new Color(s)
+        true
       )
     )
     /// [add-color-parameter-type]
@@ -56,10 +57,11 @@ describe('Custom parameter type', () => {
       parameterTypeRegistry.defineParameterType(
         new ParameterType(
           'color',
-          Color,
           [/red|blue|yellow/, /(?:dark|light) (?:red|blue|yellow)/],
+          Color,
+          s => new Color(s),
           false,
-          s => new Color(s)
+          true
         )
       )
       const expression = new CucumberExpression(
@@ -74,7 +76,7 @@ describe('Custom parameter type', () => {
     it('matches parameters with custom parameter type without constructor function and transform', () => {
       parameterTypeRegistry = new ParameterTypeRegistry()
       parameterTypeRegistry.defineParameterType(
-        new ParameterType('color', null, /red|blue|yellow/, false, null)
+        new ParameterType('color', /red|blue|yellow/, null, null, false, true)
       )
       const expression = new CucumberExpression(
         'I have a {color} ball',
@@ -87,9 +89,16 @@ describe('Custom parameter type', () => {
 
     it('defers transformation until queried from argument', () => {
       parameterTypeRegistry.defineParameterType(
-        new ParameterType('throwing', () => null, /bad/, false, s => {
-          throw new Error(`Can't transform [${s}]`)
-        })
+        new ParameterType(
+          'throwing',
+          /bad/,
+          null,
+          s => {
+            throw new Error(`Can't transform [${s}]`)
+          },
+          false,
+          true
+        )
       )
 
       const expression = new CucumberExpression(
@@ -107,10 +116,11 @@ describe('Custom parameter type', () => {
             parameterTypeRegistry.defineParameterType(
               new ParameterType(
                 'color',
-                CssColor,
                 /.*/,
+                CssColor,
+                s => new CssColor(s),
                 false,
-                s => new CssColor(s)
+                true
               )
             ),
           'There is already a parameter type with name color'
@@ -123,10 +133,11 @@ describe('Custom parameter type', () => {
             parameterTypeRegistry.defineParameterType(
               new ParameterType(
                 'whatever',
-                Color,
                 /.*/,
+                Color,
+                s => new Color(s),
                 false,
-                s => new Color(s)
+                true
               )
             ),
           'There is already a parameter type with type Color'
@@ -137,10 +148,11 @@ describe('Custom parameter type', () => {
         parameterTypeRegistry.defineParameterType(
           new ParameterType(
             'css-color',
-            CssColor,
             /red|blue|yellow/,
+            CssColor,
+            s => new CssColor(s),
             false,
-            s => new CssColor(s)
+            true
           )
         )
 
@@ -173,26 +185,6 @@ describe('Custom parameter type', () => {
           'blue'
         )
       })
-
-      it('is not detected when constructor function is anonymous', () => {
-        parameterTypeRegistry = new ParameterTypeRegistry()
-        parameterTypeRegistry.defineParameterType(
-          new ParameterType('foo', () => null, /foo/, false, s => s)
-        )
-        parameterTypeRegistry.defineParameterType(
-          new ParameterType('bar', () => null, /bar/, false, s => s)
-        )
-      })
-
-      it('is not detected when constructor function is null', () => {
-        parameterTypeRegistry = new ParameterTypeRegistry()
-        parameterTypeRegistry.defineParameterType(
-          new ParameterType('foo', null, /foo/, false, s => s)
-        )
-        parameterTypeRegistry.defineParameterType(
-          new ParameterType('bar', null, /bar/, false, s => s)
-        )
-      })
     })
 
     // JavaScript-specific
@@ -202,10 +194,11 @@ describe('Custom parameter type', () => {
       parameterTypeRegistry.defineParameterType(
         new ParameterType(
           'asyncColor',
-          Color,
           /red|blue|yellow/,
+          Color,
+          async s => new Color(s),
           false,
-          async s => new Color(s)
+          true
         )
       )
       /// [add-async-parameter-type]

--- a/cucumber-expressions/javascript/test/parameter_type_registry_test.js
+++ b/cucumber-expressions/javascript/test/parameter_type_registry_test.js
@@ -21,10 +21,11 @@ describe('ParameterTypeRegistry', () => {
     registry.defineParameterType(
       new ParameterType(
         'color',
-        Color,
         /red|blue|green/,
+        Color,
+        s => new Color(s),
         true,
-        s => new Color(s)
+        true
       )
     )
     const parameterType = registry.lookupByType(Color)
@@ -33,25 +34,34 @@ describe('ParameterTypeRegistry', () => {
 
   it('does not allow more than one preferential parameter type for each regexp', () => {
     registry.defineParameterType(
-      new ParameterType('name', Name, CAPITALISED_WORD, true, s => new Name(s))
+      new ParameterType(
+        'name',
+        CAPITALISED_WORD,
+        Name,
+        s => new Name(s),
+        true,
+        true
+      )
     )
     registry.defineParameterType(
       new ParameterType(
         'person',
-        Person,
         CAPITALISED_WORD,
+        Person,
+        s => new Person(s),
         false,
-        s => new Person(s)
+        true
       )
     )
     try {
       registry.defineParameterType(
         new ParameterType(
           'place',
-          Place,
           CAPITALISED_WORD,
+          Place,
+          s => new Place(s),
           true,
-          s => new Place(s)
+          true
         )
       )
       throw new Error('Should have failed')
@@ -64,9 +74,23 @@ describe('ParameterTypeRegistry', () => {
   })
 
   it('looks up preferential parameter type by regexp', () => {
-    const name = new ParameterType('name', null, /[A-Z]+\w+/, false, null)
-    const person = new ParameterType('person', null, /[A-Z]+\w+/, true, null)
-    const place = new ParameterType('place', null, /[A-Z]+\w+/, false, null)
+    const name = new ParameterType('name', /[A-Z]+\w+/, null, null, false, true)
+    const person = new ParameterType(
+      'person',
+      /[A-Z]+\w+/,
+      null,
+      null,
+      true,
+      true
+    )
+    const place = new ParameterType(
+      'place',
+      /[A-Z]+\w+/,
+      null,
+      null,
+      false,
+      true
+    )
 
     registry.defineParameterType(name)
     registry.defineParameterType(person)

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
@@ -39,7 +39,7 @@ module Cucumber
             # might be duplicates is that some parameter types have more than one regexp,
             # which means multiple ParameterTypeMatcher objects will have a reference to the
             # same ParameterType.
-            # We're sorting the list so preferential parameter types are listed first.
+            # We're sorting the list so prefer_for_regexp_match parameter types are listed first.
             # Users are most likely to want these, so they should be listed at the top.
             parameter_types = []
             best_parameter_type_matchers.each do |parameter_type_matcher|
@@ -77,7 +77,9 @@ module Cucumber
       def create_parameter_type_matchers(text)
         parameter_matchers = []
         @parameter_type_registry.parameter_types.each do |parameter_type|
-          parameter_matchers += create_parameter_type_matchers2(parameter_type, text)
+          if parameter_type.use_for_snippets?
+            parameter_matchers += create_parameter_type_matchers2(parameter_type, text)
+          end
         end
         parameter_matchers
       end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
@@ -21,7 +21,7 @@ I couldn't decide which one to use. You have two options:
 1) Use a Cucumber Expression instead of a Regular Expression. Try one of these:
    #{expressions(generated_expressions)}
 
-2) Make one of the parameter types preferential and continue to use a Regular Expression.
+2) Make one of the parameter types prefer_for_regexp_match and continue to use a Regular Expression.
 
         EOM
       end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -3,25 +3,31 @@ module Cucumber
     class ParameterType
       attr_reader :name, :type, :regexps
 
-      def preferential?
-        @preferential
+      def prefer_for_regexp_match?
+        @prefer_for_regexp_match
+      end
+
+      def use_for_snippets?
+        @use_for_snippets
       end
 
       # Create a new Parameter
       #
       # @param name the name of the parameter type
       # @param regexp [Array] list of regexps for capture groups. A single regexp can also be used
-      # @param preferential true if this should be preferred over similar types
+      # @param type the return type of the transformed
       # @param transformer lambda that transforms a String to (possibly) another type
+      # @param prefer_for_regexp_match true if this should be preferred over similar types
       #
-      def initialize(name, type, regexp, preferential, transformer)
+      def initialize(name, regexp, type, transformer, prefer_for_regexp_match, use_for_snippets)
         raise "name can't be nil" if name.nil?
-        raise "type can't be nil" if type.nil?
         raise "regexp can't be nil" if regexp.nil?
-        raise "preferential can't be nil" if preferential.nil?
+        raise "type can't be nil" if type.nil?
         raise "transformer can't be nil" if transformer.nil?
+        raise "prefer_for_regexp_match can't be nil" if prefer_for_regexp_match.nil?
+        raise "use_for_snippets can't be nil" if use_for_snippets.nil?
 
-        @name, @type, @preferential, @transformer = name, type, preferential, transformer
+        @name, @type, @transformer, @prefer_for_regexp_match, @use_for_snippets = name, type, transformer, prefer_for_regexp_match, use_for_snippets
         @regexps = string_array(regexp)
       end
 
@@ -30,8 +36,8 @@ module Cucumber
       end
 
       def <=>(other)
-        return -1 if preferential? && !other.preferential?
-        return 1  if other.preferential? && !preferential?
+        return -1 if prefer_for_regexp_match? && !other.prefer_for_regexp_match?
+        return 1  if other.prefer_for_regexp_match? && !prefer_for_regexp_match?
         name <=> other.name
       end
 

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -27,10 +27,11 @@ module Cucumber
           if parameter_type.nil?
             parameter_type = ParameterType.new(
                 '*',
-                String,
                 parameter_type_regexp,
+                String,
+                lambda {|s| s},
                 false,
-                lambda {|s| s}
+                false
             )
           end
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/combinatorial_generated_expression_factory_test.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/combinatorial_generated_expression_factory_test.rb
@@ -14,13 +14,13 @@ module Cucumber
       it 'generates multiple expressions' do
         parameter_type_combinations = [
           [
-            ParameterType.new('color', Color, /red|blue|yellow/, false, lambda {|s| Color.new}),
-            ParameterType.new('csscolor', CssColor, /red|blue|yellow/, false, lambda {|s| CssColor.new})
+            ParameterType.new('color', /red|blue|yellow/, Color, lambda {|s| Color.new}, false, true),
+            ParameterType.new('csscolor', /red|blue|yellow/, CssColor, lambda {|s| CssColor.new}, false, true)
           ],
           [
-            ParameterType.new('date', Date, /\d{4}-\d{2}-\d{2}/, false, lambda {|s| Date.new}),
-            ParameterType.new('datetime', DateTime, /\d{4}-\d{2}-\d{2}/, false, lambda {|s| DateTime.new}),
-            ParameterType.new('timestamp', Timestamp, /\d{4}-\d{2}-\d{2}/, false, lambda {|s| Timestamp.new})
+            ParameterType.new('date', /\d{4}-\d{2}-\d{2}/, Date, lambda {|s| Date.new}, false, true),
+            ParameterType.new('datetime', /\d{4}-\d{2}-\d{2}/, DateTime, lambda {|s| DateTime.new}, false, true),
+            ParameterType.new('timestamp', /\d{4}-\d{2}-\d{2}/, Timestamp, lambda {|s| Timestamp.new}, false, true)
           ]
         ]
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
@@ -49,10 +49,11 @@ module Cucumber
       it "numbers only second argument when type is not reserved keyword" do
         @parameter_type_registry.define_parameter_type(ParameterType.new(
           'currency',
-          Currency,
           '[A-Z]{3}',
+          Currency,
+          lambda {|s| Currency.new(s)},
           true,
-          lambda {|s| Currency.new(s)}
+          true
         ))
 
         assert_expression(

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -15,6 +15,10 @@ module Cucumber
         ### [capture-match-arguments]
       end
 
+      it "matches word" do
+        expect( match("three {word} mice", "three blind mice") ).to eq(['blind'])
+      end
+
       it "matches int" do
         expect( match("{int}", "22") ).to eq([22])
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
@@ -36,10 +36,11 @@ module Cucumber
         ### [add-color-parameter-type]
         parameter_registry.define_parameter_type(ParameterType.new(
           'color',
-          Color,
           /red|blue|yellow/,
+          Color,
+          lambda { |s| Color.new(s) },
           false,
-          lambda { |s| Color.new(s) }
+          true
         ))
         ### [add-color-parameter-type]
         @parameter_type_registry = parameter_registry
@@ -56,10 +57,11 @@ module Cucumber
           parameter_type_registry = ParameterTypeRegistry.new
           parameter_type_registry.define_parameter_type(ParameterType.new(
               'color',
-              Color,
               [/red|blue|yellow/, /(?:dark|light) (?:red|blue|yellow)/],
+              Color,
+              lambda { |s| Color.new(s) },
               false,
-              lambda { |s| Color.new(s) }
+              true
           ))
           expression = CucumberExpression.new("I have a {color} ball", parameter_type_registry)
           transformed_argument_value = expression.match("I have a dark red ball")[0].transformed_value
@@ -69,10 +71,11 @@ module Cucumber
         it "defers transformation until queried from argument" do
           @parameter_type_registry.define_parameter_type(ParameterType.new(
               'throwing',
-              String,
               /bad/,
+              CssColor,
+              lambda { |s| raise "Can't transform [#{s}]" },
               false,
-              lambda { |s| raise "Can't transform [#{s}]" }
+              true
           ))
           expression = CucumberExpression.new("I have a {throwing} parameter", @parameter_type_registry)
           args = expression.match("I have a bad parameter")
@@ -84,10 +87,11 @@ module Cucumber
             expect {
               @parameter_type_registry.define_parameter_type(ParameterType.new(
                   'color',
-                  CssColor,
                   /.*/,
+                  CssColor,
+                  lambda { |s| CssColor.new(s) },
                   false,
-                  lambda { |s| CssColor.new(s) }
+                  true
               ))
             }.to raise_error("There is already a parameter with name color")
           end
@@ -96,10 +100,11 @@ module Cucumber
             expect {
               @parameter_type_registry.define_parameter_type(ParameterType.new(
                   'whatever',
-                  Color,
                   /.*/,
+                  Color,
+                  lambda { |s| Color.new(s) },
                   false,
-                  lambda { |s| Color.new(s) }
+                  true
               ))
             }.to raise_error("There is already a parameter with type Cucumber::CucumberExpressions::Color")
           end
@@ -107,10 +112,11 @@ module Cucumber
           it "is not detected for regexp" do
             @parameter_type_registry.define_parameter_type(ParameterType.new(
                 'css-color',
-                CssColor,
                 /red|blue|yellow/,
+                CssColor,
+                lambda { |s| CssColor.new(s) },
                 false,
-                lambda { |s| CssColor.new(s) }
+                true
             ))
 
             css_color = CucumberExpression.new("I have a {css-color} ball",@parameter_type_registry)

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_registry_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_registry_spec.rb
@@ -26,21 +26,21 @@ module Cucumber
         expect(parameter_type.transform("22")).to eq(22)
       end
 
-      it 'does not allow more than one preferential parameter type for each regexp' do
-        @registry.define_parameter_type(ParameterType.new("name", Name, CAPITALISED_WORD, true, lambda {|s| Name.new}))
-        @registry.define_parameter_type(ParameterType.new("person", Person, CAPITALISED_WORD, false, lambda {|s| Person.new}))
+      it 'does not allow more than one prefer_for_regexp_match parameter type for each regexp' do
+        @registry.define_parameter_type(ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, true, true))
+        @registry.define_parameter_type(ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, false, true))
         expect do
-          @registry.define_parameter_type(ParameterType.new("place", Place, CAPITALISED_WORD, true, lambda {|s| Place.new}))
+          @registry.define_parameter_type(ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, true, true))
         end.to raise_error(
                    CucumberExpressionError,
-                   "There can only be one preferential parameter type per regexp. The regexp /[A-Z]+\\w+/ is used for two preferential parameter types, {name} and {place}"
+                   "There can only be one prefer_for_regexp_match parameter type per regexp. The regexp /[A-Z]+\\w+/ is used for two prefer_for_regexp_match parameter types, {name} and {place}"
                )
       end
 
-      it 'looks up preferential parameter type by regexp' do
-        name = ParameterType.new("name", Name, CAPITALISED_WORD, false, lambda {|s| Name.new})
-        person = ParameterType.new("person", Person, CAPITALISED_WORD, true, lambda {|s| Person.new})
-        place = ParameterType.new("place", Place, CAPITALISED_WORD, false, lambda {|s| Place.new})
+      it 'looks up prefer_for_regexp_match parameter type by regexp' do
+        name = ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, false, true)
+        person = ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, true, true)
+        place = ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, false, true)
 
         @registry.define_parameter_type(name)
         @registry.define_parameter_type(person)
@@ -49,10 +49,10 @@ module Cucumber
         expect(@registry.lookup_by_regexp(CAPITALISED_WORD.source, /([A-Z]+\w+) and ([A-Z]+\w+)/, "Lisa and Bob")).to eq(person)
       end
 
-      it 'throws ambiguous exception when no parameter types are preferential' do
-        name = ParameterType.new("name", Name, CAPITALISED_WORD, false, lambda {|s| Name.new})
-        person = ParameterType.new("person", Person, CAPITALISED_WORD, false, lambda {|s| Person.new})
-        place = ParameterType.new("place", Place, CAPITALISED_WORD, false, lambda {|s| Place.new})
+      it 'throws ambiguous exception when no parameter types are prefer_for_regexp_match' do
+        name = ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, false, true)
+        person = ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, false, true)
+        place = ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, false, true)
 
         @registry.define_parameter_type(name)
         @registry.define_parameter_type(person)
@@ -81,7 +81,7 @@ module Cucumber
                        "   {place} and {person}\n" +
                        "   {place} and {place}\n" +
                        "\n" +
-                       "2) Make one of the parameter types preferential and continue to use a Regular Expression.\n" +
+                       "2) Make one of the parameter types prefer_for_regexp_match and continue to use a Regular Expression.\n" +
                        "\n"
                )
       end


### PR DESCRIPTION
## Summary

Add a built-in `{word}` parameter type

Now that Cucumber Expressions will throw an exception for undefined types, we need to provide common defaults. a `{word}` uses `\w+` as a regexp.

This fixes #191, although a little differently than described in that issue.