### PR TITLE
[docs] Spell out JavaScript, make PHP (Behat) visible

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -7,7 +7,8 @@
   * [Pick your Flavour](./docs/404.md)
     * [Ruby](docs/installation.md#ruby)
     * [Java](docs/installation.md#java)
-    * [Javascript](docs/installation.md#javascript)
+    * [JavaScript](docs/installation.md#javascript)
+    * [PHP](docs/installation.md#php)
     * [Unofficial Cucumbers](./docs/404.md)
 * [10 minute tutorial](docs/10-minute-tutorial.md)
 


### PR DESCRIPTION

## Summary

This PR edits the docs.cucumber.io site's _menu_ on the left-hand side of the screen to **visibly include PHP** and spell JavaScript with that casing.
