### PR TITLE
gherkin-lint: Fix link in README.md

### DIFF
--- a/gherkin-lint/README.md
+++ b/gherkin-lint/README.md
@@ -4,4 +4,4 @@ Gherkin-Lint is a tool that finds common problems in Gherkin documents.
 
 It is not ready for use yet. You can contribute or follow the development
 by familiarising yourself with the open
-[Gherkin-Lint GitHub issues](https://github.com/cucumber/cucumber/labels/gherkin-lint).
+[Gherkin-Lint GitHub issues](https://github.com/cucumber/cucumber/labels/library%3A%20gherkin-lint).


### PR DESCRIPTION
## Summary

Fixes a link to the Github Issues filter that appears in the README.md.

## Details

The label name has apparently been changed and the link references the old label name.

## Motivation and Context

I followed [this link](https://docs.cucumber.io/gherkin-lint/#) and it took me to a list with no issues in it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.