### PR TITLE
[docs] Gitbook link and article on cucumber-rails

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -106,7 +106,7 @@
   * [Gherkin-Lint](gherkin-lint/README.md)
   * [Cucumber-React](cucumber-react/README.md)
   * [CLI automation - Aruba](./docs/404.md)
-  * [Ruby on Rails](./docs/404.md)
+  * [Ruby on Rails](./docs/extensions/cucumber-rails.md)
   * [Spring Framework](./docs/404.md)
   * [PicoContainer](./docs/404.md)
 * [3rd Party Extensions](./docs/404.md)

--- a/docs/extensions/cucumber-rails.md
+++ b/docs/extensions/cucumber-rails.md
@@ -4,15 +4,22 @@
 brings Ruby on Rails Generators for Cucumber with special support for Capybara
 and DatabaseCleaner.
 
+## Installing
+
 The `cucumber:install` generator sets up Cucumber in your Rails project. It
 generates the necessary files in the `features/` directory. After
 running this generator you will also get a new rake task called `cucumber`.
 
 For more details, see `rails generate cucumber:install --help`.
 
+## Usage
+
 By default, `cucumber-rails` runs `DatabaseCleaner.start` and
 `DatabaseCleaner.clean` before and after your Cucumber scenarios. This default
-behavior can be disabled. See the README for details.
+behavior can be disabled. See the
+[cucumber-rails README](https://github.com/cucumber/cucumber-rails) for details.
+
+## Resources
 
 To learn more of the tools being integrated and assisted by `cucumber-rails`,
 see the READMEs of

--- a/docs/extensions/cucumber-rails.md
+++ b/docs/extensions/cucumber-rails.md
@@ -1,0 +1,20 @@
+# cucumber-rails
+
+[cucumber-rails](https://github.com/cucumber/cucumber-rails) is a RubyGem which
+brings Ruby on Rails Generators for Cucumber with special support for Capybara
+and DatabaseCleaner.
+
+The `cucumber:install` generator sets up Cucumber in your Rails project. It
+generates the necessary files in the `features/` directory. After
+running this generator you will also get a new rake task called `cucumber`.
+
+For more details, see `rails generate cucumber:install --help`.
+
+By default, `cucumber-rails` runs `DatabaseCleaner.start` and
+`DatabaseCleaner.clean` before and after your Cucumber scenarios. This default
+behavior can be disabled. See the README for details.
+
+To learn more of the tools being integrated and assisted by `cucumber-rails`,
+see the READMEs of
+[DatabaseCleaner](https://github.com/DatabaseCleaner/database_cleaner) and
+[Capybara](https://github.com/teamcapybara/capybara).


### PR DESCRIPTION
## Summary

This PR adds a cucumber-rails article to the Gitbook.

## Details

Adding an article on cucumber-rails, I created a directory `docs/extensions/` for it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I ran the `gitbook serve` on my machine and how pretty it was.

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

![screenshot 2017-07-10 18 02 59](https://user-images.githubusercontent.com/211/28027646-13f385d0-659a-11e7-92e0-7d7a226fa478.png)
