### PR TITLE
[docs] Add Slack link to Gitbook docs on contributions

### DIFF
--- a/docs/contributing-to-documentation.md
+++ b/docs/contributing-to-documentation.md
@@ -24,7 +24,7 @@ It's great to get feedback on your writing. Start out with small changes, then w
 
 Discussions about docs that are already published can be done in [GitBook comments](https://www.gitbook.com/blog/features/discussions) - check the [discussion page](https://www.gitbook.com/book/cucumber/cucumber/discussions) regularly to see if there are open discussions.
 
-Sometimes it might be quicker to hop into the [gitter chat room](https://gitter.im/cucumber/docs) to discuss in real time, if the people you want to talk to are online.
+Sometimes it might be quicker to hop into the Cucumber [Slack](https://cucumber.io/support#slack) or [Gitter](https://cucumber.io/support#gitter) chat rooms to discuss in real time, if the people you want to talk to are online. 
 
 And finally - there is always the friendly [Cucumber Google group](mailto:cukes-devs@googlegroups.com)
 
@@ -55,7 +55,7 @@ you want to contribute you should sign up for a GitBook account and link your Gi
 The documentation is written in [Markdown](http://toolchain.gitbook.com/syntax/markdown.html)
 (simple markup) and [AsciiDoc](http://toolchain.gitbook.com/syntax/asciidoc.html) (richer markup).
 
-The documentation is stored on [GitHub](https://github.com/cucumber/cucumber)
+The documentation is stored in [the cucumber/cucumber GitHub repository](https://github.com/cucumber/cucumber).
 
 Install the [GitBook command-line](https://toolchain.gitbook.com/setup.html) tool:
 


### PR DESCRIPTION
This PR adds a link to Slack to the docs on how to contribute to documentation.