### PR TITLE
Backward support for escaped parens in steps

### DIFF
--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -5,7 +5,7 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     class RegularExpression
-      CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/
+      CAPTURE_GROUP_PATTERN = /(?<!\\)\((?!\?:)([^(]+)\)/
 
       def initialize(expression_regexp, parameter_type_registry)
         @expression_regexp = expression_regexp

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -46,6 +46,10 @@ module Cucumber
           "I can cancel the 1st slide upload")
         ).to eq(["I", "can", 1, "slide"])
       end
+      
+      it "ignores escaped 2.x parenthesis" do
+        expect( match(/Across the line\(s\)/, 'Across the line\(s\)') ).to be_nil
+      end
 
       it "exposes source and regexp" do
         regexp = /I have (\d+) cukes? in my (\+) now/

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -48,7 +48,7 @@ module Cucumber
       end
       
       it "ignores escaped 2.x parenthesis" do
-        expect( match(/Across the line\(s\)/, 'Across the line\(s\)') ).to be_nil
+        expect( match(/Across the line\(s\)/, 'Across the line(s)') ).to eq([])
       end
 
       it "exposes source and regexp" do


### PR DESCRIPTION
## Summary

When creating step def snippets from features that have parenthesis, cucumber can sometimes escape them with backslashes and this breaks the current 3.0 handling of step defs.

## Details

* Remake of [pr2](https://github.com/cucumber/cucumber-expressions-ruby/pull/2) from the expressions repo.

## Data from original PR

### Bugfix

* When generating step def snippets, Cucumber escapes parens with backslashes and cucumber-expressions-ruby was catching erroneously on that.
* Error: `Expression /^Across the line\(s\)$/ has 0 capture groups ([]), but there were 1 parameter types (["s\\"]) (Cucumber::CucumberExpressions::CucumberExpressionError)`
* [Full stack error here](https://gist.github.com/jaysonesmith/3b17b3dd830cd4b83157a865e82efadf)
* I added a test to the `regular_expression_spec.rb` file and all tests pass successfully. Can someone let me know if my test is configured correctly and in the right place, please?

### Example from my own project
* Step of: `Given I want to request "<caption_count>" caption(s)` in my feature
* Generated snippet from 2.4.0: `Given(/^I want to request "([^"]*)" caption\(s\)$/) do`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
