### PR TITLE
Cucumber expressions fix regexp parsing

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 
+* Support escaped parenthesis in Regular expressions ([#254](https://github.com/cucumber/cucumber/pull/254) by [jaysonesmith], [aslakhellesoy])
+
 ## [4.0.3] - 2017-07-24
 
 ### Fixed
@@ -226,4 +228,5 @@ N/A
 [brasmusson]:       https://github.com/brasmusson
 [charlierudolph]:   https://github.com/charlierudolph
 [gpichot]:          https://github.com/charlierudolph
+[jaysonesmith]:     https://github.com/jaysonesmith
 [kAworu]:           https://github.com/kAworu

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
@@ -8,6 +8,7 @@ import java.util.regex.Matcher;
 class GroupBuilder {
     private List<GroupBuilder> groupBuilders = new ArrayList<>();
     private boolean capturing = true;
+    private String source;
 
     void add(GroupBuilder groupBuilder) {
         groupBuilders.add(groupBuilder);
@@ -34,5 +35,17 @@ class GroupBuilder {
         for (GroupBuilder child : groupBuilders) {
             groupBuilder.add(child);
         }
+    }
+
+    public List<GroupBuilder> getChildren() {
+        return groupBuilders;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    void setSource(String source) {
+        this.source = source;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
@@ -21,19 +21,25 @@ class TreeRegexp {
 
     TreeRegexp(Pattern pattern) {
         this.pattern = pattern;
-        char[] chars = pattern.pattern().toCharArray();
+        String source = pattern.pattern();
+        char[] chars = source.toCharArray();
         Deque<GroupBuilder> stack = new ArrayDeque<>();
+        Deque<Integer> groupStartStack = new ArrayDeque<>();
 
         stack.push(new GroupBuilder());
         char last = 0;
         boolean nonCapturingMaybe = false;
+        int n = 1;
         for (char c : chars) {
             if (c == '(' && last != '\\') {
                 stack.push(new GroupBuilder());
+                groupStartStack.push(n);
                 nonCapturingMaybe = false;
             } else if (c == ')' && last != '\\') {
                 GroupBuilder gb = stack.pop();
+                int groupStart = groupStartStack.pop();
                 if (gb.isCapturing()) {
+                    gb.setSource(source.substring(groupStart, n-1));
                     stack.peek().add(gb);
                 } else {
                     gb.moveChildrenTo(stack.peek());
@@ -46,6 +52,7 @@ class TreeRegexp {
                 nonCapturingMaybe = false;
             }
             last = c;
+            n++;
         }
         groupBuilder = stack.pop();
     }
@@ -60,4 +67,7 @@ class TreeRegexp {
         return groupBuilder.build(matcher, IntStream.range(0, matcher.groupCount() + 1).iterator());
     }
 
+    public GroupBuilder getGroupBuilder() {
+        return groupBuilder;
+    }
 }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.compile;
 import static org.junit.Assert.assertEquals;
@@ -50,6 +51,14 @@ public class RegularExpressionTest {
         String step = "I can cancel the 1st slide upload";
         List<?> match = match(compile(expr), step);
         assertEquals(asList("I", "can", 1, "slide"), match);
+    }
+
+    @Test
+    public void works_with_escaped_parenthesis() {
+        String expr = "Across the line\\(s\\)";
+        String step = "Across the line(s)";
+        List<?> match = match(compile(expr), step);
+        assertEquals(emptyList (), match);
     }
 
     @Test

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
@@ -2,10 +2,19 @@ package io.cucumber.cucumberexpressions;
 
 import org.junit.Test;
 
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 
 public class TreeRegexpTest {
+    @Test
+    public void exposes_group_source() {
+        TreeRegexp tr = new TreeRegexp("(a(?:b)?)(c)");
+        assertEquals(asList("a(?:b)?", "c"), tr.getGroupBuilder().getChildren().stream().map(gb -> gb.getSource()).collect(Collectors.toList()));
+    }
+
     @Test
     public void builds_tree() {
         TreeRegexp tr = new TreeRegexp("(a(b(c))(d))");

--- a/cucumber-expressions/javascript/src/group_builder.js
+++ b/cucumber-expressions/javascript/src/group_builder.js
@@ -31,6 +31,10 @@ class GroupBuilder {
     return this._capturing
   }
 
+  get children() {
+    return this._groupBuilders
+  }
+
   moveChildrenTo(groupBuilder) {
     this._groupBuilders.forEach(child => groupBuilder.add(child))
   }

--- a/cucumber-expressions/javascript/src/regular_expression.js
+++ b/cucumber-expressions/javascript/src/regular_expression.js
@@ -10,34 +10,27 @@ class RegularExpression {
   }
 
   match(text) {
-    const parameterTypes = []
+    const parameterTypes = this._treeRegexp.groupBuilder.children.map(
+      groupBuilder => {
+        const parameterTypeRegexp = groupBuilder.source
 
-    const CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/g
-
-    let match
-    while (
-      (match = CAPTURE_GROUP_PATTERN.exec(this._treeRegexp.regexp.source)) !==
-      null
-    ) {
-      const parameterTypeRegexp = match[1]
-
-      let parameterType = this._parameterTypeRegistry.lookupByRegexp(
-        parameterTypeRegexp,
-        this._treeRegexp,
-        text
-      )
-      if (!parameterType) {
-        parameterType = new ParameterType(
-          parameterTypeRegexp,
-          parameterTypeRegexp,
-          String,
-          s => s,
-          false,
-          false
+        return (
+          this._parameterTypeRegistry.lookupByRegexp(
+            parameterTypeRegexp,
+            this._treeRegexp,
+            text
+          ) ||
+          new ParameterType(
+            parameterTypeRegexp,
+            parameterTypeRegexp,
+            String,
+            s => s,
+            false,
+            false
+          )
         )
       }
-      parameterTypes.push(parameterType)
-    }
+    )
 
     return Argument.build(this._treeRegexp, text, parameterTypes)
   }

--- a/cucumber-expressions/javascript/src/tree_regexp.js
+++ b/cucumber-expressions/javascript/src/tree_regexp.js
@@ -7,15 +7,20 @@ class TreeRegexp {
     this._regex = new Regex(this._re)
 
     const stack = [new GroupBuilder()]
+    const groupStartStack = []
+
     let last = null
     let nonCapturingMaybe = false
-    this._re.source.split('').forEach(c => {
+    this._re.source.split('').forEach((c, n) => {
       if (c === '(' && last !== '\\') {
         stack.push(new GroupBuilder())
+        groupStartStack.push(n + 1)
         nonCapturingMaybe = false
       } else if (c === ')' && last !== '\\') {
         const gb = stack.pop()
+        const groupStart = groupStartStack.pop()
         if (gb.capturing) {
+          gb.source = this._re.source.substring(groupStart, n)
           stack[stack.length - 1].add(gb)
         } else {
           gb.moveChildrenTo(stack[stack.length - 1])
@@ -34,6 +39,10 @@ class TreeRegexp {
 
   get regexp() {
     return this._re
+  }
+
+  get groupBuilder() {
+    return this._groupBuilder
   }
 
   match(s) {

--- a/cucumber-expressions/javascript/test/regular_expression_test.js
+++ b/cucumber-expressions/javascript/test/regular_expression_test.js
@@ -50,6 +50,10 @@ describe('RegularExpression', () => {
     )
   })
 
+  it('works with escaped parenthesis', () => {
+    assert.deepEqual(match(/Across the line\(s\)/, 'Across the line(s)'), [])
+  })
+
   it('exposes regexp and source', () => {
     const regexp = /I have (\d+) cukes? in my (.+) now/
     let expression = new RegularExpression(regexp, new ParameterTypeRegistry())

--- a/cucumber-expressions/javascript/test/tree_regexp_test.js
+++ b/cucumber-expressions/javascript/test/tree_regexp_test.js
@@ -3,6 +3,13 @@ const assert = require('assert')
 const TreeRegexp = require('../src/tree_regexp')
 
 describe('TreeRegexp', () => {
+  it('exposes group source', () => {
+    const tr = new TreeRegexp(/(a(?:b)?)(c)/)
+    assert.deepEqual(
+      tr.groupBuilder.children.map(gb => gb.source)[('a(?:b)?', 'c')]
+    )
+  })
+
   it('builds tree', () => {
     const tr = new TreeRegexp(/(a(?:b)?)(c)/)
     const group = tr.match('ac')

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group_builder.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group_builder.rb
@@ -3,6 +3,8 @@ require 'cucumber/cucumber_expressions/group'
 module Cucumber
   module CucumberExpressions
     class GroupBuilder
+      attr_accessor :source
+
       def initialize
         @group_builders = []
         @capturing = true
@@ -30,6 +32,10 @@ module Cucumber
         @group_builders.each do |child|
           group_builder.add(child)
         end
+      end
+
+      def children
+        @group_builders
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -5,7 +5,7 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     class RegularExpression
-      CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/
+      CAPTURE_GROUP_PATTERN = /(?<!\\)\((?!\?:)([^(]+)\)/
 
       def initialize(expression_regexp, parameter_type_registry)
         @expression_regexp = expression_regexp

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -5,7 +5,6 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     class RegularExpression
-      CAPTURE_GROUP_PATTERN = /(?<!\\)\((?!\?:)([^(]+)\)/
 
       def initialize(expression_regexp, parameter_type_registry)
         @expression_regexp = expression_regexp
@@ -14,30 +13,20 @@ module Cucumber
       end
 
       def match(text)
-        parameter_types = []
-
-        match_offset = 0
-
-        loop do
-          match = CAPTURE_GROUP_PATTERN.match(@expression_regexp.source, match_offset)
-          break if match.nil?
-          match_offset = match.offset(0)[1]
-
-          parameter_type_regexp = match[1]
-
-          parameter_type = @parameter_type_registry.lookup_by_regexp(parameter_type_regexp, @expression_regexp, text)
-          if parameter_type.nil?
-            parameter_type = ParameterType.new(
-                parameter_type_regexp,
-                parameter_type_regexp,
-                String,
-                lambda {|s| s},
-                false,
-                false
-            )
-          end
-
-          parameter_types.push(parameter_type)
+        parameter_types = @tree_regexp.group_builder.children.map do |group_builder|
+          parameter_type_regexp = group_builder.source
+          @parameter_type_registry.lookup_by_regexp(
+            parameter_type_regexp,
+            @expression_regexp,
+            text
+          ) || ParameterType.new(
+            parameter_type_regexp,
+            parameter_type_regexp,
+            String,
+            lambda {|s| s},
+            false,
+            false
+          )
         end
 
         Argument.build(@tree_regexp, text, parameter_types)

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -46,6 +46,10 @@ module Cucumber
           "I can cancel the 1st slide upload")
         ).to eq(["I", "can", 1, "slide"])
       end
+      
+      it "ignores escaped 2.x parenthesis" do
+        expect( match(/Across the line\(s\)/, 'Across the line\(s\)') ).to be_nil
+      end
 
       it "exposes source and regexp" do
         regexp = /I have (\d+) cukes? in my (\+) now/

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -47,7 +47,7 @@ module Cucumber
         ).to eq(["I", "can", 1, "slide"])
       end
 
-      it "ignores escaped 2.x parenthesis" do
+      it "works with escaped parenthesis" do
         expect( match(/Across the line\(s\)/, 'Across the line(s)') ).to eq([])
       end
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -46,9 +46,9 @@ module Cucumber
           "I can cancel the 1st slide upload")
         ).to eq(["I", "can", 1, "slide"])
       end
-      
+
       it "ignores escaped 2.x parenthesis" do
-        expect( match(/Across the line\(s\)/, 'Across the line\(s\)') ).to be_nil
+        expect( match(/Across the line\(s\)/, 'Across the line(s)') ).to eq([])
       end
 
       it "exposes source and regexp" do

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
@@ -3,6 +3,11 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     describe TreeRegexp do
+      it 'exposes group source' do
+        tr = TreeRegexp.new(/(a(?:b)?)(c)/)
+        expect(tr.group_builder.children.map{|gb| gb.source}).to eq(['a(?:b)?', 'c'])
+      end
+
       it 'builds tree' do
         tr = TreeRegexp.new(/(a(?:b)?)(c)/)
         group = tr.match('ac')


### PR DESCRIPTION
## Summary

Fix how regexps are parsed

## Details

See #253 for a description of the problem. This is an alternative implementation which leverages the existing regexp parser in `TreeRegexp`, which means consistency and reliability (compared to parsing regexp with regexp).

## How Has This Been Tested?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
