### PR TITLE
cucumber-expressions: Update CI matrix

### DIFF
--- a/cucumber-expressions/ruby/.travis.yml
+++ b/cucumber-expressions/ruby/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - jruby-9.1.7.0
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
+  - jruby-9.1.12.0
 
 notifications:
   webhooks:


### PR DESCRIPTION
## Summary

This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rbenv/ruby-build/tree/master/share/ruby-build

## Details

  - See https://github.com/cucumber/cucumber-expressions-ruby/pull/1/

