### PR TITLE
tag-expressions: Update CI matrix

### DIFF
--- a/tag-expressions/ruby/.travis.yml
+++ b/tag-expressions/ruby/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - jruby-9.1.7.0
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
+  - jruby-9.1.12.0
 
 notifications:
   webhooks:


### PR DESCRIPTION
This change updates the Rubies to latest generally available versions.

## Summary

This does the same as #256 does.

