### PR TITLE
[docs] Add note and link to docs.cucumber.io

### DIFF
--- a/docs/contributing-to-documentation.md
+++ b/docs/contributing-to-documentation.md
@@ -2,6 +2,9 @@
 
 The Cucumber documentation is open source and anyone is welcome to contribute.
 
+> **Note:** Do not update documentation in *this* repo. We are busy adding old documentation to a new repository [docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io) to replace the current documentation on cucumber.io.
+Please make **ALL** contributions to the documentation [here](https://github.com/cucumber/docs.cucumber.io).
+
 ## Process
 
 First-time **contributors** will have to send a pull request.


### PR DESCRIPTION
Summary: 
All documentation updates should be in the new docs.cucumber.io repository

Details: 
This PR is part of https://github.com/cucumber/docs.cucumber.io/issues/15


