### PR TITLE
documentation: Fix typo

### DIFF
--- a/docs/living-documentation.md
+++ b/docs/living-documentation.md
@@ -1,4 +1,4 @@
-##Living Documnetation
+##Living Documentation
 
 Cucumber tests share the benefit of traditional specification documents in that they can be written and read by business stakeholders, but they have a distinct advantage in that you can give them to a computer at any time to tell you how accurate they are. In practice, this means that your documentation, rather than being something that's written once and then gradually goes out of date, becomes a [living document](https://en.wikipedia.org/wiki/Living_document) that reflects the true state of the project.
 


### PR DESCRIPTION
## Summary

Fixed a typo on the documentation section _Living Documentation_.

## Details

It used to read _Living Documnetation_, not it is _Living Documentation_.

## How Has This Been Tested?

I don't believe this needs *testing*, it's just a change on an .md file.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
