### PR TITLE
Gherkin (i18n): add additional Dutch keywords for Given.

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -2114,7 +2114,9 @@
     ],
     "given": [
       "* ",
+      "Gegeven dat ",
       "Gegeven ",
+      "Stel dat "
       "Stel "
     ],
     "name": "Dutch",


### PR DESCRIPTION
Although it is technically possible in Dutch to write sentences that start with `Gegeven` and aren't immediately followed by `dat`, such sentences are very unnatural. In practice, `Gegeven dat` is almost always used. However, the same is not true when using a conjunction like `En` or `Maar`. To prevent having to write step definitions with the word `dat` as optional, depending on whether the keyword `Gegeven` or `En / Maar` was used in this step, it would be much easier to match `dat` as part of the keyword.

The old keywords are preserved, to this change should be backwards-compatible.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

I've built Gherkin with the changed language definitions without problems, however see #272.
