### PR TITLE
Cucumber expressions 276 escape string template

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 
-* Backport to Java 7 ([#1](https://github.com/cucumber/cucumber-expressions-java/pull/1) by [mpkorstanje])
+* java: Backport to Java 7 ([#1](https://github.com/cucumber/cucumber-expressions-java/pull/1) by [mpkorstanje])
 
 ### Fixed
 
+* Support `%` in undefined steps so snippet generation doesn't crash. ([#276](https://github.com/cucumber/cucumber/issues/276), [#279](https://github.com/cucumber/cucumber/pull/279) by [aslakhellesoy])
 * Support escaped parenthesis in Regular expressions ([#254](https://github.com/cucumber/cucumber/pull/254) by [jaysonesmith], [aslakhellesoy])
 
 ## [4.0.3] - 2017-07-24

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
@@ -62,7 +62,7 @@ public class CucumberExpressionGenerator {
                 parameterTypeCombinations.add(new ArrayList<>(parameterTypes));
 
                 expressionTemplate
-                        .append(text.substring(pos, bestParameterTypeMatcher.start()))
+                        .append(escapeForStringFormat(text.substring(pos, bestParameterTypeMatcher.start())))
                         .append("{%s}");
                 pos = bestParameterTypeMatcher.start() + bestParameterTypeMatcher.group().length();
             } else {
@@ -73,8 +73,12 @@ public class CucumberExpressionGenerator {
                 break;
             }
         }
-        expressionTemplate.append(text.substring(pos));
+        expressionTemplate.append(escapeForStringFormat(text.substring(pos)));
         return new CombinatorialGeneratedExpressionFactory(expressionTemplate.toString(), parameterTypeCombinations).generateExpressions();
+    }
+
+    private String escapeForStringFormat(String s) {
+        return s.replaceAll("%", "%%");
     }
 
     /**

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
@@ -49,6 +49,13 @@ public class CucumberExpressionGeneratorTest {
     }
 
     @Test
+    public void generates_expression_for_strings_with_percent_sign() {
+        assertExpression(
+                "I am {int}% foobar", singletonList("int1"),
+                "I am 20% foobar");
+    }
+
+    @Test
     public void generates_expression_for_just_int() {
         assertExpression(
                 "{int}", singletonList("int1"),

--- a/cucumber-expressions/javascript/src/cucumber_expression_generator.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression_generator.js
@@ -54,7 +54,9 @@ class CucumberExpressionGenerator {
 
         parameterTypeCombinations.push(parameterTypes)
 
-        expressionTemplate += text.slice(pos, bestParameterTypeMatcher.start)
+        expressionTemplate += escapeForUtilFormat(
+          text.slice(pos, bestParameterTypeMatcher.start)
+        )
         expressionTemplate += '{%s}'
 
         pos =
@@ -68,7 +70,7 @@ class CucumberExpressionGenerator {
       }
     }
 
-    expressionTemplate += text.slice(pos)
+    expressionTemplate += escapeForUtilFormat(text.slice(pos))
     return new CombinatorialGeneratedExpressionFactory(
       expressionTemplate,
       parameterTypeCombinations
@@ -105,6 +107,10 @@ class CucumberExpressionGenerator {
     }
     return result
   }
+}
+
+function escapeForUtilFormat(s) {
+  return s.replace(/%/g, '%%')
 }
 
 module.exports = CucumberExpressionGenerator

--- a/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
@@ -50,6 +50,10 @@ describe('CucumberExpressionGenerator', () => {
   })
 
   it('generates expression for strings', () => {
+    assertExpression('I am {int}%% foobar', ['int'], 'I am 20%% foobar')
+  })
+
+  it('generates expression for strings with % sign', () => {
     assertExpression(
       'I like {string} and {string}',
       ['string', 'string2'],

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
@@ -51,7 +51,7 @@ module Cucumber
 
             parameter_type_combinations.push(parameter_types)
 
-            expression_template += text.slice(pos...best_parameter_type_matcher.start)
+            expression_template += escape_for_sprintf(text.slice(pos...best_parameter_type_matcher.start))
             expression_template += "{%s}"
 
             pos = best_parameter_type_matcher.start + best_parameter_type_matcher.group.length
@@ -64,7 +64,7 @@ module Cucumber
           end
         end
 
-        expression_template += text.slice(pos..-1)
+        expression_template += escape_for_sprintf(text.slice(pos..-1))
 
         CombinatorialGeneratedExpressionFactory.new(
           expression_template,
@@ -94,6 +94,9 @@ module Cucumber
         result
       end
 
+      def escape_for_sprintf(s)
+        s.gsub(/%/, '%%')
+      end
     end
   end
 end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
@@ -40,6 +40,12 @@ module Cucumber
             'I like "bangers" and \'mash\'')
       end
 
+      it "generates expression for strings with % sign" do
+        assert_expression(
+            "I am {int}% foobar", ["int"],
+            'I am 20% foobar')
+      end
+
       it "generates expression for just int" do
         assert_expression(
           "{int}", ["int"],


### PR DESCRIPTION
This is a fix for #276. Escaping all `%` signs as `%%` before `sprintf` / `String.format` / `util.format` fixes this.