### PR TITLE
Experimental CLI for tag expressions

### DIFF
--- a/tag-expressions/ruby/bin/cucumber-tag-expressions
+++ b/tag-expressions/ruby/bin/cucumber-tag-expressions
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 #
 # This script reads NDJSON-encoded Cucumber events from STDIN and prints
-# the location of each pickle (scenario) matching a tag expression, If
-# no tag expression is specified, all pickle location is printed.
+# the location of each pickle (scenario) matching a tag expression. If
+# no tag expression is specified, all pickle locations are printed.
 #
 # Example:
 #

--- a/tag-expressions/ruby/bin/cucumber-tag-expressions
+++ b/tag-expressions/ruby/bin/cucumber-tag-expressions
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+#
+# This script reads NDJSON-encoded Cucumber events from STDIN and prints
+# the location of each pickle (scenario) matching a tag expression, If
+# no tag expression is specified, all pickle location is printed.
+#
+# Example:
+#
+#    gherkin features/*.feature | cucumber-tag-expressions "@foo and not @bar"
+#
+require 'json'
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"../lib"))
+require 'cucumber/tag_expressions'
+
+tag_expression_parser = Cucumber::TagExpressions::Parser.new
+tag_expression = ARGV[0] ? tag_expression_parser.parse(ARGV[0]) : nil
+
+STDIN.each do |json|
+  event = JSON.parse(json)
+  if event['type'] == 'pickle'
+    tag_names = event['pickle']['tags'].map {|tag| tag['name']}
+    if tag_expression.nil? || tag_expression.evaluate(tag_names)
+      location = "#{event['uri']}:#{event['pickle']['locations'][0]['line']}"
+      puts location
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Command-line tool that prints the location of scenarios matching a certain tag expression

## Details

The tool reads a Cucumber event stream (produced by the `gherkin` command line tool) from `STDIN` and prints the locations (in "rerun.txt" format) to `STDOUT`

## Motivation and Context

This tool can be used as a preprocessor before running `cucumber` to get a list of scenarios to execute before running `cucumber`.

While `cucumber` can filter scenarios with the `--tags` option, it is sometimes useful to perform this filtering before running `cucumber` so that several `cucumber` processes can be spawned in parallel.

This can speed up the execution for slow scenarios.

## How Has This Been Tested?

Manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Caveats

When multiple `cucumber` processes are run in parallel, each process will produce an independent report. These reports will have to be combined in order to produce a single report, and this isn't trivial to do until there are reporters that are based on the Cucumber event protocol.