### PR TITLE
Docs/Readme - Add wikipedia link for BDD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://secure.travis-ci.org/cucumber/cucumber.svg)](http://travis-ci.org/cucumber/cucumber)
 
 Cucumber is a tool that supports [Behaviour-Driven Development
-(BDD)](https://en.wikipedia.org/wiki/Behavior-driven_development) - a software
+(BDD)](https://cucumber.io/blog/2017/05/15/intro-to-bdd-and-tdd) - a software
 development process that aims to enhance software quality and reduce
 maintenance costs.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 
 [![Build Status](https://secure.travis-ci.org/cucumber/cucumber.svg)](http://travis-ci.org/cucumber/cucumber)
 
-Cucumber is a tool that supports [Behaviour-Driven Development (BDD)](#) - a software
-development process that aims to enhance software quality and reduce maintenance costs.
+Cucumber is a tool that supports [Behaviour-Driven Development
+(BDD)](https://en.wikipedia.org/wiki/Behavior-driven_development) - a software
+development process that aims to enhance software quality and reduce
+maintenance costs.
 
 Cucumber executes *executable specifications* written in [plain language](docs/gherkin.md)
 and produces reports indicating whether the software behaves according to the


### PR DESCRIPTION
I'm not sure if there's a subrepo for the readme - it doesn't seem like it. Let me know if I should rename this PR.

## Summary

I propose using the Wikipedia entry on BDD for the currently dead-end link in the readme.

## Motivation and Context

Fixes https://github.com/cucumber/cucumber/issues/44

## How Has This Been Tested?

Clicked the link in the readme and verified it goes to wikipedia ;)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
