### PR TITLE
Cucumber expressions run in world

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* ruby, javascript: A `transformer` function can run in the context of a world object. `Argument#value` now takes an object as argument (renamed to `Argument#getValue` in js)
+
 ### Fixed
 
 ## [4.0.4] - 2017-10-05

--- a/cucumber-expressions/README.md
+++ b/cucumber-expressions/README.md
@@ -73,7 +73,7 @@ This is how we would define a custom `color` parameter type:
 [snippet](javascript/test/custom_parameter_type_test.js#add-color-parameter-type)
 ```
 
-The `transform` function can also return a `Promise`:
+The `transformer` function can also return a `Promise`:
 ```javascript
 [snippet](javascript/test/custom_parameter_type_test.js#add-async-parameter-type)
 ```
@@ -89,7 +89,7 @@ The parameters are as follows:
 * `name` - the name the parameter type will be recognised by in output parameters.
 * `regexp` - a regexp that will match the parameter. May include capture groups.
 * `type`
-* `transform` - a function that transforms the match from the regexp. Must have arity 1 if the regexp doesn't have
+* `transformer` - a function that transforms the match from the regexp. Must have arity 1 if the regexp doesn't have
   any capture groups. Otherwise the arity must match the number of capture groups.
 * `useForSnippets` (Ruby: `use_for_snippets`) - Defaults to `true`. That means this parameter type will be used to generate
   snippets for undefined steps. If the `regexp` frequently matches text you don't intend to be
@@ -190,7 +190,7 @@ Regular Expression would automatically convert arguments to `int`:
 ### Preferential parameter types
 
 In some cases you might want to define two or more parameter types with the same
-regular expression, but different name and transform. For example, you may want
+regular expression, but different name and transformer. For example, you may want
 to define `name` and `person` parameter types with the regexp `[A-Z]+\w+`, which
 would match `Joe`, `Amy` and so on.
 
@@ -233,8 +233,7 @@ of `Argument` (or `null`/`nil` if there was no match).
 This API is similar to most regexp APIs, but the `Argument` type has additional
 information:
 
-* `value` - the string value of the match against the expression.
-* `value` - the transformed value of the match (transformed by the parameter)
+* `value` - the transformed value of the match (transformed by the `transformer` function)
 * `offset` - the offset from the start of the text where the value was found
 
 Arguments are captured by creating an *expression*, and invoking `match` with a

--- a/cucumber-expressions/javascript/src/argument.js
+++ b/cucumber-expressions/javascript/src/argument.js
@@ -31,10 +31,14 @@ class Argument {
     return this._group
   }
 
-  get value() {
-    return this._parameterType.transform(
-      this._group ? this._group.values : null
-    )
+  /**
+   * Get the value returned by the parameter type's transformer function.
+   *
+   * @param thisObj the object in which the transformer function is applied.
+   */
+  getValue(thisObj) {
+    let groupValues = this._group ? this._group.values : null
+    return this._parameterType.transform(thisObj, groupValues)
   }
 }
 

--- a/cucumber-expressions/javascript/src/parameter_type.js
+++ b/cucumber-expressions/javascript/src/parameter_type.js
@@ -54,7 +54,8 @@ class ParameterType {
     return this._useForSnippets
   }
 
-  transform(groupValues) {
+  transform(thisObj, groupValues) {
+    let args
     if (this._transform.length === 1) {
       // transform function with arity 1.
       const nonNullGroupValues = groupValues.filter(
@@ -64,10 +65,12 @@ class ParameterType {
         throw new CucumberExpressionError(
           `Single transformer unexpectedly matched 2 values - "${nonNullGroupValues[0]}" and "${nonNullGroupValues[1]}"`
         )
-      return this._transform(nonNullGroupValues[0])
+      args = [nonNullGroupValues[0]]
+    } else {
+      args = groupValues
     }
 
-    return this._transform.apply(null, groupValues)
+    return this._transform.apply(thisObj, args)
   }
 }
 

--- a/cucumber-expressions/javascript/test/custom_parameter_type_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_type_test.js
@@ -50,7 +50,7 @@ describe('Custom parameter type', () => {
         'I have a {color} ball',
         parameterTypeRegistry
       )
-      const value = expression.match('I have a red ball')[0].value
+      const value = expression.match('I have a red ball')[0].getValue(null)
       assert.equal(value.name, 'red')
     })
 
@@ -79,15 +79,15 @@ describe('Custom parameter type', () => {
       )
       const args = expression.match('A 5 thick line from 10,20,30 to 40,50,60')
 
-      const thick = args[0].value
+      const thick = args[0].getValue(null)
       assert.equal(thick, 5)
 
-      const from = args[1].value
+      const from = args[1].getValue(null)
       assert.equal(from.x, 10)
       assert.equal(from.y, 20)
       assert.equal(from.z, 30)
 
-      const to = args[2].value
+      const to = args[2].getValue(null)
       assert.equal(to.x, 40)
       assert.equal(to.y, 50)
       assert.equal(to.z, 60)
@@ -109,7 +109,7 @@ describe('Custom parameter type', () => {
         'I have a {color} ball',
         parameterTypeRegistry
       )
-      const value = expression.match('I have a dark red ball')[0].value
+      const value = expression.match('I have a dark red ball')[0].getValue(null)
       assert.equal(value.name, 'dark red')
     })
 
@@ -132,7 +132,7 @@ describe('Custom parameter type', () => {
         parameterTypeRegistry
       )
       const args = expression.match('I have a bad parameter')
-      assertThrows(() => args[0].value, "Can't transform [bad]")
+      assertThrows(() => args[0].getValue(null), "Can't transform [bad]")
     })
 
     describe('conflicting parameter type', () => {
@@ -182,28 +182,30 @@ describe('Custom parameter type', () => {
           new CucumberExpression(
             'I have a {css-color} ball',
             parameterTypeRegistry
-          ).match('I have a blue ball')[0].value.constructor,
+          )
+            .match('I have a blue ball')[0]
+            .getValue(null).constructor,
           CssColor
         )
         assert.equal(
           new CucumberExpression(
             'I have a {css-color} ball',
             parameterTypeRegistry
-          ).match('I have a blue ball')[0].value.name,
+          )
+            .match('I have a blue ball')[0]
+            .getValue(null).name,
           'blue'
         )
         assert.equal(
-          new CucumberExpression(
-            'I have a {color} ball',
-            parameterTypeRegistry
-          ).match('I have a blue ball')[0].value.constructor,
+          new CucumberExpression('I have a {color} ball', parameterTypeRegistry)
+            .match('I have a blue ball')[0]
+            .getValue(null).constructor,
           Color
         )
         assert.equal(
-          new CucumberExpression(
-            'I have a {color} ball',
-            parameterTypeRegistry
-          ).match('I have a blue ball')[0].value.name,
+          new CucumberExpression('I have a {color} ball', parameterTypeRegistry)
+            .match('I have a blue ball')[0]
+            .getValue(null).name,
           'blue'
         )
       })
@@ -230,7 +232,7 @@ describe('Custom parameter type', () => {
         parameterTypeRegistry
       )
       const args = await expression.match('I have a red ball')
-      const value = await args[0].value
+      const value = await args[0].getValue(null)
       assert.equal(value.name, 'red')
     })
   })
@@ -241,7 +243,7 @@ describe('Custom parameter type', () => {
         /I have a (red|blue|yellow) ball/,
         parameterTypeRegistry
       )
-      const value = expression.match('I have a red ball')[0].value
+      const value = expression.match('I have a red ball')[0].getValue(null)
       assert.equal(value.constructor, Color)
       assert.equal(value.name, 'red')
     })

--- a/cucumber-expressions/javascript/test/custom_parameter_type_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_type_test.js
@@ -35,7 +35,7 @@ describe('Custom parameter type', () => {
         'color',           // name
         /red|blue|yellow/, // regexp
         Color,             // type
-        s => new Color(s), // transform
+        s => new Color(s), // transformer
         false,             // useForSnippets
         true               // preferForRegexpMatch
       )

--- a/cucumber-expressions/javascript/test/expression_examples_test.js
+++ b/cucumber-expressions/javascript/test/expression_examples_test.js
@@ -13,7 +13,7 @@ describe('examples.txt', () => {
       : new CucumberExpression(expression_text, new ParameterTypeRegistry())
     const args = expression.match(text)
     if (!args) return null
-    return args.map(arg => arg.value)
+    return args.map(arg => arg.getValue(null))
   }
 
   const examples = fs.readFileSync('examples.txt', 'utf-8')

--- a/cucumber-expressions/javascript/test/regular_expression_test.js
+++ b/cucumber-expressions/javascript/test/regular_expression_test.js
@@ -11,8 +11,8 @@ describe('RegularExpression', () => {
     const expr = /I have (\d+) cukes? in my (\w+) now/
     const expression = new RegularExpression(expr, parameterRegistry)
     const args = expression.match('I have 7 cukes in my belly now')
-    assert.equal(7, args[0].value)
-    assert.equal('belly', args[1].value)
+    assert.equal(7, args[0].getValue(null))
+    assert.equal('belly', args[1].getValue(null))
     /// [capture-match-arguments]
   })
 
@@ -67,5 +67,5 @@ const match = (regexp, text) => {
   const regularExpression = new RegularExpression(regexp, parameterRegistry)
   const args = regularExpression.match(text)
   if (!args) return null
-  return args.map(arg => arg.value)
+  return args.map(arg => arg.getValue(null))
 }

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
@@ -27,8 +27,10 @@ module Cucumber
         @group, @parameter_type = group, parameter_type
       end
 
-      def value
-        @parameter_type.transform(@group ? @group.values : nil)
+      def value(self_obj=:nil)
+        raise "No self_obj" if self_obj == :nil
+        group_values = @group ? @group.values : nil
+        @parameter_type.transform(self_obj, group_values)
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -34,15 +34,17 @@ module Cucumber
         @regexps = string_array(regexp)
       end
 
-      def transform(group_values)
+      def transform(self_obj, group_values)
         if @transformer.arity == 1
           non_nil_group_values = group_values.compact
           raise CucumberExpressionError.new(
               "Single transformer unexpectedly matched 2 values - \"#{non_nil_group_values[0]}\" and \"${non_nil_group_values[1]}\""
           ) if non_nil_group_values.length >= 2
-          return @transformer.call(non_nil_group_values[0])
+          args = [non_nil_group_values[0]]
+        else
+          args = group_values
         end
-        @transformer.call(*group_values)
+        self_obj.instance_exec(*args, &@transformer)
       end
 
       def <=>(other)

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
@@ -62,7 +62,7 @@ module Cucumber
       describe CucumberExpression do
         it "matches parameters with custom parameter type" do
           expression = CucumberExpression.new("I have a {color} ball", @parameter_type_registry)
-          transformed_argument_value = expression.match("I have a red ball")[0].value
+          transformed_argument_value = expression.match("I have a red ball")[0].value(nil)
           expect(transformed_argument_value).to eq(Color.new('red'))
         end
 
@@ -82,13 +82,13 @@ module Cucumber
           )
           args = expression.match('A 5 thick line from 10,20,30 to 40,50,60')
 
-          thick = args[0].value
+          thick = args[0].value(nil)
           expect(thick).to eq(5)
 
-          from = args[1].value
+          from = args[1].value(nil)
           expect(from).to eq(Coordinate.new(10, 20, 30))
 
-          to = args[2].value
+          to = args[2].value(nil)
           expect(to).to eq(Coordinate.new(40, 50, 60))
         end
 
@@ -103,7 +103,7 @@ module Cucumber
               false
           ))
           expression = CucumberExpression.new("I have a {color} ball", parameter_type_registry)
-          transformed_argument_value = expression.match("I have a dark red ball")[0].value
+          transformed_argument_value = expression.match("I have a dark red ball")[0].value(nil)
           expect(transformed_argument_value).to eq(Color.new('dark red'))
         end
 
@@ -118,7 +118,7 @@ module Cucumber
           ))
           expression = CucumberExpression.new("I have a {throwing} parameter", @parameter_type_registry)
           args = expression.match("I have a bad parameter")
-          expect {args[0].value}.to raise_error("Can't transform [bad]")
+          expect {args[0].value(nil)}.to raise_error("Can't transform [bad]")
         end
 
         describe "conflicting parameter type" do
@@ -157,11 +157,11 @@ module Cucumber
             ))
 
             css_color = CucumberExpression.new("I have a {css-color} ball", @parameter_type_registry)
-            css_color_value = css_color.match("I have a blue ball")[0].value
+            css_color_value = css_color.match("I have a blue ball")[0].value(nil)
             expect(css_color_value).to eq(CssColor.new("blue"))
 
             color = CucumberExpression.new("I have a {color} ball", @parameter_type_registry)
-            color_value = color.match("I have a blue ball")[0].value
+            color_value = color.match("I have a blue ball")[0].value(nil)
             expect(color_value).to eq(Color.new("blue"))
           end
         end
@@ -170,7 +170,7 @@ module Cucumber
       describe RegularExpression do
         it "matches arguments with custom parameter type" do
           expression = RegularExpression.new(/I have a (red|blue|yellow) ball/, @parameter_type_registry)
-          value = expression.match("I have a red ball")[0].value
+          value = expression.match("I have a red ball")[0].value(nil)
           expect(value).to eq(Color.new('red'))
         end
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/expression_examples_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/expression_examples_spec.rb
@@ -13,7 +13,7 @@ module Cucumber
 
         arguments = expression.match(text)
         return nil if arguments.nil?
-        arguments.map { |arg| arg.value }
+        arguments.map { |arg| arg.value(nil) }
       end
 
       File.open(File.expand_path("../../../../examples.txt", __FILE__), "r:utf-8") do |io|

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -11,8 +11,8 @@ module Cucumber
         expr = /I have (\d+) cukes? in my (\w*) now/
         expression = RegularExpression.new(expr, parameter_type_registry)
         args = expression.match("I have 7 cukes in my belly now")
-        expect( args[0].value ).to eq(7)
-        expect( args[1].value ).to eq("belly")
+        expect( args[0].value(nil) ).to eq(7)
+        expect( args[1].value(nil) ).to eq("belly")
         ### [capture-match-arguments]
       end
 
@@ -62,7 +62,7 @@ module Cucumber
         regular_expression = RegularExpression.new(expression, ParameterTypeRegistry.new)
         arguments = regular_expression.match(text)
         return nil if arguments.nil?
-        arguments.map { |arg| arg.value }
+        arguments.map { |arg| arg.value(nil) }
       end
     end
   end


### PR DESCRIPTION
## Summary

Run `transformer` in the context of the World.

## Motivation and Context

`transformer` functions often need access to the World in order to transform an object.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
