### PR TITLE
cucumber-expressions: (Java) Make the jar a bundle to support osgi.

### DIFF
--- a/cucumber-expressions/java/pom.xml
+++ b/cucumber-expressions/java/pom.xml
@@ -4,8 +4,8 @@
 
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-expressions</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <version>5.0.1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>cucumber-expressions</name>
     <description>Cucumber Expressions</description>
     <url>https://github.com/cucumber/cucumber-expressions-java</url>
@@ -73,6 +73,19 @@
                 <configuration>
                     <argLine>${surefireArgLine}</argLine>
                     <useFile>false</useFile>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>3.2.0</version>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description/>
+                        <Export-Package>io.cucumber.cucumberexpressions.*</Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Summary

Build the cucumber-expressions jar as a OSGi bundle.

See also #99.

## Details

 * Declare the packaging type as bundle
 * Use the maven-bundle-plugin to create the manifest according to the OSGi requirement.

## Motivation and Context

cucumber/cucumber-jvm#873 added support to execute Cucumber-JVM in OSGi containers. To not lose that ability when using the cucumber-expression library in Cucumber-JVM, the cucumber-expressions jar need to be built as an OSGi bundle.

## How Has This Been Tested?

I have locally run the pax-exam example of Cucumber-JVM, which exemplifies testing OSGi bundles, successfully with these changes.

## Types of changes

- [X] New feature (non-breaking change which adds functionality).
