### PR TITLE
gherkin: add language parameter to API

### DIFF
--- a/gherkin/c/.gitrepo
+++ b/gherkin/c/.gitrepo
@@ -6,6 +6,6 @@
 [subrepo]
 	remote = https://github.com/cucumber/gherkin-c.git
 	branch = master
-	commit = b46061e146f77d40445f8b381e64af990c26f836
-	parent = 2e9dc31b2d26ce932d2ee5ccb898dc996001c42f
+	commit = f9940cd0ccf606355655c11ae8b424d52a2314fd
+	parent = 7250c5c08b35238773de8f5890a276fdddb9f67f
 	cmdver = 0.4.0

--- a/gherkin/c/Makefile
+++ b/gherkin/c/Makefile
@@ -48,8 +48,8 @@ libs: ./include/rule_type.h src/parser.c src/dialect.c $(SRC_FILES) src/Makefile
 	cd src; $(MAKE) CC=$(CC) $@
 .PHONY: libs
 
-.run: $(GHERKIN) $(GOOD_FEATURE_FILES)
-	$(RUN_GHERKIN) --no-source --no-ast --no-pickles $(GOOD_FEATURE_FILES)
+.run: cli $(GHERKIN) $(GOOD_FEATURE_FILES)
+	$(RUN_GHERKIN) $(GOOD_FEATURE_FILES) | jq . > /dev/null
 	touch .run
 
 ./include/rule_type.h: gherkin.berp gherkin-c-rule-type.razor

--- a/gherkin/java/gherkin-java.razor
+++ b/gherkin/java/gherkin-java.razor
@@ -88,24 +88,24 @@ public class @Model.ParserClassName<T> {
         this.builder = builder;
     }
 
-    public T parse(String sourceEvent) {
-        return parse(new StringReader(sourceEvent));
+    public T parse(String source) {
+        return parse(new StringReader(source));
     }
 
-    public T parse(Reader sourceEvent) {
-        return parse(new TokenScanner(sourceEvent));
+    public T parse(Reader source) {
+        return parse(new TokenScanner(source));
     }
 
     public T parse(ITokenScanner tokenScanner) {
         return parse(tokenScanner, new TokenMatcher());
     }
 
-    public T parse(String sourceEvent, ITokenMatcher tokenMatcher) {
-        return parse(new StringReader(sourceEvent), tokenMatcher);
+    public T parse(String source, ITokenMatcher tokenMatcher) {
+        return parse(new StringReader(source), tokenMatcher);
     }
 
-    public T parse(Reader sourceEvent, ITokenMatcher tokenMatcher) {
-        return parse(new TokenScanner(sourceEvent), tokenMatcher);
+    public T parse(Reader source, ITokenMatcher tokenMatcher) {
+        return parse(new TokenScanner(source), tokenMatcher);
     }
 
     public T parse(ITokenScanner tokenScanner, ITokenMatcher tokenMatcher) {

--- a/gherkin/java/src/main/java/gherkin/Parser.java
+++ b/gherkin/java/src/main/java/gherkin/Parser.java
@@ -98,24 +98,24 @@ public class Parser<T> {
         this.builder = builder;
     }
 
-    public T parse(String sourceEvent) {
-        return parse(new StringReader(sourceEvent));
+    public T parse(String source) {
+        return parse(new StringReader(source));
     }
 
-    public T parse(Reader sourceEvent) {
-        return parse(new TokenScanner(sourceEvent));
+    public T parse(Reader source) {
+        return parse(new TokenScanner(source));
     }
 
     public T parse(ITokenScanner tokenScanner) {
         return parse(tokenScanner, new TokenMatcher());
     }
 
-    public T parse(String sourceEvent, ITokenMatcher tokenMatcher) {
-        return parse(new StringReader(sourceEvent), tokenMatcher);
+    public T parse(String source, ITokenMatcher tokenMatcher) {
+        return parse(new StringReader(source), tokenMatcher);
     }
 
-    public T parse(Reader sourceEvent, ITokenMatcher tokenMatcher) {
-        return parse(new TokenScanner(sourceEvent), tokenMatcher);
+    public T parse(Reader source, ITokenMatcher tokenMatcher) {
+        return parse(new TokenScanner(source), tokenMatcher);
     }
 
     public T parse(ITokenScanner tokenScanner, ITokenMatcher tokenMatcher) {

--- a/gherkin/java/src/main/java/gherkin/TokenMatcher.java
+++ b/gherkin/java/src/main/java/gherkin/TokenMatcher.java
@@ -25,8 +25,8 @@ public class TokenMatcher implements ITokenMatcher {
         this(new GherkinDialectProvider());
     }
 
-    public TokenMatcher(String default_dialect_name) {
-        this(new GherkinDialectProvider(default_dialect_name));
+    public TokenMatcher(String defaultDialectName) {
+        this(new GherkinDialectProvider(defaultDialectName));
     }
 
     @Override

--- a/gherkin/java/src/main/java/gherkin/events/Events.java
+++ b/gherkin/java/src/main/java/gherkin/events/Events.java
@@ -2,6 +2,7 @@ package gherkin.events;
 
 import gherkin.AstBuilder;
 import gherkin.Parser;
+import gherkin.TokenMatcher;
 import gherkin.pickles.Compiler;
 import gherkin.ast.GherkinDocument;
 import gherkin.pickles.Pickle;
@@ -10,13 +11,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Events {
-    private static final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
-    private static final Compiler compiler = new Compiler();
-
     public static List<CucumberEvent> generate(String data, String uri) {
+        return generate(data, uri, new TokenMatcher());
+    }
+
+    public static List<CucumberEvent> generate(String data, String uri, String language) {
+        return generate(data, uri, new TokenMatcher(language));
+    }
+
+    private static List<CucumberEvent> generate(String data, String uri, TokenMatcher tokenMatcher) {
+        Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+        Compiler compiler = new Compiler();
+
         List<CucumberEvent> events = new ArrayList<>();
         events.add(new SourceEvent(data, uri));
-        GherkinDocument document = parser.parse(data);
+        GherkinDocument document = parser.parse(data, tokenMatcher);
         events.add(new GherkinDocumentEvent(uri, document));
         List<Pickle> pickles = compiler.compile(document);
         for (Pickle pickle : pickles) {

--- a/gherkin/java/src/test/java/gherkin/events/EventsTest.java
+++ b/gherkin/java/src/test/java/gherkin/events/EventsTest.java
@@ -8,10 +8,20 @@ import static org.junit.Assert.assertEquals;
 
 public class EventsTest {
     @Test
-    public void generates_events() {
+    public void generates_events_for_english_by_default() {
         String data = "Feature: Hello\n  Scenario: World\n    Given hello";
         String uri = "features/hello.feature";
         List<CucumberEvent> events = Events.generate(data, uri);
+        assertEquals(SourceEvent.class, events.get(0).getClass());
+        assertEquals(GherkinDocumentEvent.class, events.get(1).getClass());
+        assertEquals(PickleEvent.class, events.get(2).getClass());
+    }
+
+    @Test
+    public void generates_events_for_specific_language() {
+        String data = "Fonctionnalité: Bonjour\n  Scénario: Monde\n    Soit une étape";
+        String uri = "features/hello.feature";
+        List<CucumberEvent> events = Events.generate(data, uri, "fr");
         assertEquals(SourceEvent.class, events.get(0).getClass());
         assertEquals(GherkinDocumentEvent.class, events.get(1).getClass());
         assertEquals(PickleEvent.class, events.get(2).getClass());

--- a/gherkin/javascript/lib/gherkin/generate_events.js
+++ b/gherkin/javascript/lib/gherkin/generate_events.js
@@ -5,7 +5,7 @@ var compiler = new Compiler()
 var parser = new Parser()
 parser.stopAtFirstError = false
 
-function generateEvents({data, language, uri, types}) {
+function generateEvents({data, uri, types, language, types}) {
   types = Object.assign({
     'source': true,
     'gherkin-document': true,

--- a/gherkin/javascript/lib/gherkin/generate_events.js
+++ b/gherkin/javascript/lib/gherkin/generate_events.js
@@ -5,7 +5,7 @@ var compiler = new Compiler()
 var parser = new Parser()
 parser.stopAtFirstError = false
 
-function generateEvents(data, uri, types) {
+function generateEvents({data, language, uri, types}) {
   types = Object.assign({
     'source': true,
     'gherkin-document': true,
@@ -30,7 +30,7 @@ function generateEvents(data, uri, types) {
     if (!types['gherkin-document'] && !types['pickle'])
       return result
 
-    var gherkinDocument = parser.parse(data)
+    var gherkinDocument = parser.parse(data, language)
 
     if (types['gherkin-document']) {
       result.push({

--- a/gherkin/javascript/lib/gherkin/generate_events.js
+++ b/gherkin/javascript/lib/gherkin/generate_events.js
@@ -5,7 +5,7 @@ var compiler = new Compiler()
 var parser = new Parser()
 parser.stopAtFirstError = false
 
-function generateEvents(data, uri, types, language, types) {
+function generateEvents(data, uri, types, language) {
   types = Object.assign({
     'source': true,
     'gherkin-document': true,

--- a/gherkin/javascript/lib/gherkin/generate_events.js
+++ b/gherkin/javascript/lib/gherkin/generate_events.js
@@ -5,7 +5,7 @@ var compiler = new Compiler()
 var parser = new Parser()
 parser.stopAtFirstError = false
 
-function generateEvents({data, uri, types, language, types}) {
+function generateEvents(data, uri, types, language, types) {
   types = Object.assign({
     'source': true,
     'gherkin-document': true,

--- a/gherkin/javascript/lib/gherkin/parser.js
+++ b/gherkin/javascript/lib/gherkin/parser.js
@@ -48,6 +48,9 @@ module.exports = function Parser(builder) {
     if(typeof tokenScanner == 'string') {
       tokenScanner = new TokenScanner(tokenScanner);
     }
+    if(typeof tokenMatcher == 'string') {
+      tokenMatcher = new TokenMatcher(tokenMatcher);
+    }
     tokenMatcher = tokenMatcher || new TokenMatcher();
     builder.reset();
     tokenMatcher.reset();

--- a/gherkin/javascript/lib/gherkin/parser.js
+++ b/gherkin/javascript/lib/gherkin/parser.js
@@ -51,6 +51,7 @@ module.exports = function Parser(builder) {
     if(typeof tokenMatcher == 'string') {
       tokenMatcher = new TokenMatcher(tokenMatcher);
     }
+    tokenMatcher = tokenMatcher || new TokenMatcher();
     builder.reset();
     tokenMatcher.reset();
     context = {
@@ -245,7 +246,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 0;
     }
-    
+
     var stateComment = "State: 0 - Start";
     token.detach();
     var expectedTokens = ["#EOF", "#Language", "#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -277,7 +278,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 1;
     }
-    
+
     var stateComment = "State: 1 - GherkinDocument:0>Feature:0>Feature_Header:0>#Language:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -309,7 +310,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 2;
     }
-    
+
     var stateComment = "State: 2 - GherkinDocument:0>Feature:0>Feature_Header:1>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -370,7 +371,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 4;
     }
-    
+
     var stateComment = "State: 3 - GherkinDocument:0>Feature:0>Feature_Header:2>#FeatureLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -432,7 +433,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 4;
     }
-    
+
     var stateComment = "State: 4 - GherkinDocument:0>Feature:0>Feature_Header:3>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -488,7 +489,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 5;
     }
-    
+
     var stateComment = "State: 5 - GherkinDocument:0>Feature:0>Feature_Header:3>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -548,7 +549,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 7;
     }
-    
+
     var stateComment = "State: 6 - GherkinDocument:0>Feature:1>Background:0>#BackgroundLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -609,7 +610,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 7;
     }
-    
+
     var stateComment = "State: 7 - GherkinDocument:0>Feature:1>Background:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -664,7 +665,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 8;
     }
-    
+
     var stateComment = "State: 8 - GherkinDocument:0>Feature:1>Background:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -734,7 +735,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 9;
     }
-    
+
     var stateComment = "State: 9 - GherkinDocument:0>Feature:1>Background:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -803,7 +804,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 10;
     }
-    
+
     var stateComment = "State: 10 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -842,7 +843,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 11;
     }
-    
+
     var stateComment = "State: 11 - GherkinDocument:0>Feature:2>Scenario_Definition:0>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -906,7 +907,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 13;
     }
-    
+
     var stateComment = "State: 12 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:0>#ScenarioLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -971,7 +972,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 13;
     }
-    
+
     var stateComment = "State: 13 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1030,7 +1031,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 14;
     }
-    
+
     var stateComment = "State: 14 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1104,7 +1105,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 15;
     }
-    
+
     var stateComment = "State: 15 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1177,7 +1178,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 16;
     }
-    
+
     var stateComment = "State: 16 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1255,7 +1256,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 18;
     }
-    
+
     var stateComment = "State: 17 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:0>#ScenarioOutlineLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1336,7 +1337,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 18;
     }
-    
+
     var stateComment = "State: 18 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1409,7 +1410,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 19;
     }
-    
+
     var stateComment = "State: 19 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1499,7 +1500,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 20;
     }
-    
+
     var stateComment = "State: 20 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1590,7 +1591,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 21;
     }
-    
+
     var stateComment = "State: 21 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1623,7 +1624,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 22;
     }
-    
+
     var stateComment = "State: 22 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:0>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
@@ -1713,7 +1714,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 24;
     }
-    
+
     var stateComment = "State: 23 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:0>#ExamplesLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1806,7 +1807,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 24;
     }
-    
+
     var stateComment = "State: 24 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1891,7 +1892,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 25;
     }
-    
+
     var stateComment = "State: 25 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1981,7 +1982,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 26;
     }
-    
+
     var stateComment = "State: 26 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:2>Examples_Table:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2004,7 +2005,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 28;
     }
-    
+
     var stateComment = "State: 28 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2091,7 +2092,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 29;
     }
-    
+
     var stateComment = "State: 29 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2114,7 +2115,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 30;
     }
-    
+
     var stateComment = "State: 30 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2183,7 +2184,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 31;
     }
-    
+
     var stateComment = "State: 31 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2206,7 +2207,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 32;
     }
-    
+
     var stateComment = "State: 32 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2271,7 +2272,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 33;
     }
-    
+
     var stateComment = "State: 33 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];

--- a/gherkin/javascript/lib/gherkin/parser.js
+++ b/gherkin/javascript/lib/gherkin/parser.js
@@ -48,7 +48,9 @@ module.exports = function Parser(builder) {
     if(typeof tokenScanner == 'string') {
       tokenScanner = new TokenScanner(tokenScanner);
     }
-    tokenMatcher = tokenMatcher || new TokenMatcher();
+    if(typeof tokenMatcher == 'string') {
+      tokenMatcher = new TokenMatcher(tokenMatcher);
+    }
     builder.reset();
     tokenMatcher.reset();
     context = {

--- a/gherkin/javascript/lib/gherkin/parser.js
+++ b/gherkin/javascript/lib/gherkin/parser.js
@@ -48,9 +48,6 @@ module.exports = function Parser(builder) {
     if(typeof tokenScanner == 'string') {
       tokenScanner = new TokenScanner(tokenScanner);
     }
-    if(typeof tokenMatcher == 'string') {
-      tokenMatcher = new TokenMatcher(tokenMatcher);
-    }
     tokenMatcher = tokenMatcher || new TokenMatcher();
     builder.reset();
     tokenMatcher.reset();
@@ -246,7 +243,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 0;
     }
-
+    
     var stateComment = "State: 0 - Start";
     token.detach();
     var expectedTokens = ["#EOF", "#Language", "#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -278,7 +275,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 1;
     }
-
+    
     var stateComment = "State: 1 - GherkinDocument:0>Feature:0>Feature_Header:0>#Language:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -310,7 +307,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 2;
     }
-
+    
     var stateComment = "State: 2 - GherkinDocument:0>Feature:0>Feature_Header:1>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#FeatureLine", "#Comment", "#Empty"];
@@ -371,7 +368,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 4;
     }
-
+    
     var stateComment = "State: 3 - GherkinDocument:0>Feature:0>Feature_Header:2>#FeatureLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -433,7 +430,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 4;
     }
-
+    
     var stateComment = "State: 4 - GherkinDocument:0>Feature:0>Feature_Header:3>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -489,7 +486,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 5;
     }
-
+    
     var stateComment = "State: 5 - GherkinDocument:0>Feature:0>Feature_Header:3>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -549,7 +546,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 7;
     }
-
+    
     var stateComment = "State: 6 - GherkinDocument:0>Feature:1>Background:0>#BackgroundLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -610,7 +607,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 7;
     }
-
+    
     var stateComment = "State: 7 - GherkinDocument:0>Feature:1>Background:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -665,7 +662,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 8;
     }
-
+    
     var stateComment = "State: 8 - GherkinDocument:0>Feature:1>Background:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -735,7 +732,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 9;
     }
-
+    
     var stateComment = "State: 9 - GherkinDocument:0>Feature:1>Background:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -804,7 +801,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 10;
     }
-
+    
     var stateComment = "State: 10 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -843,7 +840,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 11;
     }
-
+    
     var stateComment = "State: 11 - GherkinDocument:0>Feature:2>Scenario_Definition:0>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -907,7 +904,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 13;
     }
-
+    
     var stateComment = "State: 12 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:0>#ScenarioLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -972,7 +969,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 13;
     }
-
+    
     var stateComment = "State: 13 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1031,7 +1028,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 14;
     }
-
+    
     var stateComment = "State: 14 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1105,7 +1102,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 15;
     }
-
+    
     var stateComment = "State: 15 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1178,7 +1175,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 16;
     }
-
+    
     var stateComment = "State: 16 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1256,7 +1253,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 18;
     }
-
+    
     var stateComment = "State: 17 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:0>#ScenarioOutlineLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1337,7 +1334,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 18;
     }
-
+    
     var stateComment = "State: 18 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1410,7 +1407,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 19;
     }
-
+    
     var stateComment = "State: 19 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1500,7 +1497,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 20;
     }
-
+    
     var stateComment = "State: 20 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:0>#StepLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1591,7 +1588,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 21;
     }
-
+    
     var stateComment = "State: 21 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:0>DataTable:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -1624,7 +1621,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 22;
     }
-
+    
     var stateComment = "State: 22 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:0>Tags:0>#TagLine:0";
     token.detach();
     var expectedTokens = ["#TagLine", "#ExamplesLine", "#Comment", "#Empty"];
@@ -1714,7 +1711,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 24;
     }
-
+    
     var stateComment = "State: 23 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:0>#ExamplesLine:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Empty", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1807,7 +1804,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 24;
     }
-
+    
     var stateComment = "State: 24 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:1>Description_Helper:1>Description:0>#Other:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Other"];
@@ -1892,7 +1889,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 25;
     }
-
+    
     var stateComment = "State: 25 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:1>Description_Helper:2>#Comment:0";
     token.detach();
     var expectedTokens = ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Empty"];
@@ -1982,7 +1979,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 26;
     }
-
+    
     var stateComment = "State: 26 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:3>Examples_Definition:1>Examples:2>Examples_Table:0>#TableRow:0";
     token.detach();
     var expectedTokens = ["#EOF", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2005,7 +2002,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 28;
     }
-
+    
     var stateComment = "State: 28 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2092,7 +2089,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 29;
     }
-
+    
     var stateComment = "State: 29 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:1>ScenarioOutline:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2115,7 +2112,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 30;
     }
-
+    
     var stateComment = "State: 30 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2184,7 +2181,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 31;
     }
-
+    
     var stateComment = "State: 31 - GherkinDocument:0>Feature:2>Scenario_Definition:1>__alt0:0>Scenario:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];
@@ -2207,7 +2204,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 32;
     }
-
+    
     var stateComment = "State: 32 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:1>DocString:0>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#DocStringSeparator", "#Other"];
@@ -2272,7 +2269,7 @@ module.exports = function Parser(builder) {
       build(context, token);
       return 33;
     }
-
+    
     var stateComment = "State: 33 - GherkinDocument:0>Feature:1>Background:2>Step:1>Step_Arg:0>__alt1:1>DocString:2>#DocStringSeparator:0";
     token.detach();
     var expectedTokens = ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#ScenarioOutlineLine", "#Comment", "#Empty"];

--- a/gherkin/javascript/lib/gherkin/stream/event_stream.js
+++ b/gherkin/javascript/lib/gherkin/stream/event_stream.js
@@ -24,7 +24,11 @@ class EventStream extends Stream.Transform {
   }
 
   _flush(callback) {
-    const events = generateEvents(this._gherkin, this._uri, this._types)
+    const events = generateEvents({
+      data: this._gherkin,
+      uri: this._uri,
+      types: this._types
+    })
     for (const event of events) {
       this.push(event)
     }

--- a/gherkin/javascript/lib/gherkin/stream/event_stream.js
+++ b/gherkin/javascript/lib/gherkin/stream/event_stream.js
@@ -11,7 +11,7 @@ class EventStream extends Stream.Transform {
    * @param types {object} with keys source,gherkin-document and pickle,
    *   indicating what kinds of events to emit
    */
-  constructor(uri, types) {
+  constructor(uri, types, language) {
     super({ objectMode: true })
     this._uri = uri
     this._types = types
@@ -24,11 +24,7 @@ class EventStream extends Stream.Transform {
   }
 
   _flush(callback) {
-    const events = generateEvents({
-      data: this._gherkin,
-      uri: this._uri,
-      types: this._types
-    })
+    const events = generateEvents(this._gherkin, this._uri, this._types, language)
     for (const event of events) {
       this.push(event)
     }

--- a/gherkin/javascript/lib/gherkin/stream/event_stream.js
+++ b/gherkin/javascript/lib/gherkin/stream/event_stream.js
@@ -15,6 +15,7 @@ class EventStream extends Stream.Transform {
     super({ objectMode: true })
     this._uri = uri
     this._types = types
+    this._language = language
     this._gherkin = ""
   }
 
@@ -24,7 +25,7 @@ class EventStream extends Stream.Transform {
   }
 
   _flush(callback) {
-    const events = generateEvents(this._gherkin, this._uri, this._types, language)
+    const events = generateEvents(this._gherkin, this._uri, this._types, this._language)
     for (const event of events) {
       this.push(event)
     }

--- a/gherkin/javascript/test/stream/event_stream_test.js
+++ b/gherkin/javascript/test/stream/event_stream_test.js
@@ -19,7 +19,7 @@ describe('EventStream', () => {
     fs.createReadStream(__dirname + '/test.feature', { encoding: 'utf-8' }).pipe(eventStream)
   })
 
-  it("accepts an options langauge parameter", (callback) => {
+  it("accepts a language parameter", (callback) => {
     const events = []
     const eventStream = new EventStream('test_fr.feature', {
       'source': true,

--- a/gherkin/javascript/test/stream/event_stream_test.js
+++ b/gherkin/javascript/test/stream/event_stream_test.js
@@ -18,4 +18,20 @@ describe('EventStream', () => {
     })
     fs.createReadStream(__dirname + '/test.feature', { encoding: 'utf-8' }).pipe(eventStream)
   })
+
+  it("accepts an options langauge parameter", (callback) => {
+    const events = []
+    const eventStream = new EventStream('test_fr.feature', {
+      'source': true,
+      'gherkin-document': true,
+      'pickle': true
+    }, 'fr')
+    eventStream.on('data', data => events.push(data))
+    eventStream.on('end', () => {
+      assert.equal(events.length, 3)
+      assert.deepEqual(events.map(e => e.uri), ['test_fr.feature', 'test_fr.feature', 'test_fr.feature'])
+      callback()
+    })
+    fs.createReadStream(__dirname + '/test_fr.feature', { encoding: 'utf-8' }).pipe(eventStream)
+  })
 })

--- a/gherkin/javascript/test/stream/test_fr.feature
+++ b/gherkin/javascript/test/stream/test_fr.feature
@@ -1,0 +1,3 @@
+Fonctionnalité: Bonjour
+  Scénario: Monde
+    Soit une étape

--- a/gherkin/ruby/lib/gherkin/stream/gherkin_events.rb
+++ b/gherkin/ruby/lib/gherkin/stream/gherkin_events.rb
@@ -1,21 +1,23 @@
 require 'gherkin/parser'
+require 'gherkin/token_matcher'
 require 'gherkin/pickles/compiler'
 
 module Gherkin
   module Stream
     class GherkinEvents
-      def initialize(options)
+      def initialize(options, language='en')
         @options = options
         @parser = Gherkin::Parser.new
         @compiler = Gherkin::Pickles::Compiler.new
+        @language = language
       end
 
       def enum(source_event)
         Enumerator.new do |y|
-          uri = source_event['uri']
-          source = source_event['data']
+          uri = source_event[:uri]
+          source = source_event[:data]
           begin
-            gherkin_document = @parser.parse(source)
+            gherkin_document = @parser.parse(source, TokenMatcher.new(@language))
 
             if (@options[:print_source])
               y.yield source_event

--- a/gherkin/ruby/lib/gherkin/stream/source_events.rb
+++ b/gherkin/ruby/lib/gherkin/stream/source_events.rb
@@ -9,12 +9,12 @@ module Gherkin
         Enumerator.new do |y|
           @paths.each do |path|
             event = {
-              'type' => 'source',
-              'uri' => path,
-              'data' => File.open(path, 'r:UTF-8', &:read),
-              'media' => {
-                'encoding' => 'utf-8',
-                'type' => 'text/vnd.cucumber.gherkin+plain'
+              type: 'source',
+              uri: path,
+              data: File.open(path, 'r:UTF-8', &:read),
+              media: {
+                encoding: 'utf-8',
+                type: 'text/vnd.cucumber.gherkin+plain'
               }
             }
             y.yield(event)

--- a/gherkin/ruby/spec/gherkin/stream/gherkin_events_spec.rb
+++ b/gherkin/ruby/spec/gherkin/stream/gherkin_events_spec.rb
@@ -1,0 +1,27 @@
+require 'rspec'
+require 'gherkin/stream/gherkin_events'
+require 'gherkin/stream/source_events'
+
+module Gherkin
+  module Stream
+    describe GherkinEvents do
+      it "accepts a language parameter" do
+        source_events = SourceEvents.new([File.dirname(__FILE__) + '/test_fr.feature'])
+        gherkin_events = GherkinEvents.new({
+          print_source: true,
+          print_ast: true,
+          print_pickles: true
+        }, 'fr')
+
+        event_types = []
+        source_events.enum.each do |source_event|
+          gherkin_events.enum(source_event).each do |event|
+            event_types << event[:type]
+          end
+        end
+
+        expect(event_types).to eq(['source', 'gherkin-document', 'pickle'])
+      end
+    end
+  end
+end

--- a/gherkin/ruby/spec/gherkin/stream/test_fr.feature
+++ b/gherkin/ruby/spec/gherkin/stream/test_fr.feature
@@ -1,0 +1,3 @@
+Fonctionnalité: Bonjour
+  Scénario: Monde
+    Soit une étape


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Updating a couple gherkin APIs to accept a language parameter
<!--- Provide a general summary description of your changes -->

## Details

* Allowing a language to be passed into `generateEvents` and `EventStream`
* Update `Parser.parse` to pass the second parameter to be passed through to the `TokenMatcher` to avoid having to create a `TokenMatcher` in `generateEvents`
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempting to resolve this issue: https://github.com/cucumber/cucumber-js/issues/929

## How Has This Been Tested?

Added a new test to event_stream. This tests all the changes and  
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
