### PR TITLE
gherkin java: Extended the languages list to include a column with the language name and a column with the native name

### DIFF
--- a/gherkin/java/src/main/java/gherkin/GherkinDialect.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialect.java
@@ -6,20 +6,22 @@ import java.util.Map;
 import java.util.Objects;
 
 public class GherkinDialect {
-    private final Map<String, List<String>> keywords;
+    private final Map<String, Object> dialect;
     private String language;
 
-    public GherkinDialect(String language, Map<String, List<String>> keywords) {
+    public GherkinDialect(String language, Map<String, Object> dialect) {
         this.language = language;
-        this.keywords = keywords;
+        this.dialect = dialect;
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getFeatureKeywords() {
-        return keywords.get("feature");
+        return (List<String>) dialect.get("feature");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getScenarioKeywords() {
-        return keywords.get("scenario");
+        return (List<String>) dialect.get("scenario");
     }
 
     public List<String> getStepKeywords() {
@@ -32,36 +34,44 @@ public class GherkinDialect {
         return result;
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getBackgroundKeywords() {
-        return keywords.get("background");
+        return (List<String>) dialect.get("background");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getScenarioOutlineKeywords() {
-        return keywords.get("scenarioOutline");
+        return (List<String>) dialect.get("scenarioOutline");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getExamplesKeywords() {
-        return keywords.get("examples");
+        return (List<String>) dialect.get("examples");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getGivenKeywords() {
-        return keywords.get("given");
+        return (List<String>) dialect.get("given");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getWhenKeywords() {
-        return keywords.get("when");
+        return (List<String>) dialect.get("when");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getThenKeywords() {
-        return keywords.get("then");
+        return (List<String>) dialect.get("then");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getAndKeywords() {
-        return keywords.get("and");
+        return (List<String>) dialect.get("and");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getButKeywords() {
-        return keywords.get("but");
+        return (List<String>) dialect.get("but");
     }
 
     public String getLanguage() {
@@ -69,11 +79,11 @@ public class GherkinDialect {
     }
 
     public String getName() {
-        return (String) (Object) keywords.get("name");
+        return (String) dialect.get("name");
     }
 
     public String getNativeName() {
-        return (String) (Object) keywords.get("native");
+        return (String) dialect.get("native");
     }
 
     @Override
@@ -81,12 +91,12 @@ public class GherkinDialect {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GherkinDialect that = (GherkinDialect) o;
-        return Objects.equals(keywords, that.keywords) &&
+        return Objects.equals(dialect, that.dialect) &&
                 Objects.equals(language, that.language);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keywords, language);
+        return Objects.hash(dialect, language);
     }
 }

--- a/gherkin/java/src/main/java/gherkin/GherkinDialect.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialect.java
@@ -3,6 +3,7 @@ package gherkin;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class GherkinDialect {
     private final Map<String, List<String>> keywords;
@@ -65,5 +66,27 @@ public class GherkinDialect {
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getName() {
+        return (String) (Object) keywords.get("name");
+    }
+
+    public String getNativeName() {
+        return (String) (Object) keywords.get("native");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GherkinDialect that = (GherkinDialect) o;
+        return Objects.equals(keywords, that.keywords) &&
+                Objects.equals(language, that.language);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keywords, language);
     }
 }

--- a/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -16,7 +17,6 @@ import static java.util.Collections.unmodifiableList;
 public class GherkinDialectProvider implements IGherkinDialectProvider {
     private static Map<String, Map<String, List<String>>> DIALECTS;
     private final String default_dialect_name;
-    final int separation = 5;
 
     static {
         Gson gson = new Gson();
@@ -51,65 +51,24 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     }
 
     @Override
-    public List<String> getLanguages() {
-        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+    public List<GherkinDialect> getDialects() {
+        List<String> languages = new ArrayList<>(DIALECTS.keySet());
         sort(languages);
 
-        int maxKeyLength = getMaxKeyLength();
-        int maxNameLength = getMaxNameLength();
+        List<GherkinDialect> dialects = new LinkedList<>();
 
-        List<String> languagesWithExplanation = new ArrayList<String>();
-        for (String key : languages) {
-            Map<String, List<String>> values = DIALECTS.get(key);
-
-            String name = (String) (Object) values.get("name");
-            String nativeName = (String) (Object) values.get("native");
-
-            String languageWithExplanation = formatLanguage(key, maxKeyLength, name, maxNameLength, nativeName);
-            languagesWithExplanation.add(languageWithExplanation);
+        for (String language : languages) {
+            GherkinDialect dialect = getDialect(language, null);
+            dialects.add(dialect);
         }
 
-        return unmodifiableList(languagesWithExplanation);
+        return dialects;
     }
 
-    int getMaxKeyLength() {
-        int max = 0;
-        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
-
-        for (String key : languages) {
-            if (max < key.length()) {
-                max = key.length();
-            }
-        }
-
-        return max;
-    }
-
-    int getMaxNameLength() {
-        int max = 0;
-        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
-
-        for (String key : languages) {
-            Map<String, List<String>> values = DIALECTS.get(key);
-            String name = (String) (Object) values.get("name");
-
-            if (max < name.length()) {
-                max = name.length();
-            }
-        }
-
-        return max;
-    }
-
-    private String formatLanguage(String key, int maxKeyLength, String name, int maxNameLength, String nativeName) {
-        int keyNameSeparation = maxKeyLength + separation;
-        String result = String.format("%1$-" + keyNameSeparation + "s", key);
-        result += name;
-
-        int nameNativeSeparation = keyNameSeparation + maxNameLength + separation;
-        result = String.format("%1$-" + nameNativeSeparation + "s", result);
-        result += nativeName;
-
-        return result;
+    @Override
+    public List<String> getLanguages() {
+        List<String> languages = new ArrayList<>(DIALECTS.keySet());
+        sort(languages);
+        return unmodifiableList(languages);
     }
 }

--- a/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -54,21 +54,6 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     }
 
     @Override
-    public List<GherkinDialect> getDialects() {
-        List<String> languages = new ArrayList<>(DIALECTS.keySet());
-        sort(languages);
-
-        List<GherkinDialect> dialects = new LinkedList<>();
-
-        for (String language : languages) {
-            GherkinDialect dialect = getDialect(language, null);
-            dialects.add(dialect);
-        }
-
-        return dialects;
-    }
-
-    @Override
     public List<String> getLanguages() {
         List<String> languages = new ArrayList<>(DIALECTS.keySet());
         sort(languages);

--- a/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -16,6 +16,7 @@ import static java.util.Collections.unmodifiableList;
 public class GherkinDialectProvider implements IGherkinDialectProvider {
     private static Map<String, Map<String, List<String>>> DIALECTS;
     private final String default_dialect_name;
+    final int separation = 5;
 
     static {
         Gson gson = new Gson();
@@ -53,6 +54,62 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     public List<String> getLanguages() {
         List<String> languages = new ArrayList<String>(DIALECTS.keySet());
         sort(languages);
-        return unmodifiableList(languages);
+
+        int maxKeyLength = getMaxKeyLength();
+        int maxNameLength = getMaxNameLength();
+
+        List<String> languagesWithExplanation = new ArrayList<String>();
+        for (String key : languages) {
+            Map<String, List<String>> values = DIALECTS.get(key);
+
+            String name = (String) (Object) values.get("name");
+            String nativeName = (String) (Object) values.get("native");
+
+            String languageWithExplanation = formatLanguage(key, maxKeyLength, name, maxNameLength, nativeName);
+            languagesWithExplanation.add(languageWithExplanation);
+        }
+
+        return unmodifiableList(languagesWithExplanation);
+    }
+
+    int getMaxKeyLength() {
+        int max = 0;
+        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+
+        for (String key : languages) {
+            if (max < key.length()) {
+                max = key.length();
+            }
+        }
+
+        return max;
+    }
+
+    int getMaxNameLength() {
+        int max = 0;
+        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+
+        for (String key : languages) {
+            Map<String, List<String>> values = DIALECTS.get(key);
+            String name = (String) (Object) values.get("name");
+
+            if (max < name.length()) {
+                max = name.length();
+            }
+        }
+
+        return max;
+    }
+
+    private String formatLanguage(String key, int maxKeyLength, String name, int maxNameLength, String nativeName) {
+        int keyNameSeparation = maxKeyLength + separation;
+        String result = String.format("%1$-" + keyNameSeparation + "s", key);
+        result += name;
+
+        int nameNativeSeparation = keyNameSeparation + maxNameLength + separation;
+        result = String.format("%1$-" + nameNativeSeparation + "s", result);
+        result += nativeName;
+
+        return result;
     }
 }

--- a/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -2,10 +2,12 @@ package gherkin;
 
 import gherkin.ast.Location;
 import gherkin.deps.com.google.gson.Gson;
+import gherkin.deps.com.google.gson.reflect.TypeToken;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,14 +17,15 @@ import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
 
 public class GherkinDialectProvider implements IGherkinDialectProvider {
-    private static Map<String, Map<String, List<String>>> DIALECTS;
+    private static Map<String, Map<String, Object>> DIALECTS;
     private final String default_dialect_name;
 
     static {
         Gson gson = new Gson();
         try {
             Reader dialects = new InputStreamReader(GherkinDialectProvider.class.getResourceAsStream("/gherkin/gherkin-languages.json"), "UTF-8");
-            DIALECTS = gson.fromJson(dialects, Map.class);
+            Type type = new TypeToken<Map<String, Map<String, Object>>>() {}.getType();
+            DIALECTS = gson.fromJson(dialects, type);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -42,12 +45,12 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
 
     @Override
     public GherkinDialect getDialect(String language, Location location) {
-        Map<String, List<String>> map = DIALECTS.get(language);
-        if (map == null) {
+        Map<String, Object> dialect = DIALECTS.get(language);
+        if (dialect == null) {
             throw new ParserException.NoSuchLanguageException(language, location);
         }
 
-        return new GherkinDialect(language, map);
+        return new GherkinDialect(language, dialect);
     }
 
     @Override

--- a/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
@@ -11,5 +11,9 @@ public interface IGherkinDialectProvider {
 
     List<GherkinDialect> getDialects();
 
+    /**
+     * Use List<GherkinDialect> getDialects() to get all dialects. Extract the language from each dialect.
+     */
+    @Deprecated
     List<String> getLanguages();
 }

--- a/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
@@ -9,11 +9,5 @@ public interface IGherkinDialectProvider {
 
     GherkinDialect getDialect(String language, Location location);
 
-    List<GherkinDialect> getDialects();
-
-    /**
-     * Use List<GherkinDialect> getDialects() to get all dialects. Extract the language from each dialect.
-     */
-    @Deprecated
     List<String> getLanguages();
 }

--- a/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
@@ -9,5 +9,7 @@ public interface IGherkinDialectProvider {
 
     GherkinDialect getDialect(String language, Location location);
 
+    List<GherkinDialect> getDialects();
+
     List<String> getLanguages();
 }

--- a/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
+++ b/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
@@ -24,16 +24,6 @@ public class GherkinDialectProviderTest {
     }
 
     @Test
-    public void should_include_swedish_in_dialects() {
-        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
-        GherkinDialect expected = gherkinDialectProvider.getDialect("sv", null);
-
-        List<GherkinDialect> actual = gherkinDialectProvider.getDialects();
-
-        assertTrue("Swedish with explanation should be available", actual.contains(expected));
-    }
-
-    @Test
     public void should_find_Swedish_in_sv_dialect() {
         GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
         GherkinDialect actual = gherkinDialectProvider.getDialect("sv", null);

--- a/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
+++ b/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import java.util.List;
 
 import static gherkin.SymbolCounter.countSymbols;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -16,23 +18,35 @@ public class GherkinDialectProviderTest {
     }
 
     @Test
-    public void should_include_swedish_in_languages() {
-        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
-        List<String> actual = gherkinDialectProvider.getLanguages();
+    public void should_include_emoij_in_languages() {
+        List<String> languages = new GherkinDialectProvider().getLanguages();
+        assertTrue("Emoij should be available", languages.contains("em"));
+    }
 
-        String expected = getExpected(gherkinDialectProvider);
+    @Test
+    public void should_include_swedish_in_dialects() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        GherkinDialect expected = gherkinDialectProvider.getDialect("sv", null);
+
+        List<GherkinDialect> actual = gherkinDialectProvider.getDialects();
 
         assertTrue("Swedish with explanation should be available", actual.contains(expected));
     }
 
-    private String getExpected(GherkinDialectProvider gherkinDialectProvider) {
-        int keyName = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxKeyLength() - "sv".length();
-        int nameNative = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxNameLength() - "Swedish".length();
+    @Test
+    public void should_find_Swedish_in_sv_dialect() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        GherkinDialect actual = gherkinDialectProvider.getDialect("sv", null);
 
-        return "sv" + rightPad(keyName) + "Swedish" + rightPad(nameNative) + "Svenska";
+        assertThat(actual.getName(), is("Swedish"));
     }
 
-    private String rightPad(int n) {
-        return String.format("%1$-" + n + "s", "");
+    @Test
+    public void should_find_Svenska_in_sv_dialect() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        GherkinDialect actual = gherkinDialectProvider.getDialect("sv", null);
+
+        assertThat(actual.getNativeName(), is("Svenska"));
     }
+
 }

--- a/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
+++ b/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
@@ -2,13 +2,37 @@ package gherkin;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static gherkin.SymbolCounter.countSymbols;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GherkinDialectProviderTest {
     @Test
     public void providesEmojiDialect() {
         GherkinDialect em = new GherkinDialectProvider().getDialect("em", null);
         assertEquals(1, countSymbols(em.getScenarioKeywords().get(0)));
+    }
+
+    @Test
+    public void should_include_swedish_in_languages() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        List<String> actual = gherkinDialectProvider.getLanguages();
+
+        String expected = getExpected(gherkinDialectProvider);
+
+        assertTrue("Swedish with explanation should be available", actual.contains(expected));
+    }
+
+    private String getExpected(GherkinDialectProvider gherkinDialectProvider) {
+        int keyName = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxKeyLength() - "sv".length();
+        int nameNative = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxNameLength() - "Swedish".length();
+
+        return "sv" + rightPad(keyName) + "Swedish" + rightPad(nameNative) + "Svenska";
+    }
+
+    private String rightPad(int n) {
+        return String.format("%1$-" + n + "s", "");
     }
 }


### PR DESCRIPTION
## Summary

I updated the language list to include not just the language code but also the language name in English as well as the native language name.

## Details

The list of languages looked like this:

```
af
am
ar
ast
az
bg
…
```

There are 73 languages supported. It isn't easy to know which language is which.

I extended the list to look like this:

```
af            Afrikaans               Afrikaans
am            Armenian                հայերեն
ar            Arabic                  العربية
ast           Asturian                asturianu
az            Azerbaijani             Azərbaycanca
bg            Bulgarian               български
…
```

## Motivation and Context

This will make it easier to understand what language a language code is supporting.

## How Has This Been Tested?

I added a unit test that verifies that the list contains one row 

```
sv            Swedish                 Svenska
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
