### PR TITLE
gherkin java: Remove unused mockito-all dependency

### DIFF
--- a/gherkin/java/pom.xml
+++ b/gherkin/java/pom.xml
@@ -51,12 +51,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary

mockito, hamcrest and other testing libraries typically provide an
*-all version that also contains their dependencies. This may lead
to class path conflicts. This can be avoided by importing the
indivudual core libraries.

In this case not required as mockito isn't used.