### PR TITLE
cucumber-expressions: Java: Fix for #323 - escaped backslashes

### DIFF
--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
@@ -82,6 +82,13 @@ public class TreeRegexpTest {
     }
 
     @Test
+    public void works_with_escaped_backslash() {
+        TreeRegexp tr = new TreeRegexp("foo\\\\(bar|baz)");
+        Group g = tr.match("foo\\bar");
+        assertEquals(1, g.getChildren().size());
+    }
+
+    @Test
     public void captures_start_and_end() {
         TreeRegexp tr = new TreeRegexp("^the step \"([^\"]*)\" has status \"([^\"]*)\"$");
         Group g = tr.match("the step \"a pending step\" has status \"pending\"");


### PR DESCRIPTION
Fix for #323. Do not merge until all boxes below are ticked.

* [x] Java
* [ ] Ruby
* [ ] JavaScript