### PR TITLE
cucumber-expressions: Allow parentheses to be explicitly escaped

### DIFF
--- a/cucumber-expressions/README.md
+++ b/cucumber-expressions/README.md
@@ -128,6 +128,16 @@ It would also match this text:
 
     I have 42 cucumbers in my belly
 
+If you ever need to match those parentheses literally, you can escape the
+first opening parenthesis with a backslash:
+
+    I have {int} cucumber(s) in my belly \(amazing!)
+
+This expression would match the following examples:
+
+    I have 1 cucumber in my belly (amazing!)
+    I have 42 cucumbers in my belly (amazing!)
+
 ## Alternative text
 
 Sometimes you want to relax your language, to make it flow better. For example:

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -8,7 +8,8 @@ module Cucumber
       # Does not include (){} characters because they have special meaning
       ESCAPE_REGEXP = /([\\^\[$.|?*+\]])/
       PARAMETER_REGEXP = /{([^}]+)}/
-      OPTIONAL_REGEXP = /\(([^)]+)\)/
+      # Parentheses will be double-escaped due to ESCAPE_REGEXP
+      OPTIONAL_REGEXP = /([\\][\\])?\(([^)]+)\)/
       ALTERNATIVE_NON_WHITESPACE_TEXT_REGEXP = /([^\s^\/]+)((\/[^\s^\/]+)+)/
 
       attr_reader :source
@@ -19,10 +20,18 @@ module Cucumber
         regexp = '^'
         match_offset = 0
 
+        # This will cause explicitly-escaped parentheses to be double-escaped
         expression = expression.gsub(ESCAPE_REGEXP, '\\\\\1')
 
         # Create non-capturing, optional capture groups from parenthesis
-        expression = expression.gsub(OPTIONAL_REGEXP, '(?:\1)?')
+        expression = expression.gsub(OPTIONAL_REGEXP) do |match|
+          # look for double-escaped parentheses
+          if $1 == '\\\\'
+            "\\(#{$2}\\)"
+          else
+            "(?:#{$2})?"
+          end
+        end
 
         expression = expression.gsub(ALTERNATIVE_NON_WHITESPACE_TEXT_REGEXP) do |_|
           "(?:#{$1}#{$2.tr('/', '|')})"

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -26,7 +26,7 @@ module Cucumber
       it('matches multiple double quoted strings') do
         expect(match('three {string} and {string} mice', 'three "blind" and "crippled" mice')).to eq(['blind', 'crippled'])
       end
-      
+
       it('matches single quoted string') do
         expect(match('three {string} mice', "three 'blind' mice")).to eq(['blind'])
       end
@@ -53,6 +53,10 @@ module Cucumber
 
       it('matches single quoted string with escaped single quote') do
         expect(match('three {string} mice', "three 'bl\\'nd' mice")).to eq(["bl'nd"])
+      end
+
+      it 'matches escaped parentheses' do
+        expect(match('three \\(exceptionally) {string} mice', 'three (exceptionally) "blind" mice')).to eq(['blind'])
       end
 
       it "matches int" do


### PR DESCRIPTION
## Summary

This allows parentheses to be explicitly escaped in cucumber expressions, so that they can be interpreted literally. This addresses issue #333.

## Details

I changed `OPTIONAL_REGEXP` so that it looks for an optional escape character before the opening parenthesis. If found, the subsequent `gsub` will emit escaped parentheses, rather than the optional group.

It was necessary to look for a _double_-escaped parenthesis, though, because of how the `ESCAPE_REGEXP` was already escaping special characters.

## Motivation and Context

The motivation is described in #333, but to summarize in brief, I am using Cucumber to describe an API in a platform-agnostic manner, for a book I am writing. I am using the Cucumber scenarios to describe function calls, which enclose parameter lists in parentheses. The cucumber expressions were not liking that very much.

## How Has This Been Tested?

I added a spec that matches an expression with escaped parentheses, and showed that the expression was successfully parsed. All other tests continue to be green with this change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

Thank you!