### PR TITLE
Fix default Java parameter types

### DIFF
--- a/cucumber-expressions/README.md
+++ b/cucumber-expressions/README.md
@@ -47,7 +47,7 @@ parameter types are:
 * `{word}`, for example `banana` (but not `banana split`)
 * `{string}`, for example `"bangers"` or `'mash'`. The single/double quotes themselves are removed from the match.
 
-On the JVM, there are additional parameter types for `bigint`, `bigdecimal`,
+On the JVM, there are additional parameter types for `biginteger`, `bigdecimal`,
 `byte`, `short`, `long` and `double`.
 
 ### Custom parameter types {#custom-parameter-types}

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -30,13 +30,13 @@ public class ParameterTypeRegistry {
         NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
         final NumberParser numberParser = new NumberParser(numberFormat);
 
-        defineParameterType(new ParameterType<>("bigint", INTEGER_REGEXPS, BigInteger.class, new SingleTransformer<>(new Function<String, BigInteger>() {
+        defineParameterType(new ParameterType<>("biginteger", INTEGER_REGEXPS, BigInteger.class, new SingleTransformer<>(new Function<String, BigInteger>() {
             @Override
             public BigInteger apply(String s) {
                 return new BigInteger(s);
             }
         }), false, false));
-        defineParameterType(new ParameterType<>("bigdecimal", INTEGER_REGEXPS, BigDecimal.class, new SingleTransformer<>(new Function<String, BigDecimal>() {
+        defineParameterType(new ParameterType<>("bigdecimal", FLOAT_REGEXPS, BigDecimal.class, new SingleTransformer<>(new Function<String, BigDecimal>() {
             @Override
             public BigDecimal apply(String s) {
                 return new BigDecimal(s);
@@ -47,7 +47,7 @@ public class ParameterTypeRegistry {
             public Byte apply(String s) {
                 return Byte.decode(s);
             }
-        }), false, false));
+        }), true, false));
         defineParameterType(new ParameterType<>("short", INTEGER_REGEXPS, Short.class, new SingleTransformer<>(new Function<String, Short>() {
             @Override
             public Short apply(String s) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -15,6 +15,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class CucumberExpressionTest {
+
+    public static final BigDecimal BIG_DECIMAL_PI = BigDecimal.valueOf(31415926535L, 10);
+
     @Test
     public void documents_match_arguments() {
         ParameterTypeRegistry parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
@@ -133,12 +136,12 @@ public class CucumberExpressionTest {
 
     @Test
     public void matches_bigint() {
-        assertEquals(singletonList(BigInteger.ONE), match("{bigint}", BigInteger.ONE.toString()));
+        assertEquals(singletonList(BigInteger.TEN), match("{biginteger}", BigInteger.TEN.toString()));
     }
 
     @Test
     public void matches_bigdecimal() {
-        assertEquals(singletonList(BigDecimal.ONE), match("{bigdecimal}", BigDecimal.ONE.toString()));
+        assertEquals(singletonList(BIG_DECIMAL_PI), match("{bigdecimal}", BIG_DECIMAL_PI.toString()));
     }
 
     @Test

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -25,7 +25,7 @@ public final class DataTableTypeRegistry {
         NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
         final NumberParser numberParser = new NumberParser(numberFormat);
 
-        defineDataTableType(new DataTableType("bigint", BigInteger.class, new TableCellTransformer<BigInteger>() {
+        defineDataTableType(new DataTableType("biginteger", BigInteger.class, new TableCellTransformer<BigInteger>() {
             @Override
             public BigInteger transform(String cell) {
                 return new BigInteger(cell);


### PR DESCRIPTION
## Summary
 * Renames bigint -> biginteger
 * Replaces INTEGER_REGEXPS  -> FLOAT_REGEXPS for bigdecimal
 * Enables snippet generation for bytes

## Motivation and Context

https://github.com/cucumber/cucumber-jvm/pull/1248

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
