### PR TITLE
Exposed name and native name to enable Cucumber-JVM to print the lang…

### DIFF
--- a/gherkin/java/src/main/java/gherkin/GherkinDialect.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialect.java
@@ -3,22 +3,25 @@ package gherkin;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class GherkinDialect {
-    private final Map<String, List<String>> keywords;
+    private final Map<String, Object> dialect;
     private String language;
 
-    public GherkinDialect(String language, Map<String, List<String>> keywords) {
+    public GherkinDialect(String language, Map<String, Object> dialect) {
         this.language = language;
-        this.keywords = keywords;
+        this.dialect = dialect;
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getFeatureKeywords() {
-        return keywords.get("feature");
+        return (List<String>) dialect.get("feature");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getScenarioKeywords() {
-        return keywords.get("scenario");
+        return (List<String>) dialect.get("scenario");
     }
 
     public List<String> getStepKeywords() {
@@ -31,39 +34,69 @@ public class GherkinDialect {
         return result;
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getBackgroundKeywords() {
-        return keywords.get("background");
+        return (List<String>) dialect.get("background");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getScenarioOutlineKeywords() {
-        return keywords.get("scenarioOutline");
+        return (List<String>) dialect.get("scenarioOutline");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getExamplesKeywords() {
-        return keywords.get("examples");
+        return (List<String>) dialect.get("examples");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getGivenKeywords() {
-        return keywords.get("given");
+        return (List<String>) dialect.get("given");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getWhenKeywords() {
-        return keywords.get("when");
+        return (List<String>) dialect.get("when");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getThenKeywords() {
-        return keywords.get("then");
+        return (List<String>) dialect.get("then");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getAndKeywords() {
-        return keywords.get("and");
+        return (List<String>) dialect.get("and");
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getButKeywords() {
-        return keywords.get("but");
+        return (List<String>) dialect.get("but");
     }
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getName() {
+        return (String) dialect.get("name");
+    }
+
+    public String getNativeName() {
+        return (String) dialect.get("native");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GherkinDialect that = (GherkinDialect) o;
+        return Objects.equals(dialect, that.dialect) &&
+                Objects.equals(language, that.language);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dialect, language);
     }
 }

--- a/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -2,11 +2,14 @@ package gherkin;
 
 import gherkin.ast.Location;
 import gherkin.deps.com.google.gson.Gson;
+import gherkin.deps.com.google.gson.reflect.TypeToken;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -14,14 +17,15 @@ import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
 
 public class GherkinDialectProvider implements IGherkinDialectProvider {
-    private static Map<String, Map<String, List<String>>> DIALECTS;
+    private static Map<String, Map<String, Object>> DIALECTS;
     private final String default_dialect_name;
 
     static {
         Gson gson = new Gson();
         try {
             Reader dialects = new InputStreamReader(GherkinDialectProvider.class.getResourceAsStream("/gherkin/gherkin-languages.json"), "UTF-8");
-            DIALECTS = gson.fromJson(dialects, Map.class);
+            Type type = new TypeToken<Map<String, Map<String, Object>>>() {}.getType();
+            DIALECTS = gson.fromJson(dialects, type);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -41,17 +45,32 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
 
     @Override
     public GherkinDialect getDialect(String language, Location location) {
-        Map<String, List<String>> map = DIALECTS.get(language);
-        if (map == null) {
+        Map<String, Object> dialect = DIALECTS.get(language);
+        if (dialect == null) {
             throw new ParserException.NoSuchLanguageException(language, location);
         }
 
-        return new GherkinDialect(language, map);
+        return new GherkinDialect(language, dialect);
+    }
+
+    @Override
+    public List<GherkinDialect> getDialects() {
+        List<String> languages = new ArrayList<>(DIALECTS.keySet());
+        sort(languages);
+
+        List<GherkinDialect> dialects = new LinkedList<>();
+
+        for (String language : languages) {
+            GherkinDialect dialect = getDialect(language, null);
+            dialects.add(dialect);
+        }
+
+        return dialects;
     }
 
     @Override
     public List<String> getLanguages() {
-        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+        List<String> languages = new ArrayList<>(DIALECTS.keySet());
         sort(languages);
         return unmodifiableList(languages);
     }

--- a/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
+++ b/gherkin/java/src/main/java/gherkin/IGherkinDialectProvider.java
@@ -9,5 +9,11 @@ public interface IGherkinDialectProvider {
 
     GherkinDialect getDialect(String language, Location location);
 
+    List<GherkinDialect> getDialects();
+
+    /**
+     * Use List<GherkinDialect> getDialects() to get all dialects. Extract the language from each dialect.
+     */
+    @Deprecated
     List<String> getLanguages();
 }

--- a/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
+++ b/gherkin/java/src/test/java/gherkin/GherkinDialectProviderTest.java
@@ -2,13 +2,40 @@ package gherkin;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static gherkin.SymbolCounter.countSymbols;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GherkinDialectProviderTest {
     @Test
     public void providesEmojiDialect() {
         GherkinDialect em = new GherkinDialectProvider().getDialect("em", null);
         assertEquals(1, countSymbols(em.getScenarioKeywords().get(0)));
+    }
+
+    @Test
+    public void should_include_emoij_in_languages() {
+        List<String> languages = new GherkinDialectProvider().getLanguages();
+        assertTrue("Emoij should be available", languages.contains("em"));
+    }
+
+    @Test
+    public void should_find_Swedish_in_sv_dialect() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        GherkinDialect actual = gherkinDialectProvider.getDialect("sv", null);
+
+        assertThat(actual.getName(), is("Swedish"));
+    }
+
+    @Test
+    public void should_find_Svenska_in_sv_dialect() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        GherkinDialect actual = gherkinDialectProvider.getDialect("sv", null);
+
+        assertThat(actual.getNativeName(), is("Svenska"));
     }
 }


### PR DESCRIPTION
## Summary

Cucumber-JVM can't print the name and native name for a supported language. I exposed two methods in Gherkin so the name and native name can be read from Cucumber-JVM.

## Details

This is the same as the pull request #313 but with only one commit. #313 was a mistake in the sense that it started out with a Gherkin change that made the Java implementation diverge from the other implementations. exposing two methods like this is less intrusive.

## Motivation and Context

This will make it easier to understand what language a language code is supporting.

## How Has This Been Tested?

I added unit tests that veriffies that it is possible to get the name 'Swedish' and the native name 'Svenska'

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
