### PR TITLE
tag-expressions-python: README TWEAKS

### DIFF
--- a/tag-expressions/python/README.md
+++ b/tag-expressions/python/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/cucumber/tag-expressions-python.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-python)
 
-[The docs are here](http://docs.cucumber.io/tag-expressions/)
+[The docs are here](https://docs.cucumber.io/cucumber/api/#tag-expressions)

--- a/tag-expressions/python/README.rst
+++ b/tag-expressions/python/README.rst
@@ -1,6 +1,25 @@
 Cucumber Tag Expressions for Python
 ===============================================================================
 
+
+.. image:: https://img.shields.io/travis/cucumber/tag-expressions-python/master.svg
+    :target: https://travis-ci.org/cucumber/tag-expressions-python
+    :alt: Travis CI Build Status
+
+.. image:: https://img.shields.io/pypi/v/cucumber-tag-expressions.svg
+    :target: https://pypi.python.org/pypi/cucumber-tag-expressions
+    :alt: Latest Version
+
+.. image:: https://img.shields.io/pypi/l/cucumber-tag-expressions.svg
+    :target: https://pypi.python.org/pypi/cucumber-tag-expressions/
+    :alt: License
+
+.. |logo| image:: https://github.com/cucumber-ltd/brand/raw/master/images/png/notm/cucumber-black/cucumber-black-128.png
+
+Cucumber tag-expressions for Python.
+
+|logo|
+
 Cucumber tag-expressions provide readable boolean expressions
 to select features and scenarios marked with tags in Gherkin files
 in an easy way::
@@ -16,4 +35,4 @@ in an easy way::
 
 
 SEE ALSO:
-* `cucumber tag-expressions docs <http://docs.cucumber.io/tag-expressions/>`_
+* `cucumber tag-expressions docs <https://docs.cucumber.io/cucumber/api/#tag-expressions>`_

--- a/tag-expressions/python/tasks/release.py
+++ b/tag-expressions/python/tasks/release.py
@@ -145,6 +145,8 @@ def upload(ctx, repo=None, dry_run=False, skip_existing=False):
     packages = ensure_packages_exist(original_ctx)
     print_packages(packages)
     # ctx.run("twine upload --repository={repo} dist/*".format(repo=repo))
+    # 2018-05-05 WORK-AROUND for new https://pypi.org/:
+    #   twine upload --repository-url=https://upload.pypi.org/legacy /dist/*
     ctx.run("twine upload --repository={repo} {opts} dist/*".format(
             repo=repo, opts=opts))
 


### PR DESCRIPTION
## Summary

README tweaks to publish python package on https://pypi.org

## Details

* Adapt "README.rst" for package registration on new https://pypi.org
  with Cucumber logo and badges

* Correct link to tag-expression docs:
  https://docs.cucumber.io/cucumber/api/#tag-expressions
  (was: http://docs.cucumber.io/tag-expressions/ ; now missing)

OTHERWISE:

* Add note about currently required work-around to publish
  new release packages on https://pypi.org


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Not applicable, text-only w/ correction of broken URLs in documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.