### PR TITLE
Use latest .NET Core SDK in DotNet docker image

### DIFF
--- a/Dockerfile.cucumber-build-dotnet
+++ b/Dockerfile.cucumber-build-dotnet
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-sdk-jessie
+FROM microsoft/dotnet:2.0.7-sdk-2.1.105-jessie
 WORKDIR /app
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb http://download.mono-project.com/repo/debian stable-jessie main" | tee /etc/apt/sources.list.d/mono-official-stable.list


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Together with https://github.com/cucumber/gherkin-dotnet/pull/15 it should fix the .NET build on the monorepo.
Only merge when https://github.com/cucumber/gherkin-dotnet/pull/15 is pulled into monorepo.

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->
Use latest version of .NET Core SDK as of now (2.1.105)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fix the build

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I run the tests locally in docker.
Docker image have to be regenerated and pushed to docker hub.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
