### PR TITLE
datatable: implemented js datatable

### DIFF
--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
@@ -157,7 +157,11 @@ public class DataTableTest {
 
     @Test
     public void empty_subTable_is_empty() {
-        DataTable table = getSimpleTable();
+        List<List<String>> raw = asList(
+                asList("ten", "10", "1"),
+                asList("hundred", "100", "2"),
+                asList("thousand", "1000", "3"));
+        DataTable table = DataTable.create(raw);
 
         DataTable subTable = table.subTable(0, 3, 1, 3);
 
@@ -166,14 +170,6 @@ public class DataTableTest {
         assertEquals(0, subTable.height());
         assertEquals(0, subTable.width());
         assertEquals(emptyList(), subTable.cells());
-    }
-
-    private DataTable getSimpleTable() {
-        List<List<String>> raw = asList(
-                asList("ten", "10", "1"),
-                asList("hundred", "100", "2"),
-                asList("thousand", "1000", "3"));
-        return DataTable.create(raw);
     }
 
     @Test
@@ -229,20 +225,9 @@ public class DataTableTest {
         createSimpleTable().column(-1);
     }
 
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void column_should_throw_for_negative_row_value() {
-        createSimpleTable().column(0).get(-1);
-    }
-
     @Test(expected = IndexOutOfBoundsException.class)
     public void column_should_throw_for_large_column_value() {
         createSimpleTable().column(4);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void column_should_throw_for_large_row_value() {
-        createSimpleTable().column(0).get(4);
     }
 
 

--- a/datatable/javascript/.eslintrc
+++ b/datatable/javascript/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "plugins": [
+    "prettier"
+  ],
+  "rules": {
+    "prettier/prettier": [
+      "error", {"trailingComma": "es5", "singleQuote": true, "semi": false}
+    ]
+  },
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "prettier"
+  ]
+}

--- a/datatable/javascript/.gitignore
+++ b/datatable/javascript/.gitignore
@@ -1,0 +1,8 @@
+.nyc_output
+coverage/
+dist/
+node_modules/
+
+yarn.lock
+npm-debug.log
+package-lock.json

--- a/datatable/javascript/package.json
+++ b/datatable/javascript/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "cucumber-datatable",
+  "version": "0.0.1",
+  "description": "Cucumber DataTable",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "test": "npm run eslint && npm run coverage",
+    "eslint": "eslint src test",
+    "eslint-fix": "eslint --fix src test",
+    "mocha": "mocha",
+    "coverage": "nyc --reporter=html --reporter=text mocha",
+    "build": "babel src --out-dir dist/src",
+    "build-test": "babel test --out-dir dist/test",
+    "mocha-built": "mocha dist/test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cucumber/cucumber-datatable-javascript.git"
+  },
+  "keywords": [
+    "cucumber",
+    "steps",
+    "datatable"
+  ],
+  "author": "Cucumber Limited <cukes@googlegroups.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cucumber/cucumber-expressions-javascript/issues"
+  },
+  "homepage": "https://github.com/cucumber/cucumber-expressions-javascript#readme",
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "eslint": "^4.19.1",
+    "eslint-config-eslint": "^4.0.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.0",
+    "mocha": "^5.0.5",
+    "nyc": "^11.6.0",
+    "prettier": "^1.11.1"
+  },
+  "files": [
+    "*"
+  ],
+  "dependencies": {}
+}

--- a/datatable/javascript/src/data_table.js
+++ b/datatable/javascript/src/data_table.js
@@ -1,0 +1,69 @@
+class DataTable {
+  // TODO: jsdoc
+  // TODO: fail on unequal rows?
+
+  constructor(rawTable) {
+    this._rawTable = rawTable
+  }
+
+  get cells() {
+    return this._rawTable
+  }
+
+  get height() {
+    return this._rawTable.length
+  }
+
+  get width() {
+    return this._rawTable[0].length
+  }
+
+  get isEmpty() {
+    return this.height <= 1 && this.width === 0
+  }
+
+  static create(rawTable) {
+    return new DataTable(rawTable)
+  }
+
+  transpose() {
+    let transposedRaw = this.cells[0].map((col, i) =>
+      this.cells.map(row => row[i])
+    )
+    return DataTable.create(transposedRaw)
+  }
+
+  row(index) {
+    return this.cells[index]
+  }
+
+  rows(fromRow, toRow) {
+    let rows = this.cells.filter((row, rowIndex) => {
+      return rowIndex >= fromRow && (!toRow || rowIndex < toRow)
+    })
+    return DataTable.create(rows)
+  }
+
+  column(index) {
+    return this.cells.map(row => {
+      return row[index]
+    })
+  }
+
+  columns(fromColumn, toColumn) {
+    let columns = this.cells.map(row => {
+      return row.filter((cell, columnIndex) => {
+        return (
+          columnIndex >= fromColumn && (!toColumn || columnIndex < toColumn)
+        )
+      })
+    })
+    return DataTable.create(columns)
+  }
+
+  subTable(fromRow, fromColumn, toRow, toColumn) {
+    return this.rows(fromRow, toRow).columns(fromColumn, toColumn)
+  }
+}
+
+module.exports = DataTable

--- a/datatable/javascript/src/data_table.js
+++ b/datatable/javascript/src/data_table.js
@@ -7,7 +7,7 @@ class DataTable {
   }
 
   get cells() {
-    return this._rawTable
+    return this._rawTable.slice(0)
   }
 
   get height() {
@@ -33,7 +33,15 @@ class DataTable {
     return this.cells[index]
   }
 
+  /**
+   * The table as a 2-D array, without the first row, unless a range is specified
+   * @param {number} fromRow The first row (including).
+   * @param {number} toRow The last row (excluding).
+   */
   rows(fromRow, toRow) {
+    if (typeof fromRow === 'undefined') {
+      fromRow = 1
+    }
     let rows = this.cells.filter((row, rowIndex) => {
       return rowIndex >= fromRow && (!toRow || rowIndex < toRow)
     })
@@ -46,7 +54,15 @@ class DataTable {
     })
   }
 
+  /**
+   * The table as a 2-D array, without the first column, unless a range is specified
+   * @param {number} fromColumn The first column (including).
+   * @param {number} toColumn The last column (excluding).
+   */
   columns(fromColumn, toColumn) {
+    if (typeof fromColumn === 'undefined') {
+      fromColumn = 1
+    }
     let columns = this.cells.map(row => {
       return row.filter((cell, columnIndex) => {
         return (
@@ -59,6 +75,39 @@ class DataTable {
 
   subTable(fromRow, fromColumn, toRow, toColumn) {
     return this.rows(fromRow, toRow).columns(fromColumn, toColumn)
+  }
+
+  /**
+   * @returns  returns an array of objects where each row is converted to an object (column header is the key)
+   */
+  hashes() {
+    const copy = this.cells
+    const keys = copy[0]
+    const values = copy.slice(1)
+
+    return values.map(row => {
+      const obj = {}
+      keys.forEach((key, i) => {
+        obj[key] = row[i]
+      })
+      return obj
+    }, {})
+  }
+
+  /**
+   * @returns the table as a 2-D array
+   */
+  raw() {
+    return this.cells
+  }
+
+  /**
+   * @returns returns an object where each row corresponds to an entry (first column is the key, second column is the value)
+   */
+  rowHash() {
+    return this.cells.reduce((acc, target) => {
+      return Object.assign(acc, { [target[0]]: target[1] })
+    }, {})
   }
 }
 

--- a/datatable/javascript/src/data_table.js
+++ b/datatable/javascript/src/data_table.js
@@ -22,15 +22,11 @@ class DataTable {
     return this.height <= 1 && this.width === 0
   }
 
-  static create(rawTable) {
-    return new DataTable(rawTable)
-  }
-
   transpose() {
     let transposedRaw = this.cells[0].map((col, i) =>
       this.cells.map(row => row[i])
     )
-    return DataTable.create(transposedRaw)
+    return new DataTable(transposedRaw)
   }
 
   row(index) {
@@ -41,7 +37,7 @@ class DataTable {
     let rows = this.cells.filter((row, rowIndex) => {
       return rowIndex >= fromRow && (!toRow || rowIndex < toRow)
     })
-    return DataTable.create(rows)
+    return new DataTable(rows)
   }
 
   column(index) {
@@ -58,7 +54,7 @@ class DataTable {
         )
       })
     })
-    return DataTable.create(columns)
+    return new DataTable(columns)
   }
 
   subTable(fromRow, fromColumn, toRow, toColumn) {

--- a/datatable/javascript/src/data_table.js
+++ b/datatable/javascript/src/data_table.js
@@ -3,7 +3,7 @@ class DataTable {
   // TODO: fail on unequal rows?
 
   constructor(rawTable) {
-    const raw = ignoreEmptyRows(rawTable)
+    const raw = ignoreEmptyRows(requireRectangular(rawTable))
     this._rawTable = raw
   }
 
@@ -164,6 +164,45 @@ class DataTable {
   asLists() {
     return this.cells()
   }
+
+  toString() {
+    function getColumnWidth(table, columnIndex) {
+      return table.column(columnIndex).sort((a, b) => {
+        return b.toString().length - a.toString().length
+      })[0].length
+    }
+
+    function formatCell(cell, columnWidth) {
+      return ` ${cell.toString()}${' '.repeat(
+        columnWidth - cell.toString().length
+      )} |`
+    }
+
+    let table = this
+    return this._rawTable
+      .map(row => {
+        return `|${row
+          .map((cell, colIndex) => {
+            return formatCell(cell, getColumnWidth(table, colIndex))
+          })
+          .join('')}`
+      })
+      .join('\n')
+  }
+}
+
+function requireRectangular(rawTable) {
+  var columns = rawTable[0].length
+  for (var i = 1; i < rawTable.length; i++) {
+    if (columns !== rawTable[i].length) {
+      throw new IllegalArgumentException(
+        `Table is not rectangular: expected ${columns} column(s) but found ${
+          rawTable[i].length
+        }.`
+      )
+    }
+  }
+  return rawTable
 }
 
 function ignoreEmptyRows(rawTable) {
@@ -192,6 +231,13 @@ class IndexOutOfBoundsException extends TypeError {
   constructor() {
     super(...arguments)
     this.name = 'IndexOutOfBounds'
+  }
+}
+
+class IllegalArgumentException extends TypeError {
+  constructor() {
+    super(...arguments)
+    this.name = 'IllegalArgumentException'
   }
 }
 

--- a/datatable/javascript/src/data_table.js
+++ b/datatable/javascript/src/data_table.js
@@ -109,6 +109,15 @@ class DataTable {
       return Object.assign(acc, { [target[0]]: target[1] })
     }, {})
   }
+
+  /**
+   * @returns a flattened array of all cells
+   */
+  flat() {
+    return this.cells.reduce((accumulator, row) => {
+      return accumulator.concat(row)
+    }, [])
+  }
 }
 
 module.exports = DataTable

--- a/datatable/javascript/src/data_table_registry.js
+++ b/datatable/javascript/src/data_table_registry.js
@@ -1,7 +1,19 @@
+const DataTableType = require('./data_table_type')
+const Transformer = require('./transformer')
+
 class DataTableRegistry {
   constructor() {
     this._registry = {}
-    // TODO: built-in types
+
+    let listTransformer = Transformer.list(item => {
+      return item
+    })
+    this.defineDataTableType(new DataTableType('[string]', listTransformer))
+
+    let intlistTransformer = Transformer.list(item => {
+      return parseInt(item)
+    })
+    this.defineDataTableType(new DataTableType('[int]', intlistTransformer))
   }
 
   defineDataTableType(type) {

--- a/datatable/javascript/src/data_table_registry.js
+++ b/datatable/javascript/src/data_table_registry.js
@@ -1,0 +1,18 @@
+class DataTableRegistry {
+  constructor() {
+    this._registry = {}
+    // TODO: built-in types
+  }
+
+  defineDataTableType(type) {
+    if (this._registry[type.identifier])
+      throw new Error(`Data table type already defined: ${type.name}`)
+    this._registry[type.identifier] = type
+  }
+
+  lookupTableTypeByName(identifier) {
+    return this._registry[identifier]
+  }
+}
+
+module.exports = DataTableRegistry

--- a/datatable/javascript/src/data_table_registry.js
+++ b/datatable/javascript/src/data_table_registry.js
@@ -1,16 +1,16 @@
 const DataTableType = require('./data_table_type')
-const Transformer = require('./transformer')
+const DataTableTransformer = require('./data_table_transformer')
 
 class DataTableRegistry {
   constructor() {
     this._registry = {}
 
-    let listTransformer = Transformer.list(item => {
+    let listTransformer = DataTableTransformer.list(item => {
       return item
     })
     this.defineDataTableType(new DataTableType('[string]', listTransformer))
 
-    let intlistTransformer = Transformer.list(item => {
+    let intlistTransformer = DataTableTransformer.list(item => {
       return parseInt(item)
     })
     this.defineDataTableType(new DataTableType('[int]', intlistTransformer))

--- a/datatable/javascript/src/data_table_transformer.js
+++ b/datatable/javascript/src/data_table_transformer.js
@@ -1,4 +1,4 @@
-class Transformer {
+class DataTableTransformer {
   constructor(transformFn) {
     this._transformFn = transformFn
   }
@@ -8,13 +8,13 @@ class Transformer {
   }
 
   static table(transformFn) {
-    return new Transformer(dataTable => {
+    return new DataTableTransformer(dataTable => {
       return transformFn(dataTable)
     })
   }
 
   static cell(transformFn) {
-    return new Transformer(dataTable => {
+    return new DataTableTransformer(dataTable => {
       return dataTable.raw().map(row => {
         return row.map(transformFn)
       })
@@ -22,19 +22,19 @@ class Transformer {
   }
 
   static row(transformFn) {
-    return new Transformer(dataTable => {
+    return new DataTableTransformer(dataTable => {
       return dataTable.raw().map(transformFn)
     })
   }
 
   static entry(transformFn) {
-    return new Transformer(dataTable => {
+    return new DataTableTransformer(dataTable => {
       return dataTable.hashes().map(transformFn)
     })
   }
 
   static list(transformFn) {
-    return new Transformer(dataTable => {
+    return new DataTableTransformer(dataTable => {
       return dataTable.flat().map(cell => {
         return transformFn(cell)
       })
@@ -42,4 +42,4 @@ class Transformer {
   }
 }
 
-module.exports = Transformer
+module.exports = DataTableTransformer

--- a/datatable/javascript/src/data_table_type.js
+++ b/datatable/javascript/src/data_table_type.js
@@ -11,7 +11,7 @@ class DataTableType {
   }
 
   transform(rawTable) {
-    return this._transformer(DataTable.create(rawTable))
+    return this._transformer(new DataTable(rawTable))
   }
 }
 

--- a/datatable/javascript/src/data_table_type.js
+++ b/datatable/javascript/src/data_table_type.js
@@ -1,0 +1,18 @@
+const DataTable = require('../src/data_table')
+
+class DataTableType {
+  constructor(identifier, transformer) {
+    this._id = identifier
+    this._transformer = transformer
+  }
+
+  get identifier() {
+    return this._id
+  }
+
+  transform(rawTable) {
+    return this._transformer(DataTable.create(rawTable))
+  }
+}
+
+module.exports = DataTableType

--- a/datatable/javascript/src/data_table_type.js
+++ b/datatable/javascript/src/data_table_type.js
@@ -11,7 +11,7 @@ class DataTableType {
   }
 
   transform(rawTable) {
-    return this._transformer(new DataTable(rawTable))
+    return this._transformer.transform(new DataTable(rawTable))
   }
 }
 

--- a/datatable/javascript/src/transformer.js
+++ b/datatable/javascript/src/transformer.js
@@ -1,0 +1,37 @@
+class Transformer {
+  constructor(transformFn) {
+    this._transformFn = transformFn
+  }
+
+  transform(dataTable) {
+    return this._transformFn(dataTable)
+  }
+
+  static table(transformFn) {
+    return new Transformer(dataTable => {
+      return transformFn(dataTable)
+    })
+  }
+
+  static cell(transformFn) {
+    return new Transformer(dataTable => {
+      return dataTable.raw().map(row => {
+        return row.map(transformFn)
+      })
+    })
+  }
+
+  static row(transformFn) {
+    return new Transformer(dataTable => {
+      return dataTable.raw().map(transformFn)
+    })
+  }
+
+  static entry(transformFn) {
+    return new Transformer(dataTable => {
+      return dataTable.hashes().map(transformFn)
+    })
+  }
+}
+
+module.exports = Transformer

--- a/datatable/javascript/src/transformer.js
+++ b/datatable/javascript/src/transformer.js
@@ -32,6 +32,14 @@ class Transformer {
       return dataTable.hashes().map(transformFn)
     })
   }
+
+  static list(transformFn) {
+    return new Transformer(dataTable => {
+      return dataTable.flat().map(cell => {
+        return transformFn(cell)
+      })
+    })
+  }
 }
 
 module.exports = Transformer

--- a/datatable/javascript/test/data_table_registry_test.js
+++ b/datatable/javascript/test/data_table_registry_test.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const DataTableRegistry = require('../src/data_table_registry')
+const DataTableType = require('../src/data_table_type')
+
+describe('DataTypeRegistry', () => {
+  let registry
+  let dataTableType
+  beforeEach(() => {
+    registry = new DataTableRegistry()
+    dataTableType = new DataTableType('mytype', rawTable => {
+      return rawTable
+    })
+  })
+
+  it('adds the given type to the registry and can look it up', () => {
+    // initially not there
+    assert.equal(registry.lookupTableTypeByName('mytype'), undefined)
+
+    registry.defineDataTableType(dataTableType)
+    assert.equal(registry.lookupTableTypeByName('mytype'), dataTableType)
+  })
+
+  it('does not allow more than one preferential data table type for each identifier', () => {
+    registry.defineDataTableType(dataTableType)
+    assert.throws(() => {
+      registry.defineDataTableType(dataTableType)
+    }, /already defined/)
+  })
+
+  it('looks up preferential data table type by identifier', () => {})
+
+  describe('built-in types', () => {})
+})

--- a/datatable/javascript/test/data_table_registry_test.js
+++ b/datatable/javascript/test/data_table_registry_test.js
@@ -31,5 +31,30 @@ describe('DataTypeRegistry', () => {
 
   it('looks up preferential data table type by identifier', () => {})
 
-  describe('built-in types', () => {})
+  describe('built-in types', () => {
+    describe('[string]', () => {
+      it('returns a string[] of all cells', () => {
+        const type = registry.lookupTableTypeByName('[string]')
+
+        const xList = [['foo', 'bar', 'baz']]
+        assert.deepEqual(type.transform(xList), ['foo', 'bar', 'baz'])
+
+        const yList = [['foo'], ['bar'], ['baz']]
+        assert.deepEqual(type.transform(yList), ['foo', 'bar', 'baz'])
+      })
+    })
+
+    describe('[int]', () => {
+      it('returns a int[] of all cells', () => {
+        const type = registry.lookupTableTypeByName('[int]')
+
+        const intList = [['0', '1', '2']]
+        assert.deepEqual(type.transform(intList), [0, 1, 2])
+
+        // in NaN == NaN fails, so check it separately
+        const invalidIntList = [['This is not a number']]
+        assert.equal(isNaN(type.transform(invalidIntList)[0]), true)
+      })
+    })
+  })
 })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -5,6 +5,7 @@ const DataTable = require('../src/data_table')
 
 const table2x2 = [['A0', 'A1'], ['B0', 'B1']]
 const table2x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
+const table3x2 = [['A0', 'A1'], ['B0', 'B1'], ['C0', 'C1']]
 const table3x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2'], ['C0', 'C1', 'C2']]
 
 describe('DataTable', () => {
@@ -18,6 +19,11 @@ describe('DataTable', () => {
     describe('cells', () => {
       it('returns the 2d array', () => {
         assert.deepEqual(new DataTable(table2x2).cells, table2x2)
+      })
+      it('returns a copy, not the original array', () => {
+        const datatable = new DataTable(table2x2)
+        datatable.cells = 'mutated'
+        assert.deepEqual(datatable.cells, new DataTable(table2x2).cells)
       })
     })
 
@@ -71,9 +77,14 @@ describe('DataTable', () => {
           table3x3[1],
         ])
       })
-
       it('returns all rows from fromRow if no toRow is specified', () => {
         assert.deepEqual(new DataTable(table3x3).rows(1).cells, [
+          table3x3[1],
+          table3x3[2],
+        ])
+      })
+      it('returns all rows without the first one if no fromRow is specified', () => {
+        assert.deepEqual(new DataTable(table3x3).rows().cells, [
           table3x3[1],
           table3x3[2],
         ])
@@ -97,8 +108,15 @@ describe('DataTable', () => {
           [table3x3[2][1]],
         ])
       })
-      it('returns all rows from fromRow if no toRow is specified', () => {
+      it('returns all columns from fromRow if no toColumn is specified', () => {
         assert.deepEqual(new DataTable(table3x3).columns(1).cells, [
+          [table3x3[0][1], table3x3[0][2]],
+          [table3x3[1][1], table3x3[1][2]],
+          [table3x3[2][1], table3x3[2][2]],
+        ])
+      })
+      it('returns all columns without the first one if no fromColumn is specified', () => {
+        assert.deepEqual(new DataTable(table3x3).columns().cells, [
           [table3x3[0][1], table3x3[0][2]],
           [table3x3[1][1], table3x3[1][2]],
           [table3x3[2][1], table3x3[2][2]],
@@ -112,6 +130,38 @@ describe('DataTable', () => {
           [table3x3[1][0], table3x3[1][1]],
           [table3x3[2][0], table3x3[2][1]],
         ])
+      })
+    })
+
+    describe('raw', () => {
+      it('returns the cells', () => {
+        const datatable = new DataTable(table3x3)
+        assert.deepEqual(datatable.raw(), datatable.cells)
+      })
+    })
+
+    describe('hashes', () => {
+      it('returns an array of objects where the keys are the headers', () => {
+        assert.deepEqual(new DataTable(table3x2).hashes(), [
+          {
+            [table3x2[0][0]]: table3x2[1][0],
+            [table3x2[0][1]]: table3x2[1][1],
+          },
+          {
+            [table3x2[0][0]]: table3x2[2][0],
+            [table3x2[0][1]]: table3x2[2][1],
+          },
+        ])
+      })
+    })
+
+    describe('rowHash', () => {
+      it('returns an object where the keys are the first column', () => {
+        assert.deepEqual(new DataTable(table3x2).rowHash(), {
+          [table3x2[0][0]]: table3x2[0][1],
+          [table3x2[1][0]]: table3x2[1][1],
+          [table3x2[2][0]]: table3x2[2][1],
+        })
       })
     })
   })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -3,177 +3,280 @@
 const assert = require('assert')
 const DataTable = require('../src/data_table')
 
-const table2x2 = [['A0', 'A1'], ['B0', 'B1']]
-const table2x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
-const table3x2 = [['A0', 'A1'], ['B0', 'B1'], ['C0', 'C1']]
-const table3x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2'], ['C0', 'C1', 'C2']]
-
 describe('DataTable', () => {
-  describe('constructor(2dArray)', () => {
-    it('returns a DataTable instance', () => {
-      assert.equal(new DataTable([[]]).constructor, DataTable)
+  describe('empty table', () => {
+    it('is empty', () => {
+      let table = DataTable.emptyDataTable()
+      assert.equal(table.isEmpty, true)
+      // Since javascript doesnt know 2d arrays, its really an array with an empty array in it
+      assert.equal(table.cells().length, 1)
+      assert.equal(table.cells()[0].length, 0)
     })
   })
 
-  describe('properties', () => {
-    describe('cells', () => {
-      it('returns the 2d array', () => {
-        assert.deepEqual(new DataTable(table2x2).cells, table2x2)
-      })
-      it('returns a copy, not the original array', () => {
-        const datatable = new DataTable(table2x2)
-        datatable.cells = 'mutated'
-        assert.deepEqual(datatable.cells, new DataTable(table2x2).cells)
-      })
+  describe('raw', () => {
+    it('should equal raw', () => {
+      const raw = [['hundred', '100'], ['thousand', '1000']]
+      let table = new DataTable(raw)
+      assert.deepEqual(raw, table.cells())
+    })
+  })
+
+  describe('cells', () => {
+    it('should equal raw', () => {
+      const raw = [['hundred', 100], ['thousand', 1000]]
+      let table = new DataTable(raw)
+      assert.deepEqual(raw, table.cells())
+    })
+  })
+
+  describe('cell', () => {
+    it('should get from raw', () => {
+      const raw = [['hundred', 100], ['thousand', 1000]]
+      let table = new DataTable(raw)
+      assert.equal(raw[0][0], table.cell(0, 0))
+      assert.equal(raw[0][1], table.cell(0, 1))
+      assert.equal(raw[1][0], table.cell(1, 0))
+      assert.equal(raw[1][1], table.cell(1, 1))
+    })
+  })
+
+  describe('subtable', () => {
+    it('should view subset of cells', () => {
+      let raw = [
+        ['ten', '10', '1'],
+        ['hundred', '100', '2'],
+        ['thousand', '1000', '3'],
+      ]
+      let table = new DataTable(raw)
+
+      assert.deepEqual(
+        [['ten', '10'], ['hundred', '100']],
+        table.subTable(0, 0, 2, 2).cells()
+      )
+
+      assert.deepEqual(
+        [['100', '2'], ['1000', '3']],
+        table.subTable(1, 1).cells()
+      )
+
+      assert.deepEqual(table.cells(), table.subTable(0, 0).cells())
+
+      assert.deepEqual('ten', table.subTable(0, 0, 3, 3).cell(0, 0))
+      assert.deepEqual('1', table.subTable(0, 0).cell(0, 2))
+      assert.deepEqual('thousand', table.subTable(0, 0, 3, 3).cell(2, 0))
+      assert.deepEqual('3', table.subTable(0, 0).cell(2, 2))
     })
 
-    describe('isEmpty', () => {
-      it('returns true if the table is empty', () => {
-        assert.equal(new DataTable([[]]).isEmpty, true)
-      })
+    it('throws for negative from row', () => {
+      let table = createSimpleTable()
 
-      it('returns false if the table has rows and columns', () => {
-        assert.equal(new DataTable(table2x2).isEmpty, false)
-      })
+      assert.throws(() => {
+        table.subTable(-1, 0, 1, 1)
+      }, 'IndexOutOfBoundsException')
     })
 
-    describe('height', () => {
-      it('returns the number of rows', () => {
-        assert.equal(new DataTable(table2x3).height, 2)
-      })
+    it('throws for negative from column', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, -1, 1, 1)
+      }, 'IndexOutOfBoundsException')
     })
 
-    describe('width', () => {
-      it('returns the number of columns', () => {
-        assert.equal(new DataTable(table2x3).width, 3)
+    it('throws for large to row', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 4, 1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for large to column', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 1, 4)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for invalid from to row', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(2, 0, 1, 1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for invalid from to column', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 2, 1, 1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for negative row', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 1, 1).cell(-1, 0)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for negative column', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 1, 1).cell(0, -1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for large row', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 1, 1).cell(1, 0)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('throws for large column', () => {
+      let table = createSimpleTable()
+
+      assert.throws(() => {
+        table.subTable(0, 0, 1, 1).cell(0, 1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('is empty when empty', () => {
+      const raw = [
+        ['ten', '10', '1'],
+        ['hundred', '100', '2'],
+        ['thousand', '1000', '3'],
+      ]
+      let table = new DataTable(raw)
+
+      let subTable = table.subTable(0, 3, 1, 3)
+
+      assert.deepEqual(DataTable.emptyDataTable(), subTable)
+      assert.equal(subTable.isEmpty, true)
+      assert.equal(subTable.height, 0)
+      assert.equal(subTable.width, 0)
+      assert.deepEqual([[]], subTable.cells())
+    })
+  })
+
+  describe('row', () => {
+    it('gets a row', () => {
+      const raw = [
+        ['ten', '10', '1'],
+        ['hundred', '100', '2'],
+        ['thousand', '1000', '3'],
+      ]
+      let table = new DataTable(raw)
+      assert.deepEqual(raw[2], table.row(2))
+    })
+  })
+
+  describe('rows', () => {
+    it('should view subset of rows', () => {
+      const raw = [['ten', '10'], ['hundred', '100'], ['thousand', '1000']]
+
+      let table = new DataTable(raw)
+
+      assert.deepEqual(
+        [['hundred', '100'], ['thousand', '1000']],
+        table.rows(1).cells()
+      )
+
+      assert.deepEqual([['hundred', '100']], table.rows(1, 2).cells())
+    })
+  })
+
+  function createSimpleTable() {
+    return new DataTable([
+      ['one', 'four', 'seven'],
+      ['4444', '55555', '666666'],
+    ])
+  }
+
+  describe('column', () => {
+    it('should view single column', () => {
+      const raw = [['hundred', '100', '2'], ['thousand', '1000', '3']]
+
+      let table = new DataTable(raw)
+
+      assert.deepEqual(['100', '1000'], table.column(1))
+    })
+
+    it('should throw for negative column value', () => {
+      assert.throws(() => {
+        createSimpleTable().column(-1)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    it('should throw for large column value', () => {
+      assert.throws(() => {
+        createSimpleTable().column(4)
+      }, 'IndexOutOfBoundsException')
+    })
+
+    describe('when transposed', () => {
+      it('should view single row', () => {
+        const raw = [['hundred', '100', '2'], ['thousand', '1000', '3']]
+
+        let table = new DataTable(raw).transpose()
+
+        assert.deepEqual(['thousand', '1000', '3'], table.column(1))
       })
     })
   })
 
-  describe('operations', () => {
-    describe('transpose', () => {
-      it('returns the transposed table, as a DataTable', () => {
-        const datatable = new DataTable([
-          ['A0', 'A1', 'A2'],
-          ['B0', 'B1', 'B2'],
-        ])
-        const transposed = datatable.transpose()
-        assert.deepEqual(transposed.cells, [
-          ['A0', 'B0'],
-          ['A1', 'B1'],
-          ['A2', 'B2'],
-        ])
-      })
-    })
+  describe('columns', () => {
+    it('should view sub table', () => {
+      const raw = [['hundred', '100', '2'], ['thousand', '1000', '3']]
 
-    describe('row(index)', () => {
-      it('returns a single row at the given index', () => {
-        assert.deepEqual(new DataTable(table3x3).row(1), table3x3[1])
-      })
-    })
-    describe('rows(fromRow, toRow)', () => {
-      it('returns table containing the rows between fromRow (inclusive) to toRow (exclusive)', () => {
-        assert.deepEqual(new DataTable(table3x3).rows(1, 2).cells, [
-          table3x3[1],
-        ])
-      })
-      it('returns all rows from fromRow if no toRow is specified', () => {
-        assert.deepEqual(new DataTable(table3x3).rows(1).cells, [
-          table3x3[1],
-          table3x3[2],
-        ])
-      })
-      it('returns all rows without the first one if no fromRow is specified', () => {
-        assert.deepEqual(new DataTable(table3x3).rows().cells, [
-          table3x3[1],
-          table3x3[2],
-        ])
-      })
-    })
+      let table = new DataTable(raw)
 
-    describe('column(index)', () => {
-      it('returns a single column at the given index', () => {
-        assert.deepEqual(new DataTable(table3x3).column(1), [
-          table3x3[0][1],
-          table3x3[1][1],
-          table3x3[2][1],
-        ])
-      })
-    })
-    describe('columns(fromColumn, toColumn)', () => {
-      it('returns table containing the columns between fromColumn (inclusive) to toColumn (exclusive)', () => {
-        assert.deepEqual(new DataTable(table3x3).columns(1, 2).cells, [
-          [table3x3[0][1]],
-          [table3x3[1][1]],
-          [table3x3[2][1]],
-        ])
-      })
-      it('returns all columns from fromRow if no toColumn is specified', () => {
-        assert.deepEqual(new DataTable(table3x3).columns(1).cells, [
-          [table3x3[0][1], table3x3[0][2]],
-          [table3x3[1][1], table3x3[1][2]],
-          [table3x3[2][1], table3x3[2][2]],
-        ])
-      })
-      it('returns all columns without the first one if no fromColumn is specified', () => {
-        assert.deepEqual(new DataTable(table3x3).columns().cells, [
-          [table3x3[0][1], table3x3[0][2]],
-          [table3x3[1][1], table3x3[1][2]],
-          [table3x3[2][1], table3x3[2][2]],
-        ])
-      })
-    })
+      assert.deepEqual([['100', '2'], ['1000', '3']], table.columns(1).cells())
 
-    describe('subTable(fromRow, fromColumn, toRow, toColumn)', () => {
-      it('returns a containing the columns between fromRow and fromColumn (inclusive) to toRow and toColumn (exclusive)', () => {
-        assert.deepEqual(new DataTable(table3x3).subTable(1, 0, 3, 2).cells, [
-          [table3x3[1][0], table3x3[1][1]],
-          [table3x3[2][0], table3x3[2][1]],
-        ])
-      })
+      assert.deepEqual([['100'], ['1000']], table.columns(1, 2).cells())
     })
+  })
 
-    describe('raw', () => {
-      it('returns the cells', () => {
-        const datatable = new DataTable(table3x3)
-        assert.deepEqual(datatable.raw(), datatable.cells)
-      })
+  describe('asLists', () => {
+    it('should equal raw', () => {
+      const raw = [['hundred', 100], ['thousand', 1000]]
+      let table = new DataTable(raw)
+      assert.deepEqual(raw, table.asLists())
     })
+  })
 
-    describe('hashes', () => {
-      it('returns an array of objects where the keys are the headers', () => {
-        assert.deepEqual(new DataTable(table3x2).hashes(), [
-          {
-            [table3x2[0][0]]: table3x2[1][0],
-            [table3x2[0][1]]: table3x2[1][1],
-          },
-          {
-            [table3x2[0][0]]: table3x2[2][0],
-            [table3x2[0][1]]: table3x2[2][1],
-          },
-        ])
-      })
-    })
+  it('empty rows are ignored', () => {
+    const raw = [[], []]
+    let table = new DataTable(raw)
+    assert.equal(table.isEmpty, true)
+    assert.equal(table.height, 0)
+    assert.equal(table.width, 0)
+  })
 
-    describe('rowHash', () => {
-      it('returns an object where the keys are the first column', () => {
-        assert.deepEqual(new DataTable(table3x2).rowHash(), {
-          [table3x2[0][0]]: table3x2[0][1],
-          [table3x2[1][0]]: table3x2[1][1],
-          [table3x2[2][0]]: table3x2[2][1],
-        })
-      })
-    })
+  it('cells should have three columns and two rows', () => {
+    const raw = createSimpleTable().cells()
+    assert.equal(2, raw.length)
+    for (let i = 0; i < raw.length; i++) {
+      assert.equal(3, raw[i].length)
+    }
+  })
 
-    describe('flat', () => {
-      it('returns an flattened, 1D array', () => {
-        assert.deepEqual(new DataTable(table2x2).flat(), [
-          table2x2[0][0],
-          table2x2[0][1],
-          table2x2[1][0],
-          table2x2[1][1],
-        ])
-      })
+  describe('transposed raw', () => {
+    it('should have two columns and three rows', () => {
+      const raw = createSimpleTable()
+        .transpose()
+        .cells()
+      assert.equal(3, raw.length)
+      for (let i = 0; i < raw.length; i++) {
+        assert.equal(2, raw[i].length)
+      }
     })
   })
 })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -279,4 +279,31 @@ describe('DataTable', () => {
       }
     })
   })
+
+  it('can not_support non rectangular tables missing column', () => {
+    assert.throws(() => {
+      var table = [['one', 'four', 'seven'], ['a1', 'a4444'], ['b1']]
+      new DataTable(table)
+    }, 'IndexOutOfBoundsException')
+  })
+
+  it('can not_support non rectangular tables exceeding column', () => {
+    assert.throws(() => {
+      var table = [
+        ['one', 'four', 'seven'],
+        ['a1', 'a4444', 'b7777777', 'zero'],
+      ]
+      DataTable.create(table)
+    }, 'IndexOutOfBoundsException')
+  })
+
+  describe('toString', () => {
+    it('can create table from list of list of string', () => {
+      const table = createSimpleTable()
+      assert.equal(
+        '| one  | four  | seven  |\n| 4444 | 55555 | 666666 |',
+        table.toString()
+      )
+    })
+  })
 })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -164,5 +164,16 @@ describe('DataTable', () => {
         })
       })
     })
+
+    describe('flat', () => {
+      it('returns an flattened, 1D array', () => {
+        assert.deepEqual(new DataTable(table2x2).flat(), [
+          table2x2[0][0],
+          table2x2[0][1],
+          table2x2[1][0],
+          table2x2[1][1],
+        ])
+      })
+    })
   })
 })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -8,38 +8,38 @@ const table2x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
 const table3x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2'], ['C0', 'C1', 'C2']]
 
 describe('DataTable', () => {
-  describe('.create(2dArray)', () => {
+  describe('constructor(2dArray)', () => {
     it('returns a DataTable instance', () => {
-      assert.equal(DataTable.create([[]]).constructor, DataTable)
+      assert.equal(new DataTable([[]]).constructor, DataTable)
     })
   })
 
   describe('properties', () => {
     describe('cells', () => {
       it('returns the 2d array', () => {
-        assert.deepEqual(DataTable.create(table2x2).cells, table2x2)
+        assert.deepEqual(new DataTable(table2x2).cells, table2x2)
       })
     })
 
     describe('isEmpty', () => {
       it('returns true if the table is empty', () => {
-        assert.equal(DataTable.create([[]]).isEmpty, true)
+        assert.equal(new DataTable([[]]).isEmpty, true)
       })
 
       it('returns false if the table has rows and columns', () => {
-        assert.equal(DataTable.create(table2x2).isEmpty, false)
+        assert.equal(new DataTable(table2x2).isEmpty, false)
       })
     })
 
     describe('height', () => {
       it('returns the number of rows', () => {
-        assert.equal(DataTable.create(table2x3).height, 2)
+        assert.equal(new DataTable(table2x3).height, 2)
       })
     })
 
     describe('width', () => {
       it('returns the number of columns', () => {
-        assert.equal(DataTable.create(table2x3).width, 3)
+        assert.equal(new DataTable(table2x3).width, 3)
       })
     })
   })
@@ -47,7 +47,7 @@ describe('DataTable', () => {
   describe('operations', () => {
     describe('transpose', () => {
       it('returns the transposed table, as a DataTable', () => {
-        const datatable = DataTable.create([
+        const datatable = new DataTable([
           ['A0', 'A1', 'A2'],
           ['B0', 'B1', 'B2'],
         ])
@@ -62,18 +62,18 @@ describe('DataTable', () => {
 
     describe('row(index)', () => {
       it('returns a single row at the given index', () => {
-        assert.deepEqual(DataTable.create(table3x3).row(1), table3x3[1])
+        assert.deepEqual(new DataTable(table3x3).row(1), table3x3[1])
       })
     })
     describe('rows(fromRow, toRow)', () => {
       it('returns table containing the rows between fromRow (inclusive) to toRow (exclusive)', () => {
-        assert.deepEqual(DataTable.create(table3x3).rows(1, 2).cells, [
+        assert.deepEqual(new DataTable(table3x3).rows(1, 2).cells, [
           table3x3[1],
         ])
       })
 
       it('returns all rows from fromRow if no toRow is specified', () => {
-        assert.deepEqual(DataTable.create(table3x3).rows(1).cells, [
+        assert.deepEqual(new DataTable(table3x3).rows(1).cells, [
           table3x3[1],
           table3x3[2],
         ])
@@ -82,7 +82,7 @@ describe('DataTable', () => {
 
     describe('column(index)', () => {
       it('returns a single column at the given index', () => {
-        assert.deepEqual(DataTable.create(table3x3).column(1), [
+        assert.deepEqual(new DataTable(table3x3).column(1), [
           table3x3[0][1],
           table3x3[1][1],
           table3x3[2][1],
@@ -91,14 +91,14 @@ describe('DataTable', () => {
     })
     describe('columns(fromColumn, toColumn)', () => {
       it('returns table containing the columns between fromColumn (inclusive) to toColumn (exclusive)', () => {
-        assert.deepEqual(DataTable.create(table3x3).columns(1, 2).cells, [
+        assert.deepEqual(new DataTable(table3x3).columns(1, 2).cells, [
           [table3x3[0][1]],
           [table3x3[1][1]],
           [table3x3[2][1]],
         ])
       })
       it('returns all rows from fromRow if no toRow is specified', () => {
-        assert.deepEqual(DataTable.create(table3x3).columns(1).cells, [
+        assert.deepEqual(new DataTable(table3x3).columns(1).cells, [
           [table3x3[0][1], table3x3[0][2]],
           [table3x3[1][1], table3x3[1][2]],
           [table3x3[2][1], table3x3[2][2]],
@@ -108,10 +108,10 @@ describe('DataTable', () => {
 
     describe('subTable(fromRow, fromColumn, toRow, toColumn)', () => {
       it('returns a containing the columns between fromRow and fromColumn (inclusive) to toRow and toColumn (exclusive)', () => {
-        assert.deepEqual(
-          DataTable.create(table3x3).subTable(1, 0, 3, 2).cells,
-          [[table3x3[1][0], table3x3[1][1]], [table3x3[2][0], table3x3[2][1]]]
-        )
+        assert.deepEqual(new DataTable(table3x3).subTable(1, 0, 3, 2).cells, [
+          [table3x3[1][0], table3x3[1][1]],
+          [table3x3[2][0], table3x3[2][1]],
+        ])
       })
     })
   })

--- a/datatable/javascript/test/data_table_test.js
+++ b/datatable/javascript/test/data_table_test.js
@@ -1,0 +1,118 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const DataTable = require('../src/data_table')
+
+const table2x2 = [['A0', 'A1'], ['B0', 'B1']]
+const table2x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
+const table3x3 = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2'], ['C0', 'C1', 'C2']]
+
+describe('DataTable', () => {
+  describe('.create(2dArray)', () => {
+    it('returns a DataTable instance', () => {
+      assert.equal(DataTable.create([[]]).constructor, DataTable)
+    })
+  })
+
+  describe('properties', () => {
+    describe('cells', () => {
+      it('returns the 2d array', () => {
+        assert.deepEqual(DataTable.create(table2x2).cells, table2x2)
+      })
+    })
+
+    describe('isEmpty', () => {
+      it('returns true if the table is empty', () => {
+        assert.equal(DataTable.create([[]]).isEmpty, true)
+      })
+
+      it('returns false if the table has rows and columns', () => {
+        assert.equal(DataTable.create(table2x2).isEmpty, false)
+      })
+    })
+
+    describe('height', () => {
+      it('returns the number of rows', () => {
+        assert.equal(DataTable.create(table2x3).height, 2)
+      })
+    })
+
+    describe('width', () => {
+      it('returns the number of columns', () => {
+        assert.equal(DataTable.create(table2x3).width, 3)
+      })
+    })
+  })
+
+  describe('operations', () => {
+    describe('transpose', () => {
+      it('returns the transposed table, as a DataTable', () => {
+        const datatable = DataTable.create([
+          ['A0', 'A1', 'A2'],
+          ['B0', 'B1', 'B2'],
+        ])
+        const transposed = datatable.transpose()
+        assert.deepEqual(transposed.cells, [
+          ['A0', 'B0'],
+          ['A1', 'B1'],
+          ['A2', 'B2'],
+        ])
+      })
+    })
+
+    describe('row(index)', () => {
+      it('returns a single row at the given index', () => {
+        assert.deepEqual(DataTable.create(table3x3).row(1), table3x3[1])
+      })
+    })
+    describe('rows(fromRow, toRow)', () => {
+      it('returns table containing the rows between fromRow (inclusive) to toRow (exclusive)', () => {
+        assert.deepEqual(DataTable.create(table3x3).rows(1, 2).cells, [
+          table3x3[1],
+        ])
+      })
+
+      it('returns all rows from fromRow if no toRow is specified', () => {
+        assert.deepEqual(DataTable.create(table3x3).rows(1).cells, [
+          table3x3[1],
+          table3x3[2],
+        ])
+      })
+    })
+
+    describe('column(index)', () => {
+      it('returns a single column at the given index', () => {
+        assert.deepEqual(DataTable.create(table3x3).column(1), [
+          table3x3[0][1],
+          table3x3[1][1],
+          table3x3[2][1],
+        ])
+      })
+    })
+    describe('columns(fromColumn, toColumn)', () => {
+      it('returns table containing the columns between fromColumn (inclusive) to toColumn (exclusive)', () => {
+        assert.deepEqual(DataTable.create(table3x3).columns(1, 2).cells, [
+          [table3x3[0][1]],
+          [table3x3[1][1]],
+          [table3x3[2][1]],
+        ])
+      })
+      it('returns all rows from fromRow if no toRow is specified', () => {
+        assert.deepEqual(DataTable.create(table3x3).columns(1).cells, [
+          [table3x3[0][1], table3x3[0][2]],
+          [table3x3[1][1], table3x3[1][2]],
+          [table3x3[2][1], table3x3[2][2]],
+        ])
+      })
+    })
+
+    describe('subTable(fromRow, fromColumn, toRow, toColumn)', () => {
+      it('returns a containing the columns between fromRow and fromColumn (inclusive) to toRow and toColumn (exclusive)', () => {
+        assert.deepEqual(
+          DataTable.create(table3x3).subTable(1, 0, 3, 2).cells,
+          [[table3x3[1][0], table3x3[1][1]], [table3x3[2][0], table3x3[2][1]]]
+        )
+      })
+    })
+  })
+})

--- a/datatable/javascript/test/data_table_transformer_test.js
+++ b/datatable/javascript/test/data_table_transformer_test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const Transformer = require('../src/transformer')
+const DataTableTransformer = require('../src/data_table_transformer')
 const DataTable = require('../src/data_table')
 
 describe('Transformer', () => {
@@ -9,7 +9,7 @@ describe('Transformer', () => {
 
   describe('Cell Transformer', () => {
     it('applies the given transform function on each cell individually', () => {
-      let transformer = Transformer.cell(cell => {
+      let transformer = DataTableTransformer.cell(cell => {
         return cell.toLowerCase()
       })
       let transformed = transformer.transform(datatable)
@@ -19,7 +19,7 @@ describe('Transformer', () => {
 
   describe('Row Transformer', () => {
     it('applies the given transform function on each row individually', () => {
-      let transformer = Transformer.row(row => {
+      let transformer = DataTableTransformer.row(row => {
         return row.join(',')
       })
       let transformed = transformer.transform(datatable)
@@ -29,7 +29,7 @@ describe('Transformer', () => {
 
   describe('Table Transformer', () => {
     it('applies the given transform function on the entire table', () => {
-      let transformer = Transformer.table(table => {
+      let transformer = DataTableTransformer.table(table => {
         return table.transpose().raw()
       })
       let transformed = transformer.transform(datatable)
@@ -39,7 +39,7 @@ describe('Transformer', () => {
 
   describe('Entry Transformer', () => {
     it('applies the given transform function on each entry (header value) pair', () => {
-      let transformer = Transformer.entry(entry => {
+      let transformer = DataTableTransformer.entry(entry => {
         return entry['A0'] + entry['A1']
       })
       let transformed = transformer.transform(datatable)
@@ -52,7 +52,7 @@ describe('Transformer', () => {
       const xList = [['1', '2', '3']]
       const yList = [['1'], ['2'], ['3']]
 
-      let transformer = Transformer.list(parseInt)
+      let transformer = DataTableTransformer.list(parseInt)
       let transformedX = transformer.transform(new DataTable(xList))
       assert.deepEqual(transformedX, [1, 2, 3])
 

--- a/datatable/javascript/test/data_table_type_test.js
+++ b/datatable/javascript/test/data_table_type_test.js
@@ -20,7 +20,7 @@ describe('DataTableType', () => {
     it('calls the transformer with the DataTable of the given raw data to transform', () => {
       const data = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
       let transformer = DataTableTransformer.table(dataTable => {
-        return dataTable.transpose().cells
+        return dataTable.transpose().cells()
       })
 
       dataTableType = new DataTableType('mytype', transformer)

--- a/datatable/javascript/test/data_table_type_test.js
+++ b/datatable/javascript/test/data_table_type_test.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const DataTableType = require('../src/data_table_type')
+
+describe('DataTableType', () => {
+  let dataTableType
+  beforeEach(() => {
+    dataTableType = new DataTableType('mytype', function() {})
+  })
+
+  describe('properties', () => {
+    it('has an identifier representing the type of data table', () => {
+      assert.equal(dataTableType.identifier, 'mytype')
+    })
+  })
+
+  describe('transform', () => {
+    it('calls the transformer with the DataTable of the given raw data to transform', () => {
+      const data = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
+      let transformer = function(dataTable) {
+        return dataTable.transpose().cells
+      }
+
+      dataTableType = new DataTableType('mytype', transformer)
+      assert.deepEqual(dataTableType.transform(data), [
+        ['A0', 'B0'],
+        ['A1', 'B1'],
+        ['A2', 'B2'],
+      ])
+    })
+  })
+})

--- a/datatable/javascript/test/data_table_type_test.js
+++ b/datatable/javascript/test/data_table_type_test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const DataTableType = require('../src/data_table_type')
+const Transformer = require('../src/transformer')
 
 describe('DataTableType', () => {
   let dataTableType
@@ -18,9 +19,9 @@ describe('DataTableType', () => {
   describe('transform', () => {
     it('calls the transformer with the DataTable of the given raw data to transform', () => {
       const data = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
-      let transformer = function(dataTable) {
+      let transformer = Transformer.table(dataTable => {
         return dataTable.transpose().cells
-      }
+      })
 
       dataTableType = new DataTableType('mytype', transformer)
       assert.deepEqual(dataTableType.transform(data), [

--- a/datatable/javascript/test/data_table_type_test.js
+++ b/datatable/javascript/test/data_table_type_test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert')
 const DataTableType = require('../src/data_table_type')
-const Transformer = require('../src/transformer')
+const DataTableTransformer = require('../src/data_table_transformer')
 
 describe('DataTableType', () => {
   let dataTableType
@@ -19,7 +19,7 @@ describe('DataTableType', () => {
   describe('transform', () => {
     it('calls the transformer with the DataTable of the given raw data to transform', () => {
       const data = [['A0', 'A1', 'A2'], ['B0', 'B1', 'B2']]
-      let transformer = Transformer.table(dataTable => {
+      let transformer = DataTableTransformer.table(dataTable => {
         return dataTable.transpose().cells
       })
 

--- a/datatable/javascript/test/transformer_test.js
+++ b/datatable/javascript/test/transformer_test.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const Transformer = require('../src/transformer')
+const DataTable = require('../src/data_table')
+
+describe('Transformer', () => {
+  const datatable = new DataTable([['A0', 'A1'], ['B0', 'B1']])
+
+  describe('Cell Transformer', () => {
+    it('applies the given transform function on each cell individually', () => {
+      let transformer = Transformer.cell(cell => {
+        return cell.toLowerCase()
+      })
+      let transformed = transformer.transform(datatable)
+      assert.deepEqual(transformed, [['a0', 'a1'], ['b0', 'b1']])
+    })
+  })
+
+  describe('Row Transformer', () => {
+    it('applies the given transform function on each row individually', () => {
+      let transformer = Transformer.row(row => {
+        return row.join(',')
+      })
+      let transformed = transformer.transform(datatable)
+      assert.deepEqual(transformed, ['A0,A1', 'B0,B1'])
+    })
+  })
+
+  describe('Table Transformer', () => {
+    it('applies the given transform function on the entire table', () => {
+      let transformer = Transformer.table(table => {
+        return table.transpose().raw()
+      })
+      let transformed = transformer.transform(datatable)
+      assert.deepEqual(transformed, [['A0', 'B0'], ['A1', 'B1']])
+    })
+  })
+
+  describe('Entry Transformer', () => {
+    it('applies the given transform function on each entry (header value) pair', () => {
+      let transformer = Transformer.entry(entry => {
+        return entry['A0'] + entry['A1']
+      })
+      let transformed = transformer.transform(datatable)
+      assert.deepEqual(transformed, ['B0B1'])
+    })
+  })
+})

--- a/datatable/javascript/test/transformer_test.js
+++ b/datatable/javascript/test/transformer_test.js
@@ -46,4 +46,18 @@ describe('Transformer', () => {
       assert.deepEqual(transformed, ['B0B1'])
     })
   })
+
+  describe('List Transformer', () => {
+    it('applies the given transform function on then entire, but flattened table', () => {
+      const xList = [['1', '2', '3']]
+      const yList = [['1'], ['2'], ['3']]
+
+      let transformer = Transformer.list(parseInt)
+      let transformedX = transformer.transform(new DataTable(xList))
+      assert.deepEqual(transformedX, [1, 2, 3])
+
+      let transformedY = transformer.transform(new DataTable(yList))
+      assert.deepEqual(transformedY, [1, 2, 3])
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Bringing the ability to define custom datatables to js. 

## Details
Before we're getting into details, I'd like to point this out: 
There's a lot of duplication with parameter type registry (in cucumber-expressions).
Ideally, I'd want to predefine some types, likes `[int]`... but that requires the paramter type registry.
Shouldn't we just build this at the same place the parameter type registry is? (move parameters out of expressions?)
Shouldn't it just they both just be the same registry?
@aslakhellesoy @mpkorstanje 

When we do get into details:
There's some things to be aware of / TODOs
- Its my first (real) commit: dont hold back on your comments, I likely messed up a lot
- Although I wrote tests before code, I didnt consider many edge cases yet, at least should do some parameter checks.
- I pretty much ignored any kind of CI for now
- I haven't really looked at how this ties into `cucumber-js` yet
- I did not look into a general (for all languages) DataTable test set, nor writing documentation

## Motivation and Context
conversation started here: https://cucumberbdd.slack.com/archives/C6QJ6N695/p1525332789000331

## How Has This Been Tested?
Merely unit tests - not even sure if I built the right thing (see above)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
