### PR TITLE
[wip] gherkin-pretty: create CLI to format Gherkin AST

### DIFF
--- a/gherkin/go/ast.go
+++ b/gherkin/go/ast.go
@@ -1,5 +1,10 @@
 package gherkin
 
+import (
+	"strings"
+	"regexp"
+)
+
 type Location struct {
 	Line   int `json:"line"`
 	Column int `json:"column"`
@@ -18,8 +23,13 @@ type GherkinDocument struct {
 
 type Description string
 
+var reWhitespace = regexp.MustCompile("\n *")
+
 func (d Description) String() string {
-	return string(d)
+	s := string(d)
+	s = strings.Trim(s, " ")
+	s = reWhitespace.ReplaceAllString(s, "\n" + TwoSpaces)
+	return TwoSpaces + s
 }
 
 type Feature struct {
@@ -68,7 +78,7 @@ type Examples struct {
 	Tags        []*Tag      `json:"tags"`
 	Keyword     string      `json:"keyword"`
 	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
+	Description Description `json:"description,omitempty"`
 	TableHeader *TableRow   `json:"tableHeader,omitempty"`
 	TableBody   []*TableRow `json:"tableBody"`
 }
@@ -82,6 +92,18 @@ type TableRow struct {
 	Cells []*TableCell `json:"cells"`
 }
 
+func (tr *TableRow) String() string {
+	b := strings.Builder{}
+	b.WriteString(SixSpaces)
+	b.WriteString("|")
+	for _, td := range tr.Cells {
+		b.WriteString(" ")
+		b.WriteString(td.Value)
+		b.WriteString(" |")
+	}
+	return b.String()
+}
+
 type TableCell struct {
 	Node
 	Value string `json:"value"`
@@ -89,10 +111,10 @@ type TableCell struct {
 
 type ScenarioDefinition struct {
 	Node
-	Keyword     string  `json:"keyword"`
-	Name        string  `json:"name"`
-	Description string  `json:"description,omitempty"`
-	Steps       []*Step `json:"steps"`
+	Keyword     string      `json:"keyword"`
+	Name        string      `json:"name"`
+	Description Description `json:"description,omitempty"`
+	Steps       []*Step     `json:"steps"`
 }
 
 func (s *ScenarioDefinition) String() string {

--- a/gherkin/go/ast.go
+++ b/gherkin/go/ast.go
@@ -16,14 +16,24 @@ type GherkinDocument struct {
 	Comments []*Comment `json:"comments"`
 }
 
+type Description string
+
+func (d Description) String() string {
+	return string(d)
+}
+
 type Feature struct {
 	Node
 	Tags        []*Tag        `json:"tags"`
 	Language    string        `json:"language,omitempty"`
 	Keyword     string        `json:"keyword"`
 	Name        string        `json:"name"`
-	Description string        `json:"description,omitempty"`
+	Description Description   `json:"description,omitempty"`
 	Children    []interface{} `json:"children"`
+}
+
+func (f *Feature) String() string {
+	return f.Keyword
 }
 
 type Comment struct {
@@ -63,6 +73,10 @@ type Examples struct {
 	TableBody   []*TableRow `json:"tableBody"`
 }
 
+func (e *Examples) String() string {
+	return TwoSpaces + e.Keyword
+}
+
 type TableRow struct {
 	Node
 	Cells []*TableCell `json:"cells"`
@@ -81,11 +95,19 @@ type ScenarioDefinition struct {
 	Steps       []*Step `json:"steps"`
 }
 
+func (s *ScenarioDefinition) String() string {
+	return TwoSpaces + s.Keyword
+}
+
 type Step struct {
 	Node
 	Keyword  string      `json:"keyword"`
 	Text     string      `json:"text"`
 	Argument interface{} `json:"argument,omitempty"`
+}
+
+func (s *Step) String() string {
+	return FourSpaces + s.Keyword + s.Text
 }
 
 type DocString struct {
@@ -99,3 +121,7 @@ type DataTable struct {
 	Node
 	Rows []*TableRow `json:"rows"`
 }
+
+const TwoSpaces = "  "
+const FourSpaces = "    "
+const SixSpaces = TwoSpaces + FourSpaces

--- a/gherkin/go/ast_test.go
+++ b/gherkin/go/ast_test.go
@@ -7,46 +7,31 @@ import (
 	"github.com/cucumber/cucumber/gherkin/go"
 )
 
-func Test_ltr_line_identation(t *testing.T) {
+func Test_line_indentation(t *testing.T) {
 	td := []struct {
-		s fmt.Stringer
+		fmt.Stringer
 		expected string
 		desc string
 	}{
-		{feature("Feature", "Example token used multiple times"), "Feature", "feature line should not be indented"},
-		{step("Given ", "the minimalism inside a background"), "    Given", "step should have 4 space indent"},
-		{example("Examples"), "  Examples", "examples line should have 2 spaces of indent"},
 		{background("Background"), "  Background", "background line should have 2 spaces of indent"},
+		{feature("Feature", "Example token used multiple times"), "Feature", "feature line should not be indented"},
+		{description("Hello world"), "  Hello world", "1 line description should have 2 spaces of indent"},
+		{description("Hello\nworld"), "  Hello\n  world", "multi-line description should have 2 spaces of indent on each line"},
+		{description(" Hello\n world"), "  Hello\n  world", "multi-line description with existing indent should have 2 spaces of indent on each line"},
+		{example("Examples"), "  Examples", "examples line should have 2 spaces of indent"},
 		{scenario("Scenario"), "  Scenario", "scenario line should have 2 spaces of indent"},
 		{scenarioOutline("Scenario Outline"), "  Scenario Outline", "scenario outline line should have 2 spaces of indent"},
+		{step("Given ", "the minimalism inside a background"), "    Given", "step should have 4 spaces indent"},
+		{tableRow("hello", "world"), "      | hello | world |", "table row should have 6 spaces indent"},
 	}
 
 	for _, tt := range td {
 		t.Run(tt.desc, func(t *testing.T) {
-			actual := tt.s.String()
+			actual := tt.String()
 			if !strings.HasPrefix(actual, tt.expected) {
 				pos := len(tt.expected)
-				if pos > len(actual) {
-					pos = len(actual)
-				}
-				t.Errorf("got prefix='%s', want '%v'", actual[:pos], tt.expected)
+				t.Errorf("got prefix='%s', want '%v'", truncate(actual, pos), tt.expected)
 			}
-		})
-	}
-}
-
-func Test_ltr_block_indentation(t *testing.T) {
-	t.Skip("WIP")
-	td := []struct {
-		s fmt.Stringer
-		expected string
-		desc string
-	}{
-		{},
-	}
-
-	for _, tt := range td {
-		t.Run(tt.desc, func(t *testing.T){
 		})
 	}
 }
@@ -56,6 +41,10 @@ func background(keyword string) *gherkin.Background {
 	b.Keyword = keyword
 	b.Type = "Background"
 	return b
+}
+
+func description(desc string) gherkin.Description {
+	return gherkin.Description(desc)
 }
 
 func feature(keyword, name string) *gherkin.Feature {
@@ -100,5 +89,32 @@ func step(keyword, text string) *gherkin.Step{
 	s.Type = "Step"
 
 	return s
+}
+
+func tableCell(v string) *gherkin.TableCell {
+	td := &gherkin.TableCell{
+		Value: v,
+	}
+	td.Type = "TableCell"
+	return td
+}
+
+func tableRow(vals ...string) *gherkin.TableRow {
+	r := &gherkin.TableRow{}
+	r.Type = "TableRow"
+	for _, v := range vals {
+		r.Cells = append(r.Cells, tableCell(v))
+	}
+
+	return r
+}
+
+func truncate(s string, pos int) string {
+	l := len(s)
+	if pos > l {
+		pos = l
+	}
+
+	return s[:pos]
 }
 

--- a/gherkin/go/ast_test.go
+++ b/gherkin/go/ast_test.go
@@ -1,0 +1,104 @@
+package gherkin_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"github.com/cucumber/cucumber/gherkin/go"
+)
+
+func Test_ltr_line_identation(t *testing.T) {
+	td := []struct {
+		s fmt.Stringer
+		expected string
+		desc string
+	}{
+		{feature("Feature", "Example token used multiple times"), "Feature", "feature line should not be indented"},
+		{step("Given ", "the minimalism inside a background"), "    Given", "step should have 4 space indent"},
+		{example("Examples"), "  Examples", "examples line should have 2 spaces of indent"},
+		{background("Background"), "  Background", "background line should have 2 spaces of indent"},
+		{scenario("Scenario"), "  Scenario", "scenario line should have 2 spaces of indent"},
+		{scenarioOutline("Scenario Outline"), "  Scenario Outline", "scenario outline line should have 2 spaces of indent"},
+	}
+
+	for _, tt := range td {
+		t.Run(tt.desc, func(t *testing.T) {
+			actual := tt.s.String()
+			if !strings.HasPrefix(actual, tt.expected) {
+				pos := len(tt.expected)
+				if pos > len(actual) {
+					pos = len(actual)
+				}
+				t.Errorf("got prefix='%s', want '%v'", actual[:pos], tt.expected)
+			}
+		})
+	}
+}
+
+func Test_ltr_block_indentation(t *testing.T) {
+	t.Skip("WIP")
+	td := []struct {
+		s fmt.Stringer
+		expected string
+		desc string
+	}{
+		{},
+	}
+
+	for _, tt := range td {
+		t.Run(tt.desc, func(t *testing.T){
+		})
+	}
+}
+
+func background(keyword string) *gherkin.Background {
+	b := &gherkin.Background{}
+	b.Keyword = keyword
+	b.Type = "Background"
+	return b
+}
+
+func feature(keyword, name string) *gherkin.Feature {
+	f := &gherkin.Feature{
+		Keyword: keyword,
+		Name: name,
+	}
+	f.Type = "Feature"
+	return f
+}
+
+func example(keyword string) *gherkin.Examples {
+	e := &gherkin.Examples{
+		Keyword: keyword,
+	}
+	e.Type = "Examples"
+
+	return e
+}
+
+func scenario(keyword string) *gherkin.Scenario {
+	s := &gherkin.Scenario{}
+	s.Keyword = keyword
+	s.Type = "Scenario"
+	return s
+}
+
+func scenarioOutline(keyword string) *gherkin.ScenarioOutline {
+	so := &gherkin.ScenarioOutline {
+
+	}
+	so.Keyword = keyword
+	so.Type = "Scenario Outline"
+	return so
+}
+
+func step(keyword, text string) *gherkin.Step{
+	s := &gherkin.Step{
+		Keyword: keyword,
+		Text: text,
+	}
+	s.Type = "Step"
+
+	return s
+}
+

--- a/gherkin/go/astbuilder.go
+++ b/gherkin/go/astbuilder.go
@@ -179,7 +179,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 		bg.Location = astLocation(backgroundLine)
 		bg.Keyword = backgroundLine.Keyword
 		bg.Name = backgroundLine.Text
-		bg.Description = description
+		bg.Description = Description(description)
 		bg.Steps = astSteps(node)
 		return bg, nil
 
@@ -195,7 +195,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 			sc.Location = astLocation(scenarioLine)
 			sc.Keyword = scenarioLine.Keyword
 			sc.Name = scenarioLine.Text
-			sc.Description = description
+			sc.Description = Description(description)
 			sc.Steps = astSteps(scenarioNode)
 			return sc, nil
 		} else {
@@ -211,7 +211,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 			sc.Location = astLocation(scenarioOutlineLine)
 			sc.Keyword = scenarioOutlineLine.Keyword
 			sc.Name = scenarioOutlineLine.Text
-			sc.Description = description
+			sc.Description = Description(description)
 			sc.Steps = astSteps(scenarioOutlineNode)
 			sc.Examples = astExamples(scenarioOutlineNode)
 			return sc, nil
@@ -230,7 +230,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 		ex.Location = astLocation(examplesLine)
 		ex.Keyword = examplesLine.Keyword
 		ex.Name = examplesLine.Text
-		ex.Description = description
+		ex.Description = Description(description)
 		ex.TableHeader = nil
 		ex.TableBody = nil
 		if examplesTable != nil {
@@ -282,7 +282,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 		feat.Language = featureLine.GherkinDialect
 		feat.Keyword = featureLine.Keyword
 		feat.Name = featureLine.Text
-		feat.Description = description
+		feat.Description = Description(description)
 		feat.Children = children
 		return feat, nil
 


### PR DESCRIPTION
## Summary

Implement standardised output of Gherkin AST into feature files.

## Details

- Add stringer to AST structs.
- Implement CLI main to consume a stream of Gherkin AST and write to disk as required.

## Motivation and Context

Provide standardised and consistent formatting of feature files.

## How Has This Been Tested?

Creating unit tests with the scenarios outlined in #384.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] TBD - I have updated the documentation accordingly.
