### PR TITLE
datatable: Automatic list conversion

### DIFF
--- a/datatable/README.md
+++ b/datatable/README.md
@@ -155,7 +155,20 @@ domain. Doing this has the following benefits:
 2. Document and evolve your ubiquitous domain language
 3. Enforce certain patterns
 
-A custom table type can be registered as follows:
+There are two helpers for defining custom table types:
+
+```java
+// Defines a DataTableType` that converts an entry (map of header name to row value) 
+// to an object, using reflection.
+registry.defineDataTableType(DataTableType#entry(Class))
+
+// Defines a DataTableType that converts a single cell
+// to an object, by calling its `String` constructor (if it exists).
+registry.defineDataTableType(DataTableType#cell(Class))
+```
+
+In cases where these two reflection based helpers are insufficient,
+a custom table type can be registered as follows:
 
 ```java
 registry.defineDataTableType(
@@ -204,6 +217,13 @@ represent geolocations. Airports are represented by `Airport(code:String)`.
 ```
 
 By registering two table types:
+
+```java
+registry.defineDataTableType(DataTableType.cell(Airport.class));
+registry.defineDataTableType(DataTableType.entry(Geolocation.class));
+```
+
+Alternatively, you can implement your own types if you need more control:
 
 ```java
 registry.defineDataTableType(

--- a/datatable/README.md
+++ b/datatable/README.md
@@ -158,7 +158,7 @@ domain. Doing this has the following benefits:
 There are two helpers for defining custom table types:
 
 ```java
-// Defines a DataTableType` that converts an entry (map of header name to row value) 
+// Defines a DataTableType that converts an entry (map of header name to row value) 
 // to an object, using reflection.
 registry.defineDataTableType(DataTableType#entry(Class))
 

--- a/datatable/java/README.md
+++ b/datatable/java/README.md
@@ -63,5 +63,6 @@ IntelliJ IDEA also doesn't know how to handle the shaded pom
 
 0. `mvn install`
 1. Open the 'Maven Projects' tool window. 
-2. Choose "Shaded DataTable Dependencies" -> "Ignore Project". 
-3. Select the top level `pom.xml` and choose "Maven" -> "Reimport".
+2. Choose "Shaded DataTable Dependencies" -> "Ignore Projects". 
+3. Open Project Structure, choose the "DataTable" module, add jars, select dependencies/datatable-dependencies-....jar
+4. Select the top level `pom.xml` and choose "Maven" -> "Reimport".

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTable.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTable.java
@@ -19,7 +19,7 @@ import static java.util.Collections.unmodifiableMap;
 
 /**
  * A m-by-n table of string values. For example:
- * <p>
+ *
  * <pre>
  * |     | firstName   | lastName | birthDate  |
  * | 4a1 | Annie M. G. | Schmidt  | 1911-03-20 |
@@ -28,12 +28,12 @@ import static java.util.Collections.unmodifiableMap;
  * <p>
  * A table is either empty or  contains one or more cells. As
  * such if a table has zero height it must have zero width and
- * vise versa.
+ * vice versa.
  * <p>
  * The first row of the the table may be referred to as the
  * table header. The remaining cells as the table body.
  * <p>
- * A table can be converted into an objects of an arbitrary
+ * A table can be converted into an object of an arbitrary
  * type by a {@link TableConverter}. A table created without
  * a table converter will throw a {@link NoConverterDefined}
  * exception when doing so.
@@ -67,7 +67,7 @@ public final class DataTable {
      * <p>
      *
      * @param raw the underlying table
-     * @return an new data table containing the raw values
+     * @return a new data table containing the raw values
      * @throws NullPointerException     if raw is null
      * @throws IllegalArgumentException when the table is not rectangular or contains null values.
      */
@@ -80,14 +80,13 @@ public final class DataTable {
      *
      * @param raw            the underlying table
      * @param tableConverter to transform the table
-     * @return an new data table containing the raw values
+     * @return a new data table containing the raw values
      * @throws NullPointerException     if either raw or tableConverter is null
      * @throws IllegalArgumentException when the table is not rectangular or contains null values
      */
     public static DataTable create(List<List<String>> raw, TableConverter tableConverter) {
         return new DataTable(copy(requireNonNullEntries(requireRectangularTable(raw))), tableConverter);
     }
-
 
     private static List<List<String>> copy(List<List<String>> balanced) {
         List<List<String>> rawCopy = new ArrayList<>(balanced.size());
@@ -103,7 +102,6 @@ public final class DataTable {
         }
         return unmodifiableList(rawCopy);
     }
-
 
     private static List<List<String>> requireNonNullEntries(List<List<String>> raw) {
         // Iterate in case of linked list.
@@ -148,7 +146,7 @@ public final class DataTable {
     public void diff(DataTable actual) throws TableDiffException {
         TableDiffer tableDiffer = new TableDiffer(this, actual);
         DataTableDiff dataTableDiff = tableDiffer.calculateDiffs();
-        if(!dataTableDiff.isEmpty()) {
+        if (!dataTableDiff.isEmpty()) {
             throw TableDiffException.diff(dataTableDiff);
         }
     }
@@ -162,7 +160,7 @@ public final class DataTable {
     public void unorderedDiff(DataTable actual) throws TableDiffException {
         TableDiffer tableDiffer = new TableDiffer(this, actual);
         DataTableDiff dataTableDiff = tableDiffer.calculateUnorderedDiffs();
-        if(!dataTableDiff.isEmpty()) {
+        if (!dataTableDiff.isEmpty()) {
             throw TableDiffException.diff(dataTableDiff);
         }
     }
@@ -526,7 +524,7 @@ public final class DataTable {
 
     /**
      * Returns a transposed view on this table. Example:
-     * <p>
+     *
      * <pre>
      *    | a | 7 | 4 |
      *    | b | 9 | 2 |
@@ -602,7 +600,7 @@ public final class DataTable {
          * A table converter may either map each row or each individual cell to a list element.
          * <p>
          * For example:
-         * <p>
+         *
          * <pre>
          * | Annie M. G. Schmidt | 1911-03-20 |
          * | Roald Dahl          | 1916-09-13 |
@@ -620,7 +618,7 @@ public final class DataTable {
          * </pre>
          * <p>
          * can become:
-         * <p>
+         *
          * <pre>
          * [
          *   Author[ name: Annie M. G. Schmidt, birthDate: 1911-03-20 ],
@@ -629,7 +627,7 @@ public final class DataTable {
          * </pre>
          * <p>
          * Likewise:
-         * <p>
+         *
          * <pre>
          *  | firstName   | lastName | birthDate  |
          *  | Annie M. G. | Schmidt  | 1911-03-20 |
@@ -657,7 +655,7 @@ public final class DataTable {
          * Each row maps to a list, each table cell a list entry.
          * <p>
          * For example:
-         * <p>
+         *
          * <pre>
          * | Annie M. G. Schmidt | 1911-03-20 |
          * | Roald Dahl          | 1916-09-13 |
@@ -686,7 +684,7 @@ public final class DataTable {
          * the values.
          * <p>
          * For example:
-         * <p>
+         *
          * <pre>
          * | 4a1 | Annie M. G. Schmidt | 1911-03-20 |
          * | c92 | Roald Dahl          | 1916-09-13 |
@@ -705,7 +703,7 @@ public final class DataTable {
          * left blank.
          * <p>
          * For example:
-         * <p>
+         *
          * <pre>
          * |     | firstName   | lastName | birthDate  |
          * | 4a1 | Annie M. G. | Schmidt  | 1911-03-20 |
@@ -735,7 +733,7 @@ public final class DataTable {
          * Each map represents a row in the table. The map keys are the column headers.
          * <p>
          * For example:
-         * <p>
+         *
          * <pre>
          * | firstName   | lastName | birthDate  |
          * | Annie M. G. | Schmidt  | 1911-03-20 |

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
@@ -64,7 +64,7 @@ public final class DataTableType {
      * @param type        the type of the list items
      * @param transformer a function that creates an instance of <code>type</code> from the data table entry
      * @param <T>         see <code>type</code>
-     * @see DataTableType#listOf(Class)
+     * @see DataTableType#entry(Class)
      */
     public <T> DataTableType(Class<T> type, TableEntryTransformer<T> transformer) {
         this(type, aListOf(type), new TableEntryTransformerAdaptor<>(transformer));
@@ -87,10 +87,10 @@ public final class DataTableType {
      * <p>
      * The class needs an empty constructor, and fields must have public setters (or the fields themselves must be public).
      *
-     * @param type the type of the list of lists items
+     * @param type the type of the entry
      * @param <T>  see <code>type</code>
      */
-    public static <T> DataTableType listOf(final Class<T> type) {
+    public static <T> DataTableType entry(final Class<T> type) {
         return new DataTableType(type, new TableEntryTransformer<T>() {
             @Override
             public T transform(Map<String, String> entry) {
@@ -100,7 +100,15 @@ public final class DataTableType {
         });
     }
 
-    public static <T> DataTableType stringWrapper(final Class<T> type) {
+    /**
+     * Creates a data table type that transforms individual cells to another type, calling the type's
+     * String constructor.
+     *
+     * @param type the type of the cell
+     * @param <T> see <code>type</code>
+     * @throws CucumberDataTableException if <code>type</code> does not has a public String constructor.
+     */
+    public static <T> DataTableType cell(final Class<T> type) {
         try {
             final Constructor<T> constructor = type.getConstructor(String.class);
             return new DataTableType(type, new TableCellTransformer<T>() {
@@ -109,7 +117,7 @@ public final class DataTableType {
                     try {
                         return constructor.newInstance(cell);
                     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                        throw new CucumberDataTableException(String.format("DataTable#stringWrapper could not transform \"%s\"to %s", cell, typeName(type)));
+                        throw new CucumberDataTableException(String.format("DataTable#cell could not transform \"%s\"to %s", cell, typeName(type)));
                     }
                 }
             });

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
@@ -82,8 +82,7 @@ public final class DataTableType {
     }
 
     /**
-     * Creates a data table type that transforms the cells of the table into a list of objects,
-     * using table headers to set field/property names on the objects.
+     * Creates a data table type that transforms an entry into an object, using reflection.
      * <p>
      * The class needs an empty constructor, and fields must have public setters (or the fields themselves must be public).
      *
@@ -105,7 +104,7 @@ public final class DataTableType {
      * String constructor.
      *
      * @param type the type of the cell
-     * @param <T> see <code>type</code>
+     * @param <T>  see <code>type</code>
      * @throws CucumberDataTableException if <code>type</code> does not has a public String constructor.
      */
     public static <T> DataTableType cell(final Class<T> type) {

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
@@ -1,6 +1,7 @@
 package io.cucumber.datatable;
 
 import io.cucumber.datatable.dependency.com.fasterxml.jackson.databind.JavaType;
+import io.cucumber.datatable.dependency.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -11,10 +12,9 @@ import static io.cucumber.datatable.TypeFactory.aListOf;
 import static io.cucumber.datatable.TypeFactory.constructType;
 
 /**
- * A data table targetType describes how a data table should be represented as an object.
+ * A data table type describes how a data table should be represented as an object.
  *
  * @see <a href="https://github.com/cucumber/cucumber/tree/master/datatable">DataTable - README.md</a>
- *
  */
 public final class DataTableType {
 
@@ -54,7 +54,6 @@ public final class DataTableType {
         this(type, aListOf(type), new TableRowTransformerAdaptor<>(transformer));
     }
 
-
     /**
      * Creates a data table type that transforms the entries of the table into a list of objects. An entry consists
      * of the elements of the table header paired with the values of each subsequent row.
@@ -62,6 +61,7 @@ public final class DataTableType {
      * @param type        the type of the list items
      * @param transformer a function that creates an instance of <code>type</code> from the data table entry
      * @param <T>         see <code>type</code>
+     * @see DataTableType#listOf(Class)
      */
     public <T> DataTableType(Class<T> type, TableEntryTransformer<T> transformer) {
         this(type, aListOf(type), new TableEntryTransformerAdaptor<>(transformer));
@@ -78,6 +78,25 @@ public final class DataTableType {
         this(type, aListOf(aListOf(type)), new TableCellTransformerAdaptor<>(transformer));
     }
 
+    /**
+     * Creates a data table type that transforms the cells of the table into a list of objects,
+     * using table headers to set field/property names on the objects.
+     * <p>
+     * The class needs an empty constructor, and fields must have public setters (or the fields themselves must be public).
+     *
+     * @param type the type of the list of lists items
+     * @param <T>  see <code>type</code>
+     */
+    public static <T> DataTableType listOf(final Class<T> type) {
+        return new DataTableType(type, new TableEntryTransformer<T>() {
+            @Override
+            public T transform(Map<String, String> entry) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.convertValue(entry, type);
+            }
+        });
+    }
+
     public Object transform(List<List<String>> raw) {
         try {
             return transformer.transform(raw);
@@ -91,7 +110,7 @@ public final class DataTableType {
         return targetType;
     }
 
-    String toCanonical(){
+    String toCanonical() {
         return targetType.toCanonical();
     }
 
@@ -123,7 +142,6 @@ public final class DataTableType {
 
         T transform(List<List<String>> raw) throws Throwable;
     }
-
 
     private static class TableCellTransformerAdaptor<T> implements RawTableTransformer<List<List<T>>> {
         private final TableCellTransformer<T> transformer;

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
@@ -3,8 +3,6 @@ package io.cucumber.datatable;
 import io.cucumber.datatable.dependency.com.fasterxml.jackson.databind.JavaType;
 import io.cucumber.datatable.dependency.com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +10,6 @@ import java.util.Map;
 
 import static io.cucumber.datatable.TypeFactory.aListOf;
 import static io.cucumber.datatable.TypeFactory.constructType;
-import static io.cucumber.datatable.TypeFactory.typeName;
 
 /**
  * A data table type describes how a data table should be represented as an object.
@@ -108,21 +105,13 @@ public final class DataTableType {
      * @throws CucumberDataTableException if <code>type</code> does not has a public String constructor.
      */
     public static <T> DataTableType cell(final Class<T> type) {
-        try {
-            final Constructor<T> constructor = type.getConstructor(String.class);
-            return new DataTableType(type, new TableCellTransformer<T>() {
-                @Override
-                public T transform(String cell) {
-                    try {
-                        return constructor.newInstance(cell);
-                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                        throw new CucumberDataTableException(String.format("DataTable#cell could not transform \"%s\"to %s", cell, typeName(type)));
-                    }
-                }
-            });
-        } catch (NoSuchMethodException e) {
-            throw new CucumberDataTableException(String.format("%s must have a public constructor that accepts a single String", typeName(type)));
-        }
+        return new DataTableType(type, new TableCellTransformer<T>() {
+            @Override
+            public T transform(String cell) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.convertValue(cell, type);
+            }
+        });
     }
 
     public Object transform(List<List<String>> raw) {

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableType.java
@@ -68,7 +68,7 @@ public final class DataTableType {
     }
 
     /**
-     * Creates a data table type that transforms the cells of the table into a list of lists of objects.
+     * Creates a data table type that transforms the cells of the table into a list of list of objects.
      *
      * @param type        the type of the list of lists items
      * @param transformer a function that creates an instance of <code>type</code> from the data table cell
@@ -79,9 +79,10 @@ public final class DataTableType {
     }
 
     /**
-     * Creates a data table type that transforms an entry into an object, using reflection.
+     * Creates a data table type that transforms an entry into an object, using Jackson Databind internally.
+     * The class must have an empty constructor. There must be public fields or setters matching the table headers.
      * <p>
-     * The class needs an empty constructor, and fields must have public setters (or the fields themselves must be public).
+     * Jackson annotations will be ignored. If you need those, write your own transformer.
      *
      * @param type the type of the entry
      * @param <T>  see <code>type</code>
@@ -97,12 +98,17 @@ public final class DataTableType {
     }
 
     /**
-     * Creates a data table type that transforms individual cells to another type, calling the type's
-     * String constructor.
+     * Creates a data table type that transforms individual cells to another type, using Jackson Databind internally.
+     * <p>
+     * The class must satisfy one of the following:
+     * <ul>
+     * <li>String constructor</li>
+     * <li>static <code>fromString</code> method</li>
+     * <li>static <code>valueOf</code> method</li>
+     * </ul>
      *
      * @param type the type of the cell
      * @param <T>  see <code>type</code>
-     * @throws CucumberDataTableException if <code>type</code> does not has a public String constructor.
      */
     public static <T> DataTableType cell(final Class<T> type) {
         return new DataTableType(type, new TableCellTransformer<T>() {

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -8,13 +8,14 @@ import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import static io.cucumber.datatable.TypeFactory.constructType;
 import static java.lang.String.format;
 
 public final class DataTableTypeRegistry {
 
-    private final HashMap<JavaType, DataTableType> tableTypeByType = new HashMap<>();
+    private final Map<JavaType, DataTableType> tableTypeByType = new HashMap<>();
 
     public DataTableTypeRegistry(Locale locale) {
         NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/UndefinedDataTableTypeException.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/UndefinedDataTableTypeException.java
@@ -40,7 +40,7 @@ public class UndefinedDataTableTypeException extends CucumberDataTableException 
     static CucumberDataTableException listNoConverterDefined(Type itemType, String missingConverter, Type typeToRegister) {
         return new UndefinedDataTableTypeException(
                 format("Can't convert DataTable to List<%s>.\n" +
-                                "You can register a DataTableType using DataTableType.listOf(%s.class).\n" +
+                                "You can register a DataTableType using DataTableType.entry(%s.class).\n" +
                                 "For more control you can define your own DataTableType with a %s for %s.\n",
                         typeName(itemType), typeName(typeToRegister), missingConverter, typeName(typeToRegister))
         );

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/UndefinedDataTableTypeException.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/UndefinedDataTableTypeException.java
@@ -12,45 +12,46 @@ public class UndefinedDataTableTypeException extends CucumberDataTableException 
 
     static UndefinedDataTableTypeException singletonNoConverterDefined(Type type) {
         return new UndefinedDataTableTypeException(
-                format("Can't convert DataTable to %s. " +
+                format("Can't convert DataTable to %s.\n" +
                                 "Please register a DataTableType with a " +
-                                "TableTransformer, TableEntryTransformer or TableRowTransformer for %s",
-                        typeName(type), type)
+                                "TableTransformer, TableEntryTransformer or TableRowTransformer for %s.",
+                        typeName(type), typeName(type))
         );
     }
 
     static UndefinedDataTableTypeException mapNoConverterDefined(Type keyType, Type valueType, String missingConverter, Type typeToRegister) {
         return new UndefinedDataTableTypeException(
-                format("Can't convert DataTable to Map<%s, %s>. " +
-                                "Please register a DataTableType with a %s for %s",
-                        typeName(keyType), typeName(valueType), missingConverter, typeToRegister)
+                format("Can't convert DataTable to Map<%s, %s>.\n" +
+                                "Please register a DataTableType with a %s for %s.",
+                        typeName(keyType), typeName(valueType), missingConverter, typeName(typeToRegister))
         );
     }
 
 
     static UndefinedDataTableTypeException mapsNoConverterDefined(Type keyType, Type valueType, Type typeToRegister) {
         return new UndefinedDataTableTypeException(
-                format("Can't convert DataTable to List<Map<%s, %s>>. " +
-                                "Please register a DataTableType with a TableCellTransformer for %s",
-                        typeName(keyType), typeName(valueType), typeToRegister)
+                format("Can't convert DataTable to List<Map<%s, %s>>.\n" +
+                                "Please register a DataTableType with a TableCellTransformer for %s.",
+                        typeName(keyType), typeName(valueType), typeName(typeToRegister))
         );
     }
 
 
     static CucumberDataTableException listNoConverterDefined(Type itemType, String missingConverter, Type typeToRegister) {
         return new UndefinedDataTableTypeException(
-                format("Can't convert DataTable to List<%s>. " +
-                                "Please register a DataTableType with a %s for %s",
-                        typeName(itemType), missingConverter, typeToRegister)
+                format("Can't convert DataTable to List<%s>.\n" +
+                                "You can register a DataTableType using DataTableType.listOf(%s.class).\n" +
+                                "For more control you can define your own DataTableType with a %s for %s.\n",
+                        typeName(itemType), typeName(typeToRegister), missingConverter, typeName(typeToRegister))
         );
     }
 
 
     static CucumberDataTableException listsNoConverterDefined(Type itemType) {
         return new UndefinedDataTableTypeException(
-                format("Can't convert DataTable to List<List<%s>>. " +
-                                "Please register a DataTableType with a TableCellTransformer for %s",
-                        typeName(itemType), itemType)
+                format("Can't convert DataTable to List<List<%s>>.\n" +
+                                "Please register a DataTableType with a TableCellTransformer for %s.",
+                        typeName(itemType), typeName(itemType))
         );
     }
 

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTableConverterTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTableConverterTest.java
@@ -259,7 +259,7 @@ public class DataTableTypeRegistryTableConverterTest {
 
     @Test
     public void convert_to_list_of_object_using_object_mapper() {
-        registry.defineDataTableType(DataTableType.listOf(Author.class));
+        registry.defineDataTableType(DataTableType.entry(Author.class));
 
         DataTable table = parse("",
                 " | firstName   | lastName | birthDate  |",
@@ -419,8 +419,8 @@ public class DataTableTypeRegistryTableConverterTest {
             put(new AirPortCode("KJFK"), new Coordinate(40.639722, -73.778889));
         }};
 
-        registry.defineDataTableType(DataTableType.listOf(Coordinate.class));
-        registry.defineDataTableType(DataTableType.stringWrapper(AirPortCode.class));
+        registry.defineDataTableType(DataTableType.entry(Coordinate.class));
+        registry.defineDataTableType(DataTableType.cell(AirPortCode.class));
 
         assertEquals(expected, converter.toMap(table, AirPortCode.class, Coordinate.class));
         assertEquals(expected, converter.convert(table, MAP_OF_AIR_PORT_CODE_TO_COORDINATE));

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTableConverterTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTableConverterTest.java
@@ -83,7 +83,7 @@ public class DataTableTypeRegistryTableConverterTest {
     };
     private static final TableCellTransformer<AirPortCode> AIR_PORT_CODE_TABLE_CELL_TRANSFORMER = new TableCellTransformer<AirPortCode>() {
         @Override
-        public AirPortCode transform(String cell) throws Throwable {
+        public AirPortCode transform(String cell) {
             return new AirPortCode(cell);
         }
     };
@@ -91,8 +91,8 @@ public class DataTableTypeRegistryTableConverterTest {
         @Override
         public Coordinate transform(Map<String, String> tableEntry) {
             return new Coordinate(
-                    parseDouble(tableEntry.get("latt")),
-                    parseDouble(tableEntry.get("long"))
+                    parseDouble(tableEntry.get("lat")),
+                    parseDouble(tableEntry.get("lon"))
             );
         }
     };
@@ -381,7 +381,7 @@ public class DataTableTypeRegistryTableConverterTest {
     @Test
     public void convert_to_map_of_object_to_object() {
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -397,6 +397,30 @@ public class DataTableTypeRegistryTableConverterTest {
 
         registry.defineDataTableType(new DataTableType(Coordinate.class, COORDINATE_TABLE_ENTRY_TRANSFORMER));
         registry.defineDataTableType(new DataTableType(AirPortCode.class, AIR_PORT_CODE_TABLE_CELL_TRANSFORMER));
+
+        assertEquals(expected, converter.toMap(table, AirPortCode.class, Coordinate.class));
+        assertEquals(expected, converter.convert(table, MAP_OF_AIR_PORT_CODE_TO_COORDINATE));
+    }
+
+    @Test
+    public void convert_to_map_of_object_to_object_using_list_of_and_string_wrapper() {
+        DataTable table = parse("",
+                "|      | lat       | lon         |",
+                "| KMSY | 29.993333 | -90.258056  |",
+                "| KSFO | 37.618889 | -122.375    |",
+                "| KSEA | 47.448889 | -122.309444 |",
+                "| KJFK | 40.639722 | -73.778889  |"
+        );
+
+        Map<AirPortCode, Coordinate> expected = new HashMap<AirPortCode, Coordinate>() {{
+            put(new AirPortCode("KMSY"), new Coordinate(29.993333, -90.258056));
+            put(new AirPortCode("KSFO"), new Coordinate(37.618889, -122.375));
+            put(new AirPortCode("KSEA"), new Coordinate(47.448889, -122.309444));
+            put(new AirPortCode("KJFK"), new Coordinate(40.639722, -73.778889));
+        }};
+
+        registry.defineDataTableType(DataTableType.listOf(Coordinate.class));
+        registry.defineDataTableType(DataTableType.stringWrapper(AirPortCode.class));
 
         assertEquals(expected, converter.toMap(table, AirPortCode.class, Coordinate.class));
         assertEquals(expected, converter.convert(table, MAP_OF_AIR_PORT_CODE_TO_COORDINATE));
@@ -457,7 +481,7 @@ public class DataTableTypeRegistryTableConverterTest {
     @Test
     public void convert_to_map_of_primitive_to_map_of_primitive_to_primitive() {
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -467,20 +491,20 @@ public class DataTableTypeRegistryTableConverterTest {
 
         Map<String, Map<String, Double>> expected = new HashMap<String, Map<String, Double>>() {{
             put("KMSY", new HashMap<String, Double>() {{
-                put("latt", 29.993333);
-                put("long", -90.258056);
+                put("lat", 29.993333);
+                put("lon", -90.258056);
             }});
             put("KSFO", new HashMap<String, Double>() {{
-                put("latt", 37.618889);
-                put("long", -122.375);
+                put("lat", 37.618889);
+                put("lon", -122.375);
             }});
             put("KSEA", new HashMap<String, Double>() {{
-                put("latt", 47.448889);
-                put("long", -122.309444);
+                put("lat", 47.448889);
+                put("lon", -122.309444);
             }});
             put("KJFK", new HashMap<String, Double>() {{
-                put("latt", 40.639722);
-                put("long", -73.778889);
+                put("lat", 40.639722);
+                put("lon", -73.778889);
             }});
         }};
 
@@ -490,7 +514,7 @@ public class DataTableTypeRegistryTableConverterTest {
     @Test
     public void convert_to_map_of_primitive_to_object__blank_first_cell() {
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -530,7 +554,7 @@ public class DataTableTypeRegistryTableConverterTest {
     @Test
     public void convert_to_map_of_string_to_map() {
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -539,20 +563,20 @@ public class DataTableTypeRegistryTableConverterTest {
 
         Map<String, Map<String, String>> expected = new HashMap<String, Map<String, String>>() {{
             put("KMSY", new HashMap<String, String>() {{
-                put("latt", "29.993333");
-                put("long", "-90.258056");
+                put("lat", "29.993333");
+                put("lon", "-90.258056");
             }});
             put("KSFO", new HashMap<String, String>() {{
-                put("latt", "37.618889");
-                put("long", "-122.375");
+                put("lat", "37.618889");
+                put("lon", "-122.375");
             }});
             put("KSEA", new HashMap<String, String>() {{
-                put("latt", "47.448889");
-                put("long", "-122.309444");
+                put("lat", "47.448889");
+                put("lon", "-122.309444");
             }});
             put("KJFK", new HashMap<String, String>() {{
-                put("latt", "40.639722");
-                put("long", "-73.778889");
+                put("lat", "40.639722");
+                put("lon", "-73.778889");
             }});
         }};
 
@@ -761,7 +785,7 @@ public class DataTableTypeRegistryTableConverterTest {
                 "Encountered duplicate key", typeName(AirPortCode.class), typeName(Coordinate.class)));
 
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSEA | 47.448889 | -122.309444 |",
                 "| KSFO | 37.618889 | -122.375    |",
@@ -826,7 +850,7 @@ public class DataTableTypeRegistryTableConverterTest {
                 typeName(AirPortCode.class), typeName(Coordinate.class)));
 
         DataTable table = parse("",
-                "| code | latt      | long        |",
+                "| code | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -846,7 +870,7 @@ public class DataTableTypeRegistryTableConverterTest {
                 "while using a TableRow or TableCellTransformer for the keys?", typeName(String.class), typeName(Coordinate.class)));
 
         DataTable table = parse("",
-                "| code | latt      | long        |",
+                "| code | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -894,7 +918,7 @@ public class DataTableTypeRegistryTableConverterTest {
         expectedException.expectMessage(mapNoConverterDefined(AirPortCode.class, Coordinate.class, "TableCellTransformer", AirPortCode.class).getMessage());
 
         DataTable table = parse("",
-                "|      | latt      | long        |",
+                "|      | lat       | lon         |",
                 "| KMSY | 29.993333 | -90.258056  |",
                 "| KSFO | 37.618889 | -122.375    |",
                 "| KSEA | 47.448889 | -122.309444 |",
@@ -940,7 +964,7 @@ public class DataTableTypeRegistryTableConverterTest {
         expectedException.expectMessage(mapsNoConverterDefined(String.class, Coordinate.class, Coordinate.class).getMessage());
 
         DataTable table = parse("",
-                "| latt      | long        |",
+                "| lat       | lon         |",
                 "| 29.993333 | -90.258056  |",
                 "| 37.618889 | -122.375    |",
                 "| 47.448889 | -122.309444 |",
@@ -999,7 +1023,7 @@ public class DataTableTypeRegistryTableConverterTest {
     private static final class AirPortCode {
         private final String code;
 
-        private AirPortCode(String code) {
+        public AirPortCode(String code) {
             this.code = code;
         }
 
@@ -1077,12 +1101,15 @@ public class DataTableTypeRegistryTableConverterTest {
 
     private static final class Coordinate {
 
-        private final double longitude;
-        private final double latitude;
+        public double lat;
+        public double lon;
 
-        private Coordinate(double longitude, double latitude) {
-            this.longitude = longitude;
-            this.latitude = latitude;
+        public Coordinate() {
+        }
+
+        private Coordinate(double lat, double lon) {
+            this.lat = lat;
+            this.lon = lon;
         }
 
         @Override
@@ -1092,17 +1119,17 @@ public class DataTableTypeRegistryTableConverterTest {
 
             Coordinate that = (Coordinate) o;
 
-            if (Double.compare(that.longitude, longitude) != 0) return false;
-            return Double.compare(that.latitude, latitude) == 0;
+            if (Double.compare(that.lat, lat) != 0) return false;
+            return Double.compare(that.lon, lon) == 0;
         }
 
         @Override
         public int hashCode() {
             int result;
             long temp;
-            temp = Double.doubleToLongBits(longitude);
+            temp = Double.doubleToLongBits(lat);
             result = (int) (temp ^ (temp >>> 32));
-            temp = Double.doubleToLongBits(latitude);
+            temp = Double.doubleToLongBits(lon);
             result = 31 * result + (int) (temp ^ (temp >>> 32));
             return result;
         }
@@ -1110,8 +1137,8 @@ public class DataTableTypeRegistryTableConverterTest {
         @Override
         public String toString() {
             return "Coordinate{" +
-                    "longitude=" + longitude +
-                    ", latitude=" + latitude +
+                    "lat=" + lat +
+                    ", lon=" + lon +
                     '}';
         }
     }

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -6,8 +6,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertSame;
-
 
 public class DataTableTypeRegistryTest {
 


### PR DESCRIPTION
## Summary

Provide a simple (one-liner) to convert a data table to a list of objects:

```java
registry.defineDataTableType(DataTableType.entry(Author.class))
```

Also provide a simple (one-liner) to convert a cell into a "string wrapper" value object:

```java
registry.defineDataTableType(DataTableType.cell(AirportCode.class))
```

## Details

* `entry` uses Jackson Databind's `ObjectMapper` to convert a table entry (`Map<String,String>`) into an object.
* `cell` uses reflection to call a String constructor.

## Motivation and Context

Cucumber-JVM 2 used to convert tables to `List<Something>` automatically, with zero configuration. Version 3 removed XStream and added a more flexible conversion API, but some users have reported this as a regression (in ease of use). They now need to write more code to do something that used to be automatic.

This PR makes it easy again, while keeping the flexible API.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
