### PR TITLE
Cucumber expressions no special characters in parameter types

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+* Allow `ParameterType` with no name (`nil`, `null`, `""`). Useful when the
+  Parameter Type is only used in conjunction with Regular Expressions.
+  ([#387](https://github.com/cucumber/cucumber/issues/387)
+   [#410](https://github.com/cucumber/cucumber/pull/410)
+   [aslakhellesoy])
 
 ### Changed
 
@@ -16,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+
+* Better error message if a parameter type has a name with one of the characters `()[]$.|?*+`.
+  ([#387](https://github.com/cucumber/cucumber/issues/387)
+   [#410](https://github.com/cucumber/cucumber/pull/410)
+   [aslakhellesoy])
 
 ## [6.0.0] - 2018-05-30
 

--- a/cucumber-expressions/go/cucumber_expression.go
+++ b/cucumber-expressions/go/cucumber_expression.go
@@ -108,6 +108,10 @@ func (c *CucumberExpression) processParameters(expression string, parameterTypeR
 		}
 
 		typeName := match[1 : len(match)-1]
+		err = CheckParameterTypeName(typeName)
+		if err != nil {
+			return ""
+		}
 		parameterType := parameterTypeRegistry.LookupByTypeName(typeName)
 		if parameterType == nil {
 			err = NewUndefinedParameterTypeError(typeName)

--- a/cucumber-expressions/go/cucumber_expression_test.go
+++ b/cucumber-expressions/go/cucumber_expression_test.go
@@ -145,6 +145,13 @@ func TestCucumberExpression(t *testing.T) {
 		)
 	})
 
+	t.Run("does not allow parameter type with left bracket", func(t *testing.T) {
+		parameterTypeRegistry := cucumberexpressions.NewParameterTypeRegistry()
+		_, err := cucumberexpressions.NewCucumberExpression("{[string]}", parameterTypeRegistry)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "Illegal character '[' in parameter name {[string]}")
+	})
+
 	t.Run("does not allow optional parameter types", func(t *testing.T) {
 		parameterTypeRegistry := cucumberexpressions.NewParameterTypeRegistry()
 		_, err := cucumberexpressions.NewCucumberExpression("({int})", parameterTypeRegistry)
@@ -164,13 +171,6 @@ func TestCucumberExpression(t *testing.T) {
 		_, err := cucumberexpressions.NewCucumberExpression("{int}/x", parameterTypeRegistry)
 		require.Error(t, err)
 		require.Equal(t, "Parameter types cannot be alternative: {int}/x", err.Error())
-	})
-
-	t.Run("returns error for parameter type with left bracket", func(t *testing.T) {
-		parameterTypeRegistry := cucumberexpressions.NewParameterTypeRegistry()
-		_, err := cucumberexpressions.NewCucumberExpression("{[string]}", parameterTypeRegistry)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "Illegal character '[' in parameter name {[string]}")
 	})
 
 	t.Run("returns error for unknown parameter", func(t *testing.T) {

--- a/cucumber-expressions/go/cucumber_expression_test.go
+++ b/cucumber-expressions/go/cucumber_expression_test.go
@@ -166,6 +166,13 @@ func TestCucumberExpression(t *testing.T) {
 		require.Equal(t, "Parameter types cannot be alternative: {int}/x", err.Error())
 	})
 
+	t.Run("returns error for parameter type with left bracket", func(t *testing.T) {
+		parameterTypeRegistry := cucumberexpressions.NewParameterTypeRegistry()
+		_, err := cucumberexpressions.NewCucumberExpression("{[string]}", parameterTypeRegistry)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "Illegal character '[' in parameter name {[string]}")
+	})
+
 	t.Run("returns error for unknown parameter", func(t *testing.T) {
 		parameterTypeRegistry := cucumberexpressions.NewParameterTypeRegistry()
 		_, err := cucumberexpressions.NewCucumberExpression("{unknown}", parameterTypeRegistry)

--- a/cucumber-expressions/go/custom_parameter_type_test.go
+++ b/cucumber-expressions/go/custom_parameter_type_test.go
@@ -40,7 +40,7 @@ func CreateParameterTypeRegistry(t *testing.T) *cucumberexpressions.ParameterTyp
 }
 
 func TestCustomParameterTypes(t *testing.T) {
-	t.Run("throws exception for illegal character", func(t *testing.T) {
+	t.Run("throws exception for illegal character in parameter type name", func(t *testing.T) {
 		_, err := cucumberexpressions.NewParameterType(
 			"[string]",
 			[]*regexp.Regexp{regexp.MustCompile(`.*`)},

--- a/cucumber-expressions/go/parameter_type.go
+++ b/cucumber-expressions/go/parameter_type.go
@@ -6,6 +6,8 @@ import (
 )
 
 var HAS_FLAG_REGEKP = regexp.MustCompile(`\(\?[imsU-]+(\:.*)?\)`)
+var UNESCAPE_REGEXP = regexp.MustCompile(`(\\([\[$.|?*+\]]))`)
+var ILLEGAL_PARAMETER_NAME_REGEXP = regexp.MustCompile(`([\[\]()$.|?*+])`)
 
 type ParameterType struct {
 	name                 string
@@ -14,6 +16,13 @@ type ParameterType struct {
 	transform            func(...*string) interface{}
 	useForSnippets       bool
 	preferForRegexpMatch bool
+}
+
+func CheckParameterTypeName(typeName string) (error) {
+	if ILLEGAL_PARAMETER_NAME_REGEXP.MatchString(typeName) {
+		return errors.New("Illegal character '[' in parameter name {[string]}")
+	}
+	return nil
 }
 
 func NewParameterType(name string, regexps []*regexp.Regexp, type1 string, transform func(...*string) interface{}, useForSnippets bool, preferForRegexpMatch bool) (*ParameterType, error) {
@@ -26,6 +35,10 @@ func NewParameterType(name string, regexps []*regexp.Regexp, type1 string, trans
 		if HAS_FLAG_REGEKP.MatchString(r.String()) {
 			return nil, errors.New("ParameterType Regexps can't use flags")
 		}
+	}
+	err := CheckParameterTypeName(name)
+	if err != nil {
+		return nil, err
 	}
 	return &ParameterType{
 		name:                 name,

--- a/cucumber-expressions/go/parameter_type.go
+++ b/cucumber-expressions/go/parameter_type.go
@@ -3,6 +3,7 @@ package cucumberexpressions
 import (
 	"errors"
 	"regexp"
+	"fmt"
 )
 
 var HAS_FLAG_REGEKP = regexp.MustCompile(`\(\?[imsU-]+(\:.*)?\)`)
@@ -19,8 +20,10 @@ type ParameterType struct {
 }
 
 func CheckParameterTypeName(typeName string) (error) {
+	unescapedTypeName := UNESCAPE_REGEXP.ReplaceAllString(typeName, "$2");
 	if ILLEGAL_PARAMETER_NAME_REGEXP.MatchString(typeName) {
-		return errors.New("Illegal character '[' in parameter name {[string]}")
+		c := ILLEGAL_PARAMETER_NAME_REGEXP.FindStringSubmatch(typeName)[0]
+		return errors.New(fmt.Sprintf("Illegal character '%s' in parameter name {%s}", c, unescapedTypeName))
 	}
 	return nil
 }

--- a/cucumber-expressions/go/parameter_type.go
+++ b/cucumber-expressions/go/parameter_type.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-var HAS_FLAG_REGEKP = regexp.MustCompile(`\(\?[imsU-]+(\:.*)?\)`)
+var HAS_FLAG_REGEXP = regexp.MustCompile(`\(\?[imsU-]+(:.*)?\)`)
 var UNESCAPE_REGEXP = regexp.MustCompile(`(\\([\[$.|?*+\]]))`)
 var ILLEGAL_PARAMETER_NAME_REGEXP = regexp.MustCompile(`([\[\]()$.|?*+])`)
 
@@ -35,7 +35,7 @@ func NewParameterType(name string, regexps []*regexp.Regexp, type1 string, trans
 		}
 	}
 	for _, r := range regexps {
-		if HAS_FLAG_REGEKP.MatchString(r.String()) {
+		if HAS_FLAG_REGEXP.MatchString(r.String()) {
 			return nil, errors.New("ParameterType Regexps can't use flags")
 		}
 	}

--- a/cucumber-expressions/go/parameter_type_registry.go
+++ b/cucumber-expressions/go/parameter_type_registry.go
@@ -128,10 +128,12 @@ func (p *ParameterTypeRegistry) LookupByRegexp(parameterTypeRegexp string, expre
 }
 
 func (p *ParameterTypeRegistry) DefineParameterType(parameterType *ParameterType) error {
-	if _, ok := p.parameterTypeByName[parameterType.Name()]; ok {
-		return fmt.Errorf("There is already a parameter type with name %s", parameterType.Name())
+	if len(parameterType.Name()) > 0 {
+		if _, ok := p.parameterTypeByName[parameterType.Name()]; ok {
+			return fmt.Errorf("There is already a parameter type with name %s", parameterType.Name())
+		}
+		p.parameterTypeByName[parameterType.Name()] = parameterType
 	}
-	p.parameterTypeByName[parameterType.Name()] = parameterType
 	for _, parameterTypeRegexp := range parameterType.Regexps() {
 		if _, ok := p.parameterTypesByRegexp[parameterTypeRegexp.String()]; !ok {
 			p.parameterTypesByRegexp[parameterTypeRegexp.String()] = []*ParameterType{}

--- a/cucumber-expressions/go/regular_expression.go
+++ b/cucumber-expressions/go/regular_expression.go
@@ -28,7 +28,7 @@ func (r *RegularExpression) Match(text string) ([]*Argument, error) {
 		}
 		if parameterType == nil {
 			parameterType, err = NewParameterType(
-				parameterTypeRegexp,
+				"",
 				[]*regexp.Regexp{regexp.MustCompile(parameterTypeRegexp)},
 				"string",
 				func(arg3 ...*string) interface{} {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -91,6 +91,7 @@ public class CucumberExpression implements Expression {
                 matcher.appendReplacement(sb, "\\\\{" + matcher.group(2) + "\\\\}");
             } else {
                 String typeName = matcher.group(2);
+                ParameterType.checkParameterTypeName(typeName);
                 ParameterType<?> parameterType = parameterTypeRegistry.lookupByTypeName(typeName);
                 if (parameterType == null) {
                     throw new UndefinedParameterTypeException(typeName);

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -9,8 +9,8 @@ import static java.util.Collections.singletonList;
 
 public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     @SuppressWarnings("RegExpRedundantEscape") // Android can't parse unescaped braces
-    private static final Pattern ILLEGAL_PARAMETER_NAME_PATTERN = Pattern.compile("([\\[$.|?*+\\]\\(\\)\\{\\}])");
-    private static final Pattern UNESCAPE_PATTERN = Pattern.compile("([\\\\^]([\\[$.|?*+\\]]))");
+    private static final Pattern ILLEGAL_PARAMETER_NAME_PATTERN = Pattern.compile("([\\[\\]()$.|?*+])");
+    private static final Pattern UNESCAPE_PATTERN = Pattern.compile("(\\\\([\\[$.|?*+\\]]))");
 
     private final String name;
     private final Type type;
@@ -19,7 +19,7 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     private final boolean useForSnippets;
     private final CaptureGroupTransformer<T> transformer;
 
-    public static void checkParameterTypeName(String name) {
+    static void checkParameterTypeName(String name) {
         String unescapedTypeName = UNESCAPE_PATTERN.matcher(name).replaceAll("$2");
         Matcher matcher = ILLEGAL_PARAMETER_NAME_PATTERN.matcher(unescapedTypeName);
         if (matcher.find()) {
@@ -146,7 +146,9 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     public int compareTo(ParameterType<?> o) {
         if (preferForRegexpMatch() && !o.preferForRegexpMatch()) return -1;
         if (o.preferForRegexpMatch() && !preferForRegexpMatch()) return 1;
-        return getName().compareTo(o.getName());
+        String name = getName() != null ? getName() : "";
+        String otherName = o.getName() != null ? o.getName() : "";
+        return name.compareTo(otherName);
     }
 
     private static final class TransformerAdaptor<T> implements CaptureGroupTransformer<T> {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -2,10 +2,16 @@ package io.cucumber.cucumberexpressions;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
 
 public final class ParameterType<T> implements Comparable<ParameterType<?>> {
+    @SuppressWarnings("RegExpRedundantEscape") // Android can't parse unescaped braces
+    private static final Pattern ILLEGAL_PARAMETER_NAME_PATTERN = Pattern.compile("([\\[$.|?*+\\]\\(\\)\\{\\}])");
+    private static final Pattern UNESCAPE_PATTERN = Pattern.compile("([\\\\^]([\\[$.|?*+\\]]))");
+
     private final String name;
     private final Type type;
     private final List<String> regexps;
@@ -13,11 +19,19 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     private final boolean useForSnippets;
     private final CaptureGroupTransformer<T> transformer;
 
+    public static void checkParameterTypeName(String name) {
+        String unescapedTypeName = UNESCAPE_PATTERN.matcher(name).replaceAll("$2");
+        Matcher matcher = ILLEGAL_PARAMETER_NAME_PATTERN.matcher(unescapedTypeName);
+        if (matcher.find()) {
+            throw new CucumberExpressionException(String.format("Illegal character '%s' in parameter name {%s}.", matcher.group(1), unescapedTypeName));
+        }
+    }
+
     public ParameterType(String name, List<String> regexps, Type type, CaptureGroupTransformer<T> transformer, boolean useForSnippets, boolean preferForRegexpMatch) {
-        if (name == null) throw new NullPointerException("name cannot be null");
         if (regexps == null) throw new NullPointerException("regexps cannot be null");
         if (type == null) throw new NullPointerException("type cannot be null");
         if (transformer == null) throw new NullPointerException("transformer cannot be null");
+        if (name != null) checkParameterTypeName(name);
         this.name = name;
         this.regexps = regexps;
         this.type = type;
@@ -119,7 +133,7 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
         }
 
         try {
-            String[] groupValueArray = groupValues.toArray(new String[groupValues.size()]);
+            String[] groupValueArray = groupValues.toArray(new String[0]);
             return transformer.transform(groupValueArray);
         } catch (CucumberExpressionException e) {
             throw e;

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -92,9 +92,11 @@ public class ParameterTypeRegistry {
     }
 
     public void defineParameterType(ParameterType<?> parameterType) {
-        if (parameterTypeByName.containsKey(parameterType.getName()))
-            throw new DuplicateTypeNameException(String.format("There is already a parameter type with name %s", parameterType.getName()));
-        parameterTypeByName.put(parameterType.getName(), parameterType);
+        if (parameterType.getName() != null) {
+            if (parameterTypeByName.containsKey(parameterType.getName()))
+                throw new DuplicateTypeNameException(String.format("There is already a parameter type with name %s", parameterType.getName()));
+            parameterTypeByName.put(parameterType.getName(), parameterType);
+        }
 
         for (String parameterTypeRegexp : parameterType.getRegexps()) {
             if (parameterTypesByRegexp.get(parameterTypeRegexp) == null) {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
@@ -31,7 +31,7 @@ public class RegularExpression implements Expression {
 
             ParameterType<?> parameterType = parameterTypeRegistry.lookupByRegexp(parameterTypeRegexp, expressionRegexp, text);
             if (parameterType == null) parameterType = new ParameterType<>(
-                    parameterTypeRegexp,
+                    null,
                     parameterTypeRegexp,
                     String.class,
                     new Transformer<String>() {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -110,7 +110,7 @@ public class CucumberExpressionTest {
     }
 
     @Test
-    public void throws_illegal_parameter_type_for_left_bracket() {
+    public void does_not_allow_parameter_type_with_left_bracket() {
         expectedException.expectMessage("Illegal character '[' in parameter name {[string]}");
         match("{[string]}", "something");
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -14,6 +14,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CucumberExpressionTest {
 
@@ -59,7 +60,7 @@ public class CucumberExpressionTest {
 
     @Test
     public void does_not_match_misquoted_string() {
-        assertEquals(null, match("three {string} mice", "three \"blind' mice"));
+        assertNull(match("three {string} mice", "three \"blind' mice"));
     }
 
     @Test
@@ -99,13 +100,19 @@ public class CucumberExpressionTest {
 
     @Test
     public void doesnt_match_float_as_int() {
-        assertEquals(null, match("{int}", "1.22"));
+        assertNull(match("{int}", "1.22"));
     }
 
     @Test
     public void matches_float() {
         assertEquals(singletonList(0.22f), match("{float}", "0.22"));
         assertEquals(singletonList(0.22f), match("{float}", ".22"));
+    }
+
+    @Test
+    public void throws_illegal_parameter_type_for_left_bracket() {
+        expectedException.expectMessage("Illegal character '[' in parameter name {[string]}");
+        match("{[string]}", "something");
     }
 
     @Test

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
@@ -70,7 +70,7 @@ public class CustomParameterTypeTest {
     }
 
     @Test
-    public void throws_exception_for_illegal_character() {
+    public void throws_exception_for_illegal_character_in_parameter_name() {
         expectedException.expectMessage("Illegal character '[' in parameter name {[string]}");
         new ParameterType<>(
                 "[string]",

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
@@ -72,7 +72,7 @@ public class CustomParameterTypeTest {
     @Test
     public void throws_exception_for_illegal_character() {
         expectedException.expectMessage("Illegal character '[' in parameter name {[string]}");
-        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+        new ParameterType<>(
                 "[string]",
                 ".*",
                 String.class, new Transformer<String>() {
@@ -83,7 +83,7 @@ public class CustomParameterTypeTest {
                 },
                 false,
                 false
-        ));
+        );
     }
 
     @Test

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
@@ -70,6 +70,24 @@ public class CustomParameterTypeTest {
     }
 
     @Test
+    public void throws_exception_for_illegal_character() {
+        expectedException.expectMessage("Illegal character '[' in parameter name {[string]}");
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                "[string]",
+                ".*",
+                String.class, new Transformer<String>() {
+                    @Override
+                    public String transform(String s) {
+                        return s;
+                    }
+                },
+                false,
+                false
+        ));
+
+    }
+
+    @Test
     public void matches_CucumberExpression_parameters_with_custom_parameter_type() {
         Expression expression = new CucumberExpression("I have a {color} ball", parameterTypeRegistry);
         Object argumentValue = expression.match("I have a red ball").get(0).getValue();

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CustomParameterTypeTest.java
@@ -84,7 +84,6 @@ public class CustomParameterTypeTest {
                 false,
                 false
         ));
-
     }
 
     @Test
@@ -259,7 +258,22 @@ public class CustomParameterTypeTest {
     }
 
     @Test
-    public void matches_RegularExpression_arguments_with_custom_parameter_type() {
+    public void matches_RegularExpression_arguments_with_custom_parameter_type_without_name() {
+        parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                null,
+                "red|blue|yellow",
+                Color.class,
+                new Transformer<Color>() {
+                    @Override
+                    public Color transform(String arg) {
+                        return new Color(arg);
+                    }
+                },
+                false,
+                false
+        ));
+
         Expression expression = new RegularExpression(compile("I have a (red|blue|yellow) ball"), parameterTypeRegistry);
         Object argumentValue = expression.match("I have a red ball").get(0).getValue();
         assertEquals(new Color("red"), argumentValue);

--- a/cucumber-expressions/javascript/src/cucumber_expression.js
+++ b/cucumber-expressions/javascript/src/cucumber_expression.js
@@ -1,5 +1,6 @@
 const Argument = require('./argument')
 const TreeRegexp = require('./tree_regexp')
+const ParameterType = require('./parameter_type')
 const {
   UndefinedParameterTypeError,
   CucumberExpressionError,
@@ -77,6 +78,7 @@ class CucumberExpression {
       if (p1 === DOUBLE_ESCAPE) return `\\{${p2}\\}`
 
       const typeName = p2
+      ParameterType.checkParameterTypeName(typeName)
       const parameterType = parameterTypeRegistry.lookupByTypeName(typeName)
       if (!parameterType) throw new UndefinedParameterTypeError(typeName)
       this._parameterTypes.push(parameterType)

--- a/cucumber-expressions/javascript/src/parameter_type.js
+++ b/cucumber-expressions/javascript/src/parameter_type.js
@@ -1,10 +1,24 @@
 const { CucumberExpressionError } = require('./errors')
 
+const ILLEGAL_PARAMETER_NAME_PATTERN = /([[\]()$.|?*+])/
+const UNESCAPE_PATTERN = () => /(\\([[$.|?*+\]]))/g
+
 class ParameterType {
   static compare(pt1, pt2) {
     if (pt1.preferForRegexpMatch && !pt2.preferForRegexpMatch) return -1
     if (pt2.preferForRegexpMatch && !pt1.preferForRegexpMatch) return 1
     return pt1.name.localeCompare(pt2.name)
+  }
+
+  static checkParameterTypeName(typeName) {
+    const unescapedTypeName = typeName.replace(UNESCAPE_PATTERN(), '$2')
+    const match = unescapedTypeName.match(ILLEGAL_PARAMETER_NAME_PATTERN)
+    if (match)
+      throw new CucumberExpressionError(
+        `Illegal character '${
+          match[1]
+        }' in parameter name {${unescapedTypeName}}`
+      )
   }
 
   /**
@@ -26,6 +40,9 @@ class ParameterType {
     if (transform === undefined) transform = s => s
     if (useForSnippets === undefined) useForSnippets = true
     if (preferForRegexpMatch === undefined) preferForRegexpMatch = false
+
+    if (name) ParameterType.checkParameterTypeName(name)
+
     this._name = name
     this._regexps = stringArray(regexps)
     this._type = type

--- a/cucumber-expressions/javascript/src/parameter_type_registry.js
+++ b/cucumber-expressions/javascript/src/parameter_type_registry.js
@@ -65,11 +65,13 @@ class ParameterTypeRegistry {
   }
 
   defineParameterType(parameterType) {
-    if (this._parameterTypeByName.has(parameterType.name))
-      throw new Error(
-        `There is already a parameter type with name ${parameterType.name}`
-      )
-    this._parameterTypeByName.set(parameterType.name, parameterType)
+    if (parameterType.name) {
+      if (this._parameterTypeByName.has(parameterType.name))
+        throw new Error(
+          `There is already a parameter type with name ${parameterType.name}`
+        )
+      this._parameterTypeByName.set(parameterType.name, parameterType)
+    }
 
     for (const parameterTypeRegexp of parameterType.regexps) {
       if (!this._parameterTypesByRegexp.has(parameterTypeRegexp)) {

--- a/cucumber-expressions/javascript/src/regular_expression.js
+++ b/cucumber-expressions/javascript/src/regular_expression.js
@@ -21,7 +21,7 @@ class RegularExpression {
             text
           ) ||
           new ParameterType(
-            parameterTypeRegexp,
+            null,
             parameterTypeRegexp,
             String,
             s => s,

--- a/cucumber-expressions/javascript/test/cucumber_expression_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_test.js
@@ -160,6 +160,20 @@ describe('CucumberExpression', () => {
     }
   })
 
+  for (const c of '[]()$.|?*+'.split('')) {
+    it(`does not allow parameter type with ${c}`, () => {
+      try {
+        match(`{${c}string}`, 'something')
+        assert.fail()
+      } catch (expected) {
+        assert.equal(
+          expected.message,
+          `Illegal character '${c}' in parameter name {${c}string}`
+        )
+      }
+    })
+  }
+
   it('exposes source', () => {
     const expr = 'I have {int} cuke(s)'
     assert.equal(

--- a/cucumber-expressions/javascript/test/custom_parameter_type_test.js
+++ b/cucumber-expressions/javascript/test/custom_parameter_type_test.js
@@ -45,6 +45,13 @@ describe('Custom parameter type', () => {
   })
 
   describe('CucumberExpression', () => {
+    it('throws exception for illegal character in parameter name', () => {
+      assertThrows(
+        () => new ParameterType('[string]', /.*/, String, s => s, false, true),
+        "Illegal character '[' in parameter name {[string]}"
+      )
+    })
+
     it('matches parameters with custom parameter type', () => {
       const expression = new CucumberExpression(
         'I have a {color} ball',

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -80,6 +80,7 @@ module Cucumber
             "\\{#{$2}\\}"
           else
             type_name = $2
+            ParameterType.check_parameter_type_name(type_name)
             parameter_type = parameter_type_registry.lookup_by_type_name(type_name)
             raise UndefinedParameterTypeError.new(type_name) if parameter_type.nil?
             @parameter_types.push(parameter_type)

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -42,10 +42,12 @@ module Cucumber
       end
 
       def define_parameter_type(parameter_type)
-        if @parameter_type_by_name.has_key?(parameter_type.name)
-          raise CucumberExpressionError.new("There is already a parameter with name #{parameter_type.name}")
+        if parameter_type.name
+          if @parameter_type_by_name.has_key?(parameter_type.name)
+            raise CucumberExpressionError.new("There is already a parameter with name #{parameter_type.name}")
+          end
+          @parameter_type_by_name[parameter_type.name] = parameter_type
         end
-        @parameter_type_by_name[parameter_type.name] = parameter_type
 
         parameter_type.regexps.each do |parameter_type_regexp|
           parameter_types = @parameter_types_by_regexp[parameter_type_regexp]

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -20,7 +20,7 @@ module Cucumber
             @expression_regexp,
             text
           ) || ParameterType.new(
-            parameter_type_regexp,
+            nil,
             parameter_type_regexp,
             String,
             lambda {|*s| s[0]},

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -77,7 +77,7 @@ module Cucumber
       end
 
       '[]()$.|?*+'.split('').each do |char|
-        it "throws illegal parameter type for left bracket" do
+        it "does not allow parameter type with #{char}" do
           expect {match("{#{char}string}", "something")}.to raise_error("Illegal character '#{char}' in parameter name {#{char}string}")
         end
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -76,6 +76,12 @@ module Cucumber
         expect(match("{float}", ".22")).to eq([0.22])
       end
 
+      '[]()$.|?*+'.split('').each do |char|
+        it "throws illegal parameter type for left bracket" do
+          expect {match("{#{char}string}", "something")}.to raise_error("Illegal character '#{char}' in parameter name {#{char}string}")
+        end
+      end
+
       it "throws unknown parameter type" do
         expect {match("{unknown}", "something")}.to raise_error('Undefined parameter type {unknown}')
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
@@ -59,7 +59,7 @@ module Cucumber
         @parameter_type_registry = parameter_type_registry
       end
 
-      it "throws exception for illegal character" do
+      it "throws exception for illegal character in parameter name" do
         expect do
           ParameterType.new(
               '[string]',

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
@@ -61,14 +61,14 @@ module Cucumber
 
       it "throws exception for illegal character" do
         expect do
-          @parameter_type_registry.define_parameter_type(ParameterType.new(
+          ParameterType.new(
               '[string]',
               /.*/,
               String,
               lambda {|s| s},
               true,
               false
-          ))
+          )
         end.to raise_error("Illegal character '[' in parameter name {[string]}")
       end
 


### PR DESCRIPTION
Fix for #387. Also allows registration of parameter types without a name (useful if only used in conjunction with regular expressions)