### PR TITLE
gherkin: Is there a problem with accepting a range of synonyms?

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -688,10 +688,21 @@
   "en": {
     "and": [
       "* ",
-      "And "
+      "And ",
+      "Also ",
+      "Likewise ",
+      "Plus "
     ],
     "background": [
-      "Background"
+      "Background",
+      "Beforehand",
+      "History",
+      "Precondition",
+      "Precursor",
+      "Preliminary",
+      "Prelude",
+      "Prerequisite",
+      "Setup"
     ],
     "but": [
       "* ",
@@ -708,7 +719,11 @@
     ],
     "given": [
       "* ",
-      "Given "
+      "Given ",
+      "Assume",
+      "Assuming ",
+      "Presume",
+      "Presuming "
     ],
     "name": "English",
     "native": "English",


### PR DESCRIPTION

## Background

I'm a bit new to cucumber, and I find it odd how that (in some respects) the project can be so incredibly flexible (such as to allow tests to be written in LOLCAT & pirate-speak), and in other respects seems a bit stringent on the use of acceptable keywords (even mention of deprecating & removing gherkin keywords).

In fact, looking at the table of languages, most localization tuples have only one acceptable keyword (though a few have **many**).

## Details

In part, this is simply a question that I did not come across in the docs/videos/issues:
* Is there an actual policy or consideration that seeks to (or pressures us to) use the fewest keywords per tuple?

Also, this pull request contains a few synonyms that I reason might allow for more flexible wording of English gherkin files.

## Motivation and Context

I recognize that this change is not required, as having even one per keyword is adequate for functionality.

But in what I assume to be the common use case (that the gherkin feature files be visible and approvable by the non-technical business unit), sometimes it seems that the language becomes a bit tortured and unnatural trying to shoe-horn the originally-provided user stories into the minimal keyword set with minimal modification.

Other times, it seems that the design has been so pressured to use a single word (such as for "Background"), that it does not seem to adequately convey its purpose, and I wonder if a more verbose match (such as "Before each scenario") would be acceptable?

This could all be a bad assumption on my part, so I certainly won't be offended if this is closed with even a one-sentence semi-authoritative explanation.

## How Has This Been Tested?

I have run the only modified file through "json_verify" to make sure I didn't screw up the syntax (like a missing comma or quote).

## Types of changes

Approximately 15 entirely-redundant strings added to the "en" entry in gherkin-languages.json

No breakages are expected.

## Checklist:

- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
