### PR TITLE
cucumber-expressions/ruby: Exclude spec/ from coverage counting

### DIFF
--- a/cucumber-expressions/ruby/spec/coverage.rb
+++ b/cucumber-expressions/ruby/spec/coverage.rb
@@ -3,4 +3,5 @@ require 'simplecov'
 formatters = [ SimpleCov::Formatter::HTMLFormatter ]
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(*formatters)
+SimpleCov.add_filter 'spec/'
 SimpleCov.start


### PR DESCRIPTION
## Summary

This PR changes the code coverage counting in the Ruby sub-project to **only count non-spec files**.

## Motivation and Context

The motivation for this is **clarity and understandability** of the code **coverage report** to its reader.

## How Has This Been Tested?

I only re-ran the tests, to have a new coverage HTML report generated.

## Screenshots (after this change):

![image](https://user-images.githubusercontent.com/211/41818230-a61285b0-77aa-11e8-839f-7efa71d3dd18.png)

## Types of changes

Non-functional change to reporting.
