### PR TITLE
Use the DocString.Content for ToString

### DIFF
--- a/gherkin/dotnet/Gherkin/Ast/DocString.cs
+++ b/gherkin/dotnet/Gherkin/Ast/DocString.cs
@@ -12,5 +12,7 @@
             ContentType = contentType;
             Content = content;
         }
+        
+        public override string ToString() => Content;
     }
 }


### PR DESCRIPTION
This makes it far easier to debug/visualize or even consume by just doing step.Argument.ToString().