### PR TITLE
Add ParameterType.fromEnum(Class enumClass)

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* (Java) Added ParameterType.fromEnum(MyEnumClass.class) to make it easier
+  to register enums.
+  ([aslakhellesoy])
+
 ### Changed
 
 ### Deprecated

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -27,6 +27,27 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
         }
     }
 
+    public static <E extends Enum> ParameterType<E> fromEnum(final Class<E> enumClass) {
+        Enum[] enumConstants = enumClass.getEnumConstants();
+        StringBuilder regexpBuilder = new StringBuilder();
+        for(int i = 0; i < enumConstants.length; i++) {
+            if(i>0) regexpBuilder.append("|");
+            regexpBuilder.append(enumConstants[i].name());
+        }
+        return new ParameterType<>(
+                enumClass.getSimpleName(),
+                regexpBuilder.toString(),
+                enumClass,
+                new Transformer<E>() {
+                    @Override
+                    public E transform(String arg) {
+                        return (E) Enum.valueOf(enumClass, arg);
+                    }
+                }
+
+        );
+    }
+
     public ParameterType(String name, List<String> regexps, Type type, CaptureGroupTransformer<T> transformer, boolean useForSnippets, boolean preferForRegexpMatch) {
         if (regexps == null) throw new NullPointerException("regexps cannot be null");
         if (type == null) throw new NullPointerException("type cannot be null");

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -30,8 +30,8 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     public static <E extends Enum> ParameterType<E> fromEnum(final Class<E> enumClass) {
         Enum[] enumConstants = enumClass.getEnumConstants();
         StringBuilder regexpBuilder = new StringBuilder();
-        for(int i = 0; i < enumConstants.length; i++) {
-            if(i>0) regexpBuilder.append("|");
+        for (int i = 0; i < enumConstants.length; i++) {
+            if (i > 0) regexpBuilder.append("|");
             regexpBuilder.append(enumConstants[i].name());
         }
         return new ParameterType<>(
@@ -44,7 +44,6 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
                         return (E) Enum.valueOf(enumClass, arg);
                     }
                 }
-
         );
     }
 

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/EnumParameterTypeTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/EnumParameterTypeTest.java
@@ -2,22 +2,28 @@ package io.cucumber.cucumberexpressions;
 
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Locale;
+
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 public class EnumParameterTypeTest {
-    @Test
-    public void constructs_enum() {
-        ParameterType<Color> t = new ParameterType<>("color", "\\w+", Color.class, new Transformer<Color>() {
-            @Override
-            public Color transform(String arg) {
-                return Color.valueOf(arg);
-            }
-        });
-        assertEquals(Color.BLUE, t.transform(singletonList("BLUE")));
+    public enum Mood {
+        happy,
+        meh,
+        sad
     }
 
-    public enum Color {
-        RED, BLUE, YELLOW
+    @Test
+    public void converts_to_enum() {
+        ParameterTypeRegistry registry = new ParameterTypeRegistry(Locale.ENGLISH);
+        registry.defineParameterType(ParameterType.fromEnum(Mood.class));
+
+        CucumberExpression expression = new CucumberExpression("I am {Mood}", registry);
+        List<Argument<?>> args = expression.match("I am happy");
+        assertEquals(Mood.happy, args.get(0).getValue());
     }
+
+
 }


### PR DESCRIPTION
## Summary

Simplify creation of `ParameterType` from an enum class

## Details

The enum constants' names are used to build a regexp for the match (`red|green|blue`), and the name is the simplified name of the enum class (`Color`).

## Motivation and Context

See https://github.com/cucumber/cucumber-jvm/issues/1393#issuecomment-400985459

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
