### PR TITLE
Update gherkin-languages.json

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -2362,7 +2362,9 @@
     ],
     "then": [
       "* ",
-      "Dan "
+      "Dan ",
+      "Verwacht dat ",
+      "Valideer dat "
     ],
     "when": [
       "* ",


### PR DESCRIPTION
Extended dutch 'then' to improve on grammar

<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Extended dutch 'then' to improve on grammar

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context
Steps as 'Given / When / Then / And the window is opened and active' translate into 'Gegeven / Als / Dan / En het venster actief en geopend is'. 'Dan' should be extended to increase readability. 'Verwacht dat / Valideer dat het venster actief en geopend is' is correct.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
