### PR TITLE
Fix links to docs site.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -62,7 +62,7 @@ In the new directory, create the following files:
 
     [![Build Status](https://travis-ci.org/cucumber/tag-expressions-go.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-go)
 
-    [The docs are here](http://docs.cucumber.io/tag-expressions/).
+    [The docs are here](http://docs.cucumber.io/cucumber/tag-expressions/).
 
 #### Sync files
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -62,7 +62,7 @@ In the new directory, create the following files:
 
     [![Build Status](https://travis-ci.org/cucumber/tag-expressions-go.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-go)
 
-    [The docs are here](http://docs.cucumber.io/cucumber/tag-expressions/).
+    [The docs are here](https://docs.cucumber.io/cucumber/tag-expressions/).
 
 #### Sync files
 

--- a/config/java/README.md
+++ b/config/java/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/cucumber/config-java.svg?branch=master)](https://travis-ci.org/cucumber/config-java)
 
-[The docs are here](http://docs.cucumber.io/config/).
+[The docs are here](https://docs.cucumber.io/cucumber/configuration/).

--- a/gherkin-lint/javascript/README.md
+++ b/gherkin-lint/javascript/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/cucumber/gherkin-lint-javascript.svg?branch=master)](https://travis-ci.org/cucumber/gherkin-lint-javascript)
 
-[The docs are here](http://docs.cucumber.io/gherkin-lint/).
+[The docs are here](https://docs.cucumber.io/).

--- a/html-formatter/nodejs/README.md
+++ b/html-formatter/nodejs/README.md
@@ -2,5 +2,5 @@
 
 [![Build Status](https://travis-ci.org/cucumber/html-formatter-nodejs.svg?branch=master)](https://travis-ci.org/cucumber/html-formatter-nodejs)
 
-[The docs are here](http://docs.cucumber.io/html-formatter/).
+[The docs are here](https://docs.cucumber.io/cucumber/reporting/).
 

--- a/tag-expressions/java/README.md
+++ b/tag-expressions/java/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/cucumber/tag-expressions-java.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-java)
 
-[The docs are here](http://docs.cucumber.io/tag-expressions/).
+[The docs are here](http://docs.cucumber.io/cucumber/tag-expressions/).

--- a/tag-expressions/ruby/README.md
+++ b/tag-expressions/ruby/README.md
@@ -1,3 +1,3 @@
 # Cucumber Tag Expressions for Ruby
 
-[The docs are here](http://docs.cucumber.io/tag-expressions/).
+[The docs are here](http://docs.cucumber.io/cucumber/tag-expressions/).

--- a/tag-expressions/ruby/cucumber-tag_expressions.gemspec
+++ b/tag-expressions/ruby/cucumber-tag_expressions.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = 'Cucumber tag expressions for ruby'
   s.summary     = "#{s.name}-#{s.version}"
   s.email       = 'cukes@googlegroups.com'
-  s.homepage    = 'https://docs.cucumber.io/tag-expressions/'
+  s.homepage    = 'https://docs.cucumber.io/cucumber/tag-expressions/'
   s.platform    = Gem::Platform::RUBY
   s.license     = 'MIT'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
## Summary

There were a few broken links, this PR fixes them. Gherkin-lint does not have docs yet [docs-issue#215](https://github.com/cucumber/docs.cucumber.io/issues/215).

## Motivation and Context

Fixes issue #450, although Event Protocol does not seem to be in docs as mentioned in the issue.