### PR TITLE
WIP: cucumber-expressions: java: Fix for #455

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GeneratedExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GeneratedExpression.java
@@ -1,39 +1,17 @@
 package io.cucumber.cucumberexpressions;
 
-import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
-
 public class GeneratedExpression {
-    private static final Collator ENGLISH_COLLATOR = Collator.getInstance(Locale.ENGLISH);
-    private static final String JAVA_KEYWORDS[] = {
-            "abstract", "assert", "boolean", "break", "byte", "case",
-            "catch", "char", "class", "const", "continue",
-            "default", "do", "double", "else", "extends",
-            "false", "final", "finally", "float", "for",
-            "goto", "if", "implements", "import", "instanceof",
-            "int", "interface", "long", "native", "new",
-            "null", "package", "private", "protected", "public",
-            "return", "short", "static", "strictfp", "super",
-            "switch", "synchronized", "this", "throw", "throws",
-            "transient", "true", "try", "void", "volatile",
-            "while"
-    };
     private final String expressionTemplate;
     private final List<ParameterType<?>> parameterTypes;
 
     public GeneratedExpression(String expressionTemplate, List<ParameterType<?>> parameterTypes) {
         this.expressionTemplate = expressionTemplate;
         this.parameterTypes = parameterTypes;
-    }
-
-    private static boolean isJavaKeyword(String keyword) {
-        return (Arrays.binarySearch(JAVA_KEYWORDS, keyword, ENGLISH_COLLATOR) >= 0);
     }
 
     public String getSource() {
@@ -45,19 +23,19 @@ public class GeneratedExpression {
         return String.format(expressionTemplate, parameterTypeNames.toArray());
     }
 
-    private String getParameterName(String typeName, Map<String, Integer> usageByTypeName) {
-        Integer count = usageByTypeName.get(typeName);
-        count = count != null ? count + 1 : 1;
-        usageByTypeName.put(typeName, count);
-
-        return count == 1 && !isJavaKeyword(typeName) ? typeName : typeName + count;
+    /**
+     * @deprecated use {@link #getParameterNames(LetterCase, ProgrammingLanguage)}
+     */
+    @Deprecated
+    public List<String> getParameterNames() {
+        return getParameterNames(LetterCase.LOWER_CAMEL_CASE, ProgrammingLanguage.JAVA);
     }
 
-    public List<String> getParameterNames() {
+    public List<String> getParameterNames(LetterCase letterCase, ProgrammingLanguage programmingLanguage) {
         HashMap<String, Integer> usageByTypeName = new HashMap<>();
         List<String> list = new ArrayList<>();
         for (ParameterType<?> parameterType : parameterTypes) {
-            String parameterName = getParameterName(parameterType.getName(), usageByTypeName);
+            String parameterName = getParameterName(parameterType.getName(), usageByTypeName, letterCase, programmingLanguage);
             list.add(parameterName);
         }
         return list;
@@ -65,5 +43,15 @@ public class GeneratedExpression {
 
     public List<ParameterType<?>> getParameterTypes() {
         return parameterTypes;
+    }
+
+    private String getParameterName(String typeName, Map<String, Integer> usageByTypeName, LetterCase letterCase, ProgrammingLanguage programmingLanguage) {
+        String name = letterCase.convert(typeName);
+
+        Integer count = usageByTypeName.get(name);
+        count = count != null ? count + 1 : 1;
+        usageByTypeName.put(name, count);
+
+        return count == 1 && !programmingLanguage.isKeyword(name) ? name : name + count;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/LetterCase.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/LetterCase.java
@@ -1,0 +1,27 @@
+package io.cucumber.cucumberexpressions;
+
+public enum LetterCase {
+    LOWER_CAMEL_CASE {
+        @Override
+        public String convert(String s) {
+            String camel = CAMEL_CASE.convert(s);
+            return Character.toLowerCase(camel.charAt(0)) + camel.substring(1);
+        }
+    },
+
+    CAMEL_CASE {
+        @Override
+        public String convert(String s) {
+            StringBuilder sb = new StringBuilder();
+            for (String part : s.split("[_-]")) {
+                sb.append(Character.toUpperCase(part.charAt(0)));
+                if (part.length() > 1) {
+                    sb.append(part.substring(1).toLowerCase());
+                }
+            }
+            return sb.toString();
+        }
+    };
+
+    public abstract String convert(String s);
+}

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ProgrammingLanguage.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ProgrammingLanguage.java
@@ -1,0 +1,31 @@
+package io.cucumber.cucumberexpressions;
+
+import java.text.Collator;
+import java.util.Arrays;
+import java.util.Locale;
+
+public enum ProgrammingLanguage {
+    JAVA {
+        private final String JAVA_KEYWORDS[] = {
+                "abstract", "assert", "boolean", "break", "byte", "case",
+                "catch", "char", "class", "const", "continue",
+                "default", "do", "double", "else", "extends",
+                "false", "final", "finally", "float", "for",
+                "goto", "if", "implements", "import", "instanceof",
+                "int", "interface", "long", "native", "new",
+                "null", "package", "private", "protected", "public",
+                "return", "short", "static", "strictfp", "super",
+                "switch", "synchronized", "this", "throw", "throws",
+                "transient", "true", "try", "void", "volatile",
+                "while"
+        };
+        private final Collator ENGLISH_COLLATOR = Collator.getInstance(Locale.ENGLISH);
+
+        @Override
+        public boolean isKeyword(String keyword) {
+            return (Arrays.binarySearch(JAVA_KEYWORDS, keyword, ENGLISH_COLLATOR) >= 0);
+        }
+    };
+
+    public abstract boolean isKeyword(String s);
+}

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CombinatorialGeneratedExpressionFactoryTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CombinatorialGeneratedExpressionFactoryTest.java
@@ -51,8 +51,7 @@ public class CombinatorialGeneratedExpressionFactoryTest {
 
         CombinatorialGeneratedExpressionFactory factory = new CombinatorialGeneratedExpressionFactory(
                 "I bought a {%s} ball on {%s}",
-                parameterTypeCombinations
-        );
+                parameterTypeCombinations);
         List<GeneratedExpression> generatedExpressions = factory.generateExpressions();
         List<String> expressions = new ArrayList<>();
         for (GeneratedExpression generatedExpression : generatedExpressions) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/LetterCaseTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/LetterCaseTest.java
@@ -1,0 +1,14 @@
+package io.cucumber.cucumberexpressions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LetterCaseTest {
+
+    @Test
+    public void java_converts_to_camel_case() {
+        assertEquals("fooBarZap", LetterCase.LOWER_CAMEL_CASE.convert("FOO-Bar_zap"));
+        assertEquals("x", LetterCase.LOWER_CAMEL_CASE.convert("X"));
+    }
+}


### PR DESCRIPTION
This is a fix for #455

Introduces `LetterCase` and `ProgrammingLanguage` enums that can be used to configure how parameter names in snippets are generated. We should port this over to Go (and add the following enum values):

* `LetterCase`
  * `CAMEL_CASE`
  * `LOWER_CAMEL_CASE`
  * `SNAKE_CASE`
* `ProgrammingLanguage`
  * `JAVA`
  * `RUBY`
  * `GO`
  * `JAVASCRIPT`

This way, [cucumber-engine](https://github.com/cucumber/cucumber-engine) will be able to generate expressions for multiple languages.

We do not need to port this code over to Ruby or JavaScript, as the plan is to adopt cucumber-engine. See the [roadmap](https://docs.google.com/document/d/12Y3Ut-SVSGdw9L_aW6NGQY9JaCcn3z0alY4d7kzOndU/) for details.