### PR TITLE
cucumber-expressions: {word}-expression with unicode fix

### DIFF
--- a/cucumber-expressions/java/examples.txt
+++ b/cucumber-expressions/java/examples.txt
@@ -17,3 +17,7 @@ I have 1 cuke in my belly now
 /^Something( with an optional argument)?$/
 Something
 [null]
+---
+Привет, {word}!
+Привет, Мир!
+["Мир"]

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
@@ -17,7 +17,7 @@ class TreeRegexp {
     private final GroupBuilder groupBuilder;
 
     TreeRegexp(String regexp) {
-        this(Pattern.compile(regexp));
+        this(Pattern.compile(regexp, Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     TreeRegexp(Pattern pattern) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ExpressionExamplesTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ExpressionExamplesTest.java
@@ -40,7 +40,7 @@ public class ExpressionExamplesTest {
         String[] chunks = s.split("---");
         for (String chunk : chunks) {
             chunk = chunk.trim();
-            data.add(chunk.split("\n"));
+            data.add(chunk.split(System.lineSeparator()));
         }
         return data;
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/TreeRegexpTest.java
@@ -97,9 +97,9 @@ public class TreeRegexpTest {
 
     @Test
     public void works_digit_and_word() {
-        TreeRegexp tr = new TreeRegexp("^(\\d) (\\w+)$");
-        Group g = tr.match("2 you");
-        assertEquals(2, g.getChildren().size());
+        TreeRegexp tr = new TreeRegexp("^(\\d) (\\w+) (\\w+)$");
+        Group g = tr.match("2 you привет");
+        assertEquals(3, g.getChildren().size());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- fix {word}-expression using Unicode characters.
- fix line separator in ExpressionExamplesTest.

## Details
I think the summary is detailed enough :)

## Motivation and Context

I have a problem when using {word}-expression with russian words. 

## How Has This Been Tested?

I've written unit-tests. An I'm testing it in my bdd-project. 

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
