### PR TITLE
cucumber-messages: Allow compatible version of google-protobuf with JRuby

### DIFF
--- a/cucumber-messages/ruby/Gemfile
+++ b/cucumber-messages/ruby/Gemfile
@@ -2,4 +2,5 @@
 source "https://rubygems.org"
 gemspec
 
+# Pick a known-good version when running builds for cucumber-messages on JRuby.
 gem 'google-protobuf', '~> 3.2.0.2', platform: :jruby

--- a/cucumber-messages/ruby/Gemfile
+++ b/cucumber-messages/ruby/Gemfile
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 gemspec
+
+gem 'google-protobuf', '~> 3.2.0.2', platform: :jruby

--- a/cucumber-messages/ruby/cucumber-messages.gemspec
+++ b/cucumber-messages/ruby/cucumber-messages.gemspec
@@ -19,6 +19,17 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/cucumber-messages/ruby',
                   }
 
+  # As of this writing (28 June 2018), the latest version is
+  # 3.6.0, which doesn't works with JRuby. 
+  # See https://github.com/google/protobuf/issues/1594 
+  # 3.1.0 works with JRuby, but fails with MRI 2.4.4 and above.
+  #
+  # There doesn't seem to be a version that works with all rubies,
+  # so we're specifying a loose dependency here on purpose so end users can
+  # pick the appropriate one in their bundle.
+  #
+  # Users of JRuby would probably install 3.2.0, while users of MRI would use
+  # 3.6.0.
   s.add_dependency 'google-protobuf', '~> 3.2'
 
   s.add_development_dependency 'bundler'

--- a/cucumber-messages/ruby/cucumber-messages.gemspec
+++ b/cucumber-messages/ruby/cucumber-messages.gemspec
@@ -19,13 +19,7 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/cucumber-messages/ruby',
                   }
 
-  # As of this writing (28 June 2018), the latest version is
-  # 3.6.0, which doesn't works with JRuby. 
-  # See https://github.com/google/protobuf/issues/1594 
-  # 3.1.0 works with JRuby, but fails with MRI 2.4.4 and above.
-  # There doesn't seem to be a version that works with all rubies,
-  # so we're picking the version that works with the most recent MRIs.
-  s.add_dependency 'google-protobuf', '3.6.1'
+  s.add_dependency 'google-protobuf', '~> 3.2'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake',      '~> 12.3'


### PR DESCRIPTION
## Summary

There is no Java release of google-protobuf version 3.6.1. The latest working Java version seems to be 3.2.0.2. Allow JRuby users to select this older version by loosening the dependency on google-protobuf.

## Details

Loosens the gem dependency as declared in the gemspec.

## Motivation and Context

Builds with Cucumber 4.0.0.rc.1 currently fail on JRuby because no compatible version of google-protobuf can be installed.

## How Has This Been Tested?

I ran the specs and installed `cucumber-messages` locally on JRuby with the older `google-protobuf` version (3.2.0.2). I then was able to ~run Cucumber scenarios with~ install cucumber 4.0.0.rc.1 under JRuby.

## Types of changes

- Bug fix (non-breaking change which fixes an issue).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
