### PR TITLE
cucumber-messages: Add testResult to the TestCaseFinished message

### DIFF
--- a/cucumber-messages/go/messages.proto
+++ b/cucumber-messages/go/messages.proto
@@ -214,7 +214,8 @@ message TestCaseStarted {
 
 message TestCaseFinished {
   string pickleId = 1;
-  google.protobuf.Timestamp timestamp = 2;
+  TestResult testResult = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message TestStepStarted {

--- a/cucumber-messages/java/messages.proto
+++ b/cucumber-messages/java/messages.proto
@@ -214,7 +214,8 @@ message TestCaseStarted {
 
 message TestCaseFinished {
   string pickleId = 1;
-  google.protobuf.Timestamp timestamp = 2;
+  TestResult testResult = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message TestStepStarted {

--- a/cucumber-messages/javascript/messages.proto
+++ b/cucumber-messages/javascript/messages.proto
@@ -214,7 +214,8 @@ message TestCaseStarted {
 
 message TestCaseFinished {
   string pickleId = 1;
-  google.protobuf.Timestamp timestamp = 2;
+  TestResult testResult = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message TestStepStarted {

--- a/cucumber-messages/messages.proto
+++ b/cucumber-messages/messages.proto
@@ -214,7 +214,8 @@ message TestCaseStarted {
 
 message TestCaseFinished {
   string pickleId = 1;
-  google.protobuf.Timestamp timestamp = 2;
+  TestResult testResult = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message TestStepStarted {

--- a/cucumber-messages/ruby/messages.proto
+++ b/cucumber-messages/ruby/messages.proto
@@ -214,7 +214,8 @@ message TestCaseStarted {
 
 message TestCaseFinished {
   string pickleId = 1;
-  google.protobuf.Timestamp timestamp = 2;
+  TestResult testResult = 2;
+  google.protobuf.Timestamp timestamp = 3;
 }
 
 message TestStepStarted {


### PR DESCRIPTION
## Summary

The TestCaseFinished message should have a testResult field.

## Details

Also the TestCaseFinished message should have a testResult field, not only the TestStepFinished.

## Motivation and Context

Since the summary is printed:
```
xxx scenarios (x1 Passed, ...)
yyy steps (y1 Passed, ...)
```
the concept of test cases having result clearly exists. It should be the responsibility of the cucumber-engine to calculate that result, not each and every listener to the message stream. The cucumber-engine need to know the result of the test case (so far) anyway to be able to decide how to treat the next step (run, skip ...).

## How Has This Been Tested?

Still WIP

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

Is adding a field to a message a "new feature" or a "breaking change"?

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
