### PR TITLE
tag-expressions-python: Update and basic support for #406

### DIFF
--- a/tag-expressions/python/.bumpversion.cfg
+++ b/tag-expressions/python/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
-current_version = 1.0.2
-files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg
+current_version = 1.1.1
+files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg pytest.ini
 commit = False
 tag = False
 allow_dirty = True

--- a/tag-expressions/python/.gitignore
+++ b/tag-expressions/python/.gitignore
@@ -17,4 +17,6 @@ __*/
 .venv*/
 .DS_Store
 .coverage
+.deps
+.tested
 Pipfile.lock

--- a/tag-expressions/python/.subrepo
+++ b/tag-expressions/python/.subrepo
@@ -1,1 +1,1 @@
-cucumber/tag-expressions-python
+cucumber/tag-expressions-python.git

--- a/tag-expressions/python/.travis.yml
+++ b/tag-expressions/python/.travis.yml
@@ -6,8 +6,9 @@
 sudo: false
 language: python
 python:
-  - "3.6"
+  - "3.7-dev"
   - "2.7"
+  - "3.6"
   - "3.5"
   - "pypy"
   - "pypy3"

--- a/tag-expressions/python/Pipfile
+++ b/tag-expressions/python/Pipfile
@@ -1,19 +1,14 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [dev-packages]
 
-
-
 [packages]
-
-pytest = ">=3.0"
-pytest-html = ">=1.16"
-tox = ">=2.9.1"
+pytest = ">=3.2"
+pytest-html = ">=1.19"
+tox = ">=2.9"
 coverage = ">=4.2"
 "enum34" = "*"
 invoke = ">=0.21.0"
@@ -21,3 +16,4 @@ invoke = ">=0.21.0"
 pathlib = "*"
 "backports.shutil_which" = "*"
 pycmd = "*"
+six = ">=1.11.0"

--- a/tag-expressions/python/README.md
+++ b/tag-expressions/python/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/cucumber/tag-expressions-python.svg?branch=master)](https://travis-ci.org/cucumber/tag-expressions-python)
 
-[The docs are here](https://docs.cucumber.io/cucumber/api/#tag-expressions)
+[The docs are here](https://docs.cucumber.io/cucumber/tag-expressions/)

--- a/tag-expressions/python/README.rst
+++ b/tag-expressions/python/README.rst
@@ -1,7 +1,6 @@
 Cucumber Tag Expressions for Python
 ===============================================================================
 
-
 .. image:: https://img.shields.io/travis/cucumber/tag-expressions-python/master.svg
     :target: https://travis-ci.org/cucumber/tag-expressions-python
     :alt: Travis CI Build Status
@@ -24,15 +23,16 @@ Cucumber tag-expressions provide readable boolean expressions
 to select features and scenarios marked with tags in Gherkin files
 in an easy way::
 
-    # -- TAG-EXPRESSION EXAMPLES:
-
+    # -- SIMPLE TAG-EXPRESSION EXAMPLES:
     @a and @b
     @a or  @b
     not @a
 
+    # -- MORE TAG-EXPRESSION EXAMPLES:
     @a and not @b
     (@a or @b) and not @c
 
 
 SEE ALSO:
-* `cucumber tag-expressions docs <https://docs.cucumber.io/cucumber/api/#tag-expressions>`_
+
+* https://docs.cucumber.io/cucumber/tag-expressions/

--- a/tag-expressions/python/cucumber_tag_expressions/__init__.py
+++ b/tag-expressions/python/cucumber_tag_expressions/__init__.py
@@ -1,6 +1,19 @@
 # -*- coding: UTF-8 -*-
+"""
+Python implementation of `cucumber tag-expressions`_.
+
+Tag-expressions are used in cucumber, behave and other BDD frameworks
+to select features, scenarios, etc. in `Gherkin`_ files.
+Theses selected items are normally included in a test run.
+
+.. seealso:: https://docs.cucumber.io/cucumber/tag-expressions/
+
+.. _`cucumber tag-expressions`: https://docs.cucumber.io/cucumber/tag-expressions/
+.. _`Gherkin`: https://docs.cucumber.io/gherkin/reference/
+.. _`behave: Gherkin`: https://behave.readthedocs.io/en/latest/philosophy.html#the-gherkin-language
+"""
 
 from __future__ import absolute_import
 from .parser import parse, TagExpressionParser, TagExpressionError
 
-__version__ = "1.0.2"
+__version__ = "1.1.1"

--- a/tag-expressions/python/cucumber_tag_expressions/parser.py
+++ b/tag-expressions/python/cucumber_tag_expressions/parser.py
@@ -10,7 +10,7 @@ Provides parsing of boolean tag expressions.
     assert "( a and ( b or not (c) ) )" == str(expression)
 
 UNSUPPORTED:
-* Support special tags w/ escaped-parens: @reqid\(10\)
+* Support special tags w/ escaped-parens: ``@reqid\(10\)``
 """
 
 from __future__ import absolute_import
@@ -108,7 +108,7 @@ class TagExpressionError(Exception):
 # -----------------------------------------------------------------------------
 class TagExpressionParser(object):
     """Parser class to parse boolean tag-expressions.
-    This class uses the `Shunting Yard algorithm`_ to parse the tag-expression. 
+    This class uses the `Shunting Yard algorithm`_ to parse the tag-expression.
 
     Boolean operations:
 
@@ -130,7 +130,7 @@ class TagExpressionParser(object):
         expression = TagExpressionParser.parse(text11)
         assert False == expression.evaluate(["foo"])
         assert True  == expression.evaluate(["other"])
-        
+
         # -- BINARY OPERATIONS:
         text21 = "foo and bar" = "(foo and bar)"
         expression = TagExpressionParser.parse(text21)
@@ -143,9 +143,9 @@ class TagExpressionParser(object):
         assert True  == expression.evaluate(["foo", "bar"])
         assert True  == expression.evaluate(["foo", "other"])
         assert False == expression.evaluate([])
-        
+
     .. see::
-    
+
         * `Shunting Yard algorithm`_
         * http://rosettacode.org/wiki/Parsing/Shunting-yard_algorithm
 
@@ -163,6 +163,12 @@ class TagExpressionParser(object):
         :return: Token object or None, if not found.
         """
         return cls.TOKEN_MAP.get(text, None)
+
+    @classmethod
+    def make_operand(cls, text):
+        """Creates operand-object from parsed text."""
+        # -- EXTENSION-POINT: For #406 or similar.
+        return Literal(text)
 
     @classmethod
     def parse(cls, text):
@@ -195,8 +201,9 @@ class TagExpressionParser(object):
         for index, part in enumerate(parts):
             token = cls.select_token(part)
             if token is None:
+                # -- CASE OPERAND: Literal or ...
                 ensure_expected_token_type(TokenType.OPERAND)
-                expressions.append(Literal(part))
+                expressions.append(cls.make_operand(part))
                 expected_token_type = TokenType.OPERATOR
             elif token.is_unary:
                 ensure_expected_token_type(TokenType.OPERAND)

--- a/tag-expressions/python/invoke.yaml
+++ b/tag-expressions/python/invoke.yaml
@@ -16,4 +16,7 @@ run:
     echo: true
     pty:  true
 
-
+clean_all:
+    extra_directories:
+      - .pytest_cache
+      - .hypothesis

--- a/tag-expressions/python/py.requirements/testing.txt
+++ b/tag-expressions/python/py.requirements/testing.txt
@@ -2,9 +2,9 @@
 # PYTHON PACKAGE REQUIREMENTS FOR: For testing only
 # ============================================================================
 
-pytest >= 3.0
-pytest-html >= 1.16
+pytest >= 3.2
+pytest-html >= 1.19
 
 # -- DEVELOPMENT SUPPORT: Testing
-tox >= 2.9.1
+tox >= 2.9
 coverage >= 4.2

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -19,6 +19,11 @@
 minversion    = 3.2
 testpaths     = tests
 python_files  = test_*.py
+addopts = --metadata PACKAGE_UNDER_TEST cucumber-tag-expressions
+    --metadata PACKAGE_VERSION 1.1.1
+    --html=build/testing/report.html --self-contained-html
+    --junit-xml=build/testing/report.xml
+
 # -- BACKWARD COMPATIBILITY: pytest < 2.8
 norecursedirs = .git .tox attic build dist py.requirements tmp* _WORKSPACE
 

--- a/tag-expressions/python/setup.py
+++ b/tag-expressions/python/setup.py
@@ -6,7 +6,7 @@ Setup package for package life-cycle tasks: install, sdist, ...
 SEE ALSO:
 
 * https://packaging.python.org
-  
+
 REQUIRES:
 
 * setuptools are installed
@@ -54,28 +54,36 @@ def find_packages_by_root_package(where):
 # -----------------------------------------------------------------------------
 setup(
     name = "cucumber-tag-expressions",
-    version = "1.0.2",
+    version = "1.1.1",
     author = "Jens Engel",
     author_email = "jenisys@noreply.github.com",
     url = "https://github.com/cucumber/tag-expressions-python",
     download_url= "http://pypi.python.org/pypi/cucumber-tag-expressions",
     description = "Provides tag-expression parser for cucumber/behave",
     long_description = long_description,
-    keywords= "BDD, testing, behave, cucumber, tag-expressions",
-    license = "BSD",
+    keywords= "BDD, testing, cucumber, tag-expressions, behave",
+    license = "MIT",
     packages = find_packages_by_root_package("cucumber_tag_expressions"),
     include_package_data = True,
 
     # -- REQUIREMENTS:
     python_requires=">=2.7",
-    # XXX setup_requires = ["pytest-runner >= 3.0"],
-    install_requires=["enum34; python_version < '3.4'"],
-    tests_require=["pytest >= 3.0"],
+    install_requires=[
+        "enum34; python_version < '3.4'"
+    ],
+    tests_require=[
+        "pytest >= 3.2",
+        "pytest-html >= 1.19.0",
+    ],
     extras_require={
         # PREPARED: 'docs': ["sphinx>=1.5"],
         'develop': [
-            "coverage", "pytest >= 3.0", "tox >= 2.9",
-            "invoke", "path.py",
+            "coverage",
+            "pytest >= 3.2",
+            "pytest-html >= 1.19.0",
+            "tox >= 2.9",
+            "invoke",
+            "path.py",
             "pylint"
         ],
     },
@@ -93,6 +101,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Testing",

--- a/tag-expressions/python/tox.ini
+++ b/tag-expressions/python/tox.ini
@@ -22,7 +22,7 @@
 
 [tox]
 minversion   = 2.8
-envlist      = py27, py35, py36, pypy
+envlist      = py27, py37, py36, py36, py35, pypy
 skip_missing_interpreters = True
 
 

--- a/tag-expressions/python/tox.ini
+++ b/tag-expressions/python/tox.ini
@@ -35,7 +35,8 @@ changedir = {toxinidir}
 commands=
     pytest {posargs:tests}
 deps=
-    pytest>=3.0
+    pytest>=3.2
+    pytest-html>=1.19
 passenv =
      PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
## Summary

Add basic support for #406 to be solved externally by providing overridable function as extension point.

## Details

In addition:

* Update to newest Python 3.7 and newer package versions.
* Fix URL to cucumber tag-expression docs in `README.md` (info was moved, already corrected on other  tag-expression implementations (Java, Javascript, ...).

## Motivation and Context

With this change the functionality of feature request #406 can be solved externally.
A function was added that can serve as extension point to implement the desired functionality.

## How Has This Been Tested?

Test suite works (as before).

## Types of changes

- [x] Refactoring (to improve extensibility and future code changes).
- [x] Bug fix (non-breaking change which fixes an issue): URL to docs fixed.
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.