### PR TITLE
tag-expressions.python: Bump version to 1.1.2.dev0 (was: 1.1.1)

### DIFF
--- a/tag-expressions/python/.bumpversion.cfg
+++ b/tag-expressions/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2.dev0
 files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg pytest.ini
 commit = False
 tag = False

--- a/tag-expressions/python/cucumber_tag_expressions/__init__.py
+++ b/tag-expressions/python/cucumber_tag_expressions/__init__.py
@@ -16,4 +16,4 @@ Theses selected items are normally included in a test run.
 from __future__ import absolute_import
 from .parser import parse, TagExpressionParser, TagExpressionError
 
-__version__ = "1.1.1"
+__version__ = "1.1.2.dev0"

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -20,7 +20,7 @@ minversion    = 3.2
 testpaths     = tests
 python_files  = test_*.py
 addopts = --metadata PACKAGE_UNDER_TEST cucumber-tag-expressions
-    --metadata PACKAGE_VERSION 1.1.1
+    --metadata PACKAGE_VERSION 1.1.2.dev0
     --html=build/testing/report.html --self-contained-html
     --junit-xml=build/testing/report.xml
 

--- a/tag-expressions/python/setup.py
+++ b/tag-expressions/python/setup.py
@@ -54,7 +54,7 @@ def find_packages_by_root_package(where):
 # -----------------------------------------------------------------------------
 setup(
     name = "cucumber-tag-expressions",
-    version = "1.1.1",
+    version = "1.1.2.dev0",
     author = "Jens Engel",
     author_email = "jenisys@noreply.github.com",
     url = "https://github.com/cucumber/tag-expressions-python",


### PR DESCRIPTION
## Summary

BUMP-VERSION: 1.1.2.dev0 (was: 1.1.1). 
Reenable development mode again.

## Motivation and Context

After release post-processing to mark package version as in development mode.

## How Has This Been Tested?

Tox run w/ multiple Python versions.

## Types of changes

- [x] Version bump
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
