### PR TITLE
tag-expressions.python: FIX: CI travis build: push_subrepos step

### DIFF
--- a/tag-expressions/python/.subrepo
+++ b/tag-expressions/python/.subrepo
@@ -1,1 +1,1 @@
-cucumber/tag-expressions-python.git
+cucumber/tag-expressions-python


### PR DESCRIPTION
## Summary

FIX Travis build that currently fails in step "scripts/push_subrepos.sh". 

## Details 

Current Travis build fails in step "scripts/push_subrepos.sh":

```
# -- TRAVIS BUILD LOG:
...
28 commits created, 2210 commits traversed, in 1.005s
remote: Repository not found.
fatal: repository 'https://[secure]@github.com/cucumber/tag-expressions-python.git.git/' not found

The command "scripts/push_subrepos.sh" exited with 1.
...
```

FIX: Remove ".git" in file ".subrepo" again.

## How Has This Been Tested?

SAD: Can only be tested on Travis build (AFAIK).

## Types of changes

- [x] Bug fix (non-breaking change; was not notices yet ?!?).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
