### PR TITLE
Leading Tab characters break parser logic

### DIFF
--- a/gherkin/c/src/gherkin_line.c
+++ b/gherkin/c/src/gherkin_line.c
@@ -28,7 +28,7 @@ const GherkinLine* GherkinLine_new(const wchar_t* line_text, int line_number) {
     line->indent = 0;
     line->line_text = line_text;
     line->trimmed_line = line_text;
-    while (line->trimmed_line[0] != '\0' && line->trimmed_line[0] == L' ') {
+    while (line->trimmed_line[0] != '\0' && (line->trimmed_line[0] == L' ' || line->trimmed_line[0] == L'\t')) {
         ++line->trimmed_line;
         ++line->indent;
     }


### PR DESCRIPTION
Leading Tab characters is kept in the trimmed_line and
GherkinLine_start_with can't recognize keywords in this case

<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

If a feature file uses Tab character for indentation then the parser build incorrect AST: nothing keywords will not be detected in the text with indentation.

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->
I'v modified GherkinLine_new to remove leading Tab characters in the trimmed_line field as well as whitespaces.

## Motivation and Context

Our editor allows to use Tab characters. In this case we had invalid AST.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
