### PR TITLE
[Gherkin C] Empty lines in the description break the parser with memory access error

### DIFF
--- a/gherkin/c/src/ast_builder.c
+++ b/gherkin/c/src/ast_builder.c
@@ -429,7 +429,7 @@ static const wchar_t* get_description_text(AstNode* ast_node) {
     int current_line = 0;
     while (queue_item) {
         ++current_line;
-        if (!GherkinLine_is_empty(((Token*)queue_item->item)->line)) {
+        if (/*!GherkinLine_is_empty(((Token*)queue_item->item)->line)*/true) { //create_multi_line_text_from_tokens doesn't skip GherkinLine_is_empty lines
             line_count = current_line;
             text_length += wcslen(((Token*)queue_item->item)->matched_text);
         }


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Lines in the description that comply condition GherkinLine_is_empty can break down the parser with memory access error
<!--- Provide a general summary description of your changes -->

## Details
GherkinLine_is_empty returns true if the line is empty or contains only whitespaces (or/and tab characters). In the second case the line has real content and nonzero length. Let's see on the get_description_text implementation. At first we pass through description lines to calculate text_length and empty lines (GherkinLine_is_empty) is skipped here. At now let's see on the create_multi_line_text_from_tokens.
The buffer with text_length size for result text is allocated. Then we again pass through description lines and sequentially copy its to the prepared buffer. Empty lines isn't skipped on this step and summary size of the copied text is greater then buffer size. So we wrote outside of the prepared buffer.

I made a consistent calculation of the buffer size (text_length) and filling the buffer 
<!--- Describe your changes in detail -->

## Motivation and Context
Modern editors keep indentation of the new line by the previous line indent. So the line with only whitespaces/tabs in the description is common case, especially while editing file
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
