### PR TITLE
datatables: Fix priority of default converters

### DIFF
--- a/datatable/CHANGELOG.md
+++ b/datatable/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
+* Fix priority of default converters
+  ([#514](https://github.com/cucumber/cucumber/pull/514)
+   [mpkorstanje])
 ## [1.1.3] - 2018-07-27
 
 ### Added

--- a/datatable/README.md
+++ b/datatable/README.md
@@ -348,6 +348,10 @@ private class JacksonDataTableTransformer implements TableEntryByTypeTransformer
 }
 ```
 
+The`TableEntryByTypeTransformer` and `TableCellByTypeTransformer` are used when there is no table entry or table cell 
+defined for a given type. Note that when installing both `TableEntryByTypeTransformer` and `TableCellByTypeTransformer`
+it becomes impossible to disambiguate between table entries and table cells. By default table entries are assumed over
+table cells. This ambiguity can be resolved by adding a header.
 
 ## Diffing
 

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -118,34 +118,32 @@ public final class DataTableTypeRegistry {
 
     public DataTableType lookupTableTypeByType(final Type tableType) {
         JavaType targetType = constructType(tableType);
-        DataTableType dataTableType = tableTypeByType.get(targetType);
+        return tableTypeByType.get(targetType);
+    }
 
-        if(dataTableType != null){
-            return dataTableType;
-        }
-
-        if(!targetType.isCollectionLikeType()){
-            return  null;
-        }
-
-        JavaType contentType = targetType.getContentType();
-        if(contentType.isCollectionLikeType()) {
-            if(defaultDataTableCellTransformer != null){
-                return DataTableType.defaultCell(
-                        contentType.getContentType().getRawClass(),
-                        defaultDataTableCellTransformer
-                );
-            }
+    public DataTableType getDefaultTableCellTransformer(final Type tableType) {
+        if (defaultDataTableCellTransformer == null) {
             return null;
         }
-        if (defaultDataTableEntryTransformer != null){
-            return DataTableType.defaultEntry(
-                    contentType.getRawClass(),
-                    defaultDataTableEntryTransformer,
-                    tableCellByTypeTransformer
-            );
+
+        JavaType targetType = constructType(tableType);
+        return DataTableType.defaultCell(
+                targetType.getRawClass(),
+                defaultDataTableCellTransformer
+        );
+    }
+
+    public DataTableType getDefaultTableEntryTransformer(final Type tableType) {
+        if (defaultDataTableEntryTransformer == null) {
+            return null;
         }
-        return null;
+
+        JavaType targetType = constructType(tableType);
+        return DataTableType.defaultEntry(
+                targetType.getRawClass(),
+                defaultDataTableEntryTransformer,
+                tableCellByTypeTransformer
+        );
     }
 
     public void setDefaultDataTableEntryTransformer(TableEntryByTypeTransformer defaultDataTableEntryTransformer) {

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -97,39 +97,6 @@ public class DataTableTypeRegistryTest {
         assertNull(lookupTableTypeByType);
     }
 
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void returns_default_data_table_type_for_cell_if_none_match_and_default_registered() {
-
-        registry.defineDataTableType(DataTableType.cell(DataTableTypeRegistryTest.class));
-        registry.defineDataTableType(DataTableType.entry(DataTableTypeRegistryTest.class));
-        registry.setDefaultDataTableCellTransformer(PLACE_TABLE_CELL_TRANSFORMER);
-        registry.setDefaultDataTableEntryTransformer(PLACE_TABLE_ENTRY_TRANSFORMER);
-
-        DataTableType dataTableType = requireNonNull(registry.lookupTableTypeByType(LIST_OF_LIST_OF_PLACE));
-        List<List<Place>> transformedCells = (List<List<Place>>) dataTableType.transform(singletonList(singletonList("here")));
-
-        assertEquals(singletonList(singletonList(new Place("here"))), transformedCells);
-
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void returns_default_data_table_type_for_entry_if_none_match_and_default_registered() {
-
-        registry.defineDataTableType(DataTableType.cell(DataTableTypeRegistryTest.class));
-        registry.defineDataTableType(DataTableType.entry(DataTableTypeRegistryTest.class));
-        registry.setDefaultDataTableCellTransformer(PLACE_TABLE_CELL_TRANSFORMER);
-        registry.setDefaultDataTableEntryTransformer(PLACE_TABLE_ENTRY_TRANSFORMER);
-
-        DataTableType dataTableType = requireNonNull(registry.lookupTableTypeByType(LIST_OF_PLACE));
-
-        List<Place> transformedEntries = (List<Place>) dataTableType.transform(asList(asList("name","index of place"), asList("here","20")));
-
-        assertEquals(singletonList(new Place("here", 20)), transformedEntries);
-    }
-
     @Test
     public void returns_cell_data_table_type() {
 


### PR DESCRIPTION
## Summary

In some scenarios default converters would be used when a defined
converter was available. This was caused by returning a default
converter as soon as no regular converter was available.

This heuristic works well with two exceptions:
 * When the table contains a single line the default table entry
   transformer is never applicable
 * When the table keys don't imply a table entry the default table
   entry transformer is never applicable

By inlining this lookup and working out the exceptions the
old behaviour is restored.

## Details

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1489
Fixes: https://github.com/cucumber/cucumber-jvm/issues/1490

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
