### PR TITLE
[Gherkin C] Memory leak occurs due too many parser errors

### DIFF
--- a/gherkin/c/src/error_list.c
+++ b/gherkin/c/src/error_list.c
@@ -66,9 +66,6 @@ Error* ErrorList_remove(ErrorList* error_list) {
 
 void ErrorList_add(ErrorList* error_list, const wchar_t* error_text, const Location location) {
     ItemQueue_add(error_list->errors, (Item*)Error_new(error_text, location));
-    if (ItemQueue_size(error_list->errors) > 10) {
-        ErrorList_jump_to_global_rescue_env(error_list);
-    }
 }
 
 void ErrorList_add_unexpected_eof_error(ErrorList* error_list, Token* received_token, const wchar_t* expected_tokens) {


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Memory leak occurs when count of parse errors exceeds 10: parse cycle is broke and current token doesn't released

## Details

`ErrorList_add` is internally used in the `ErrorList_add_unexpected_eof_error` and `ErrorList_add_unexpected_token_error`.
These 2 functions are used in the `match_token_at_XX` by the next template:
```
Token_is_eof(token) ? ErrorList_add_unexpected_eof_error(context->errors, token, expected_tokens) : ErrorList_add_unexpected_token_error(context->errors, token, expected_tokens);
Token_delete(token);

```
So if `ErrorList_jump_to_global_rescue_env` will executed within `ErrorList_add_unexpected_eof_error` or `ErrorList_add_unexpected_token_error`, then `Token_delete` for the current
token will never executed and we get memory leak.

## Motivation and Context

It's easy to break structure of the feature file while editing. In my case parser is started on each change of the file.

## How Has This Been Tested?

I've observed the leak in the debug mode of the MS Visual Studio with memory leak detection mode:

```
#define _CRTDBG_MAP_ALLOC  
#include <stdlib.h>  
#include <crtdbg.h>  

_CrtDumpMemoryLeaks();

```

I have no ideas how it can be tested

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
