### PR TITLE
datatable-java: use provided locale to parse BigDecimal in DataTableRegistry

### DIFF
--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -34,7 +34,7 @@ public final class DataTableTypeRegistry {
         defineDataTableType(new DataTableType(BigDecimal.class, new TableCellTransformer<BigDecimal>() {
             @Override
             public BigDecimal transform(String cell) {
-                return new BigDecimal(cell);
+                return numberParser.parseDecimal(cell);
             }
         }));
 

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/NumberParser.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/NumberParser.java
@@ -1,5 +1,6 @@
 package io.cucumber.datatable;
 
+import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.ParseException;
 
@@ -16,6 +17,10 @@ class NumberParser {
 
     float parseFloat(String s) {
         return parse(s).floatValue();
+    }
+
+    BigDecimal parseDecimal(String s) {
+        return BigDecimal.valueOf(parse(s).doubleValue());
     }
 
     private Number parse(String s) {

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -5,15 +5,14 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static io.cucumber.datatable.TypeFactory.aListOf;
 import static io.cucumber.datatable.TypeFactory.constructType;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -22,6 +21,7 @@ public class DataTableTypeRegistryTest {
 
     private static final Type LIST_OF_LIST_OF_PLACE = aListOf(aListOf(Place.class));
     private static final Type LIST_OF_PLACE = aListOf(Place.class);
+    private static final Type LIST_OF_LIST_OF_DECIMAL = aListOf(aListOf(BigDecimal.class));
     private static final TableCellByTypeTransformer PLACE_TABLE_CELL_TRANSFORMER = new TableCellByTypeTransformer() {
         @Override
         @SuppressWarnings("unchecked")
@@ -119,5 +119,25 @@ public class DataTableTypeRegistryTest {
         DataTableType lookupTableTypeByType = registry.lookupTableTypeByType(LIST_OF_PLACE);
 
         assertSame(entry, lookupTableTypeByType);
+    }
+
+    @Test
+    public void parse_decimal_with_english_locale() {
+        parse_decimal_with_provided_locale(registry, "12.45", 12.45);
+    }
+
+    @Test
+    public void parse_decimal_with_polish_locale() {
+        DataTableTypeRegistry plRegistry = new DataTableTypeRegistry(Locale.forLanguageTag("pl"));
+        parse_decimal_with_provided_locale(plRegistry, "12,45", 12.45);
+
+    }
+
+    private void parse_decimal_with_provided_locale(DataTableTypeRegistry typeRegistry, String decimalString, double expectedDecimalValue) {
+        //noinspection unchecked
+        List<List<BigDecimal>> transform = (List<List<BigDecimal>>) typeRegistry.lookupTableTypeByType(LIST_OF_LIST_OF_DECIMAL).transform(Collections.singletonList(Collections.singletonList(decimalString)));
+
+        assertEquals(1,transform.size());
+        assertEquals(0,transform.get(0).get(0).compareTo(BigDecimal.valueOf(expectedDecimalValue)));
     }
 }


### PR DESCRIPTION
## Summary

Parse `BigDecimal` in DataTableRegistry using locale provided by `TypeRegistryConfigurer`

## Details
Previously BigDecimal in data table cell was parsed by invoking `new BigDecimal(cell)`. This does not work well with non english locale like polish. However double and float are parsed with provided locale so BigDecimal should be treated the same way.

## How Has This Been Tested?

I've added unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
