### PR TITLE
Fix locale for number parsers

### DIFF
--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 
 public class NumberParserTest {
 
-    private final NumberParser english = new NumberParser(Locale.forLanguageTag("fy"));
+    private final NumberParser english = new NumberParser(Locale.ENGLISH);
     private final NumberParser german = new NumberParser(Locale.GERMAN);
 
     @Test

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/NumberParserTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/NumberParserTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 
 public class NumberParserTest {
 
-    private final NumberParser english = new NumberParser(Locale.forLanguageTag("fy"));
+    private final NumberParser english = new NumberParser(Locale.ENGLISH);
     private final NumberParser german = new NumberParser(Locale.GERMAN);
 
     @Test


### PR DESCRIPTION
## Summary

Fix locale for number parsers

## Motivation and Context

Obvious mistake. Failure went unnoticed because the core repo always fails.