### PR TITLE
gherkin-c: Allow user to choose between static and dynamic lib

### DIFF
--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -64,7 +64,7 @@ LIST(APPEND GHERKIN_CLI
         )
 
 
-add_library(gherkin SHARED ${GHERKIN_SRS})
+add_library(gherkin ${GHERKIN_SRS})
 target_include_directories(gherkin PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
 


### PR DESCRIPTION
## Summary
Allow the user to specify whether they want a static or dynamic library.

## Details
The `SHARED` in the call of `add_library` has been removed.

## Motivation and Context
Not everyone wants to have a dynamic `gherkin-c` library, it should be the users choice whether they need a static or a dynamic build. For that purpose CMake provides the variable `BUILD_SHARED_LIBS` to be set by the user. However, explicitly specifying a SHARED or STATIC library build in `add_library` causes this setting to be ignored. Thus by removing the `SHARED` in `add_library` the users can now choose themselves.

## How Has This Been Tested?
I built the library locally using 
`cmake -DBUILD_SHARED_LIBS=ON -Bbuild -H. && cmake --build build`
and using `cmake -DBUILD_SHARED_LIBS=OFF -Bbuild -H. && cmake --build build`
with cmake 3.13.1 on linux.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
