### PR TITLE
gherkin-c: Link against `libm` if required

### DIFF
--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -68,6 +68,23 @@ add_library(gherkin ${GHERKIN_SRS})
 target_include_directories(gherkin PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
 
+include(CheckSymbolExists)
+include(CMakePushCheckState)
+
+cmake_push_check_state()
+set(CMAKE_REQUIRED_QUIET ON)
+check_symbol_exists(log10 math.h RES)
+if(NOT RES)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+  check_symbol_exists(log10 math.h RES2)
+  if(RES2)
+    target_link_libraries(gherkin PRIVATE m)
+  else()
+      message(FATAL_ERROR "Don't know what library to link against to use log10.")
+  endif()
+endif()
+cmake_pop_check_state()
+
 add_executable(gherkinexe ${GHERKIN_CLI})
 target_link_libraries(gherkinexe gherkin)
 target_include_directories(gherkinexe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)


### PR DESCRIPTION
## Summary
Duing the configuration of the build, check whether linking against `libm` is required to use `log10`, and if so, link against it. 

## Details
Using the `CheckSymbolExists` CMake module we now first check whether `log10` can be used without any additional library, if not we try again with `libm`, and if it still fails we give up and abort the build.

## Motivation and Context
The `glibc` C library used by most linux distributions requires to link against `libm` to use `log10`. gherkin-c uses `log10` in `error_list.c` but so far didn't link against `libm`, causing the build to fail on my Arch linux. 

## How Has This Been Tested?
By observing that after this change I can build gherkin-c on my linux box with both GCC and clang.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
