### PR TITLE
gherkin-c: Use CTest to run the tests in CMake builds

### DIFF
--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -89,7 +89,22 @@ foreach(ENTITY ${GOOD_FEATURE_FILES})
     get_filename_component(TEST_NAME ${ENTITY} NAME_WE)
     add_test(
         NAME ${TEST_NAME}
-        COMMAND $<TARGET_FILE:gherkinexe> ${ENTITY}
+        COMMAND ${CMAKE_COMMAND}
+                -DGHERKINEXE=$<TARGET_FILE:gherkinexe>
+                -DGHERKIN_GENERATE_TOKENS=$<TARGET_FILE:gherkin_generate_tokens>
+                -DFEATUREFILE=${ENTITY}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TestRunner.cmake
+    )
+endforeach()
+foreach(ENTITY ${BAD_FEATURE_FILES})
+    get_filename_component(TEST_NAME ${ENTITY} NAME_WE)
+    add_test(
+        NAME ${TEST_NAME}
+        COMMAND ${CMAKE_COMMAND}
+                -DGHERKINEXE=$<TARGET_FILE:gherkinexe>
+                -DGHERKIN_GENERATE_TOKENS=$<TARGET_FILE:gherkin_generate_tokens>
+                -DFEATUREFILE=${ENTITY}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TestRunner.cmake
     )
 endforeach()
 

--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -64,6 +64,8 @@ LIST(APPEND GHERKIN_CLI
         src/gherkin_cli.c
         )
 
+include(CTest)
+enable_testing()
 
 add_library(gherkin ${GHERKIN_SRS})
 target_include_directories(gherkin PUBLIC
@@ -82,16 +84,15 @@ file(GLOB GOOD_FEATURE_FILES
 file(GLOB BAD_FEATURE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/testdata/bad/*.feature
         )
-add_custom_target(invo DEPENDS invo)
-add_dependencies(invo gherkinexe)
-FOREACH(ENTITY ${GOOD_FEATURE_FILES})
-    add_custom_command(
-            TARGET gherkinexe
-            POST_BUILD
-            COMMAND gherkinexe  ${ENTITY}
-            DEPENDS invo
+
+foreach(ENTITY ${GOOD_FEATURE_FILES})
+    get_filename_component(TEST_NAME ${ENTITY} NAME_WE)
+    add_test(
+        NAME ${TEST_NAME}
+        COMMAND $<TARGET_FILE:gherkinexe> ${ENTITY}
     )
-ENDFOREACH()
+endforeach()
+
 ############ Installation section ############
 set(include_install_dir "include")
 set(lib_install_dir "lib/")

--- a/gherkin/c/README.md
+++ b/gherkin/c/README.md
@@ -2,11 +2,19 @@
 
 <h2>Build instruction:</h2>
 
+From the source directory run
+
 ```
-mkdir build
-cd build
-cmake ..
-cmake --build . --target install
+cmake -Bbuild -H.
+cmake --build build
+```
+to build, then optionally run the tests via
+```
+cmake --build build --target test
+```
+and finally install via
+```
+cmake --build build --target install
 ```
 
 ![](https://raw.githubusercontent.com/Pwera/gherkin-c/master/gherkin.gif)

--- a/gherkin/c/cmake/TestRunner.cmake
+++ b/gherkin/c/cmake/TestRunner.cmake
@@ -1,0 +1,125 @@
+# This script expects 3 variables to be set when called
+#
+#   GHERKINEXE: Path to the `gherkinexe` executable
+#   GHERKIN_GENERATE_TOKENS: Path to the `gherkin_generate_tokens` executable
+#   FEATUREFILE: Path to the feature file to run on
+
+get_filename_component(FEATUREFILE_DIRECTORY ${FEATUREFILE} DIRECTORY)
+get_filename_component(GOOD_OR_BAD ${FEATUREFILE_DIRECTORY} NAME)
+
+if (GOOD_OR_BAD STREQUAL "good")
+    set(EXPECT_ERROR FALSE)
+else()
+    set(EXPECT_ERROR TRUE)
+endif()
+
+get_filename_component(PROJECT_ROOT "${FEATUREFILE_DIRECTORY}/../.." REALPATH)
+
+# ensure FEATUREFILE is a relative path w.r.t PROJECT_ROOT
+# this is required because the expected output assumes the uris are relative
+if (IS_ABSOLUTE ${FEATUREFILE})
+    file(RELATIVE_PATH FEATUREFILE ${PROJECT_ROOT} ${FEATUREFILE})
+endif()
+
+# in a first step check that the feature file can be parsed successfully
+# if and only if we expect it to be parsed successfully
+execute_process(COMMAND ${GHERKINEXE} --no-pickles --no-ast --no-source ${FEATUREFILE}
+                RESULT_VARIABLE HAD_ERROR
+                WORKING_DIRECTORY ${PROJECT_ROOT}
+)
+
+if(HAD_ERROR AND NOT EXPECT_ERROR)
+    message(FATAL_ERROR "Parsing failed unexpectedly.")
+endif()
+if (NOT HAD_ERROR AND EXPECT_ERROR)
+    message(FATAL_ERROR "Expected parse failure but parsing was successful.")
+endif()
+
+# if the `diff` and `jq` utilities are available do a thorough comparison of
+# expected parse results and actual results
+find_program(DIFF diff)
+find_program(JQ jq)
+if (NOT (DIFF STREQUAL "DIFF-NOTFOUND") AND NOT(JQ STREQUAL "JQ-NOTFOUND"))
+    # first, ensure that the output directories exists
+    get_filename_component(OUTPUT_DIR ${PROJECT_ROOT}/acceptance/${FEATUREFILE} DIRECTORY)
+    file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+    if (NOT EXPECT_ERROR)
+        # compare tokens
+        execute_process(
+            COMMAND ${GHERKIN_GENERATE_TOKENS} ${FEATUREFILE}
+            COMMAND ${DIFF} --unified --strip-trailing-cr - ${FEATUREFILE}.tokens
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            RESULT_VARIABLE DIFFERENT_TOKENS
+        )
+
+        # compare AST
+        execute_process(
+            COMMAND ${GHERKINEXE} --no-source --no-pickles ${FEATUREFILE}
+            COMMAND ${JQ} --sort-keys "."
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            OUTPUT_FILE ${PROJECT_ROOT}/acceptance/${FEATUREFILE}.ast.ndjson
+            OUTPUT_QUIET
+        )
+        execute_process(
+            COMMAND ${JQ} --sort-keys "." ${FEATUREFILE}.ast.ndjson
+            COMMAND ${DIFF} --unified --strip-trailing-cr - acceptance/${FEATUREFILE}.ast.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            RESULT_VARIABLE DIFFERENT_AST
+        )
+
+        # compare pickles
+        execute_process(
+            COMMAND ${GHERKINEXE} --no-source --no-ast ${FEATUREFILE}
+            COMMAND ${JQ} --sort-keys "."
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            OUTPUT_FILE ${PROJECT_ROOT}/acceptance/${FEATUREFILE}.pickles.ndjson
+            OUTPUT_QUIET
+        )
+        execute_process(
+            COMMAND ${JQ} --sort-keys "." ${FEATUREFILE}.pickles.ndjson
+            COMMAND ${DIFF} --unified --strip-trailing-cr - acceptance/${FEATUREFILE}.pickles.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            RESULT_VARIABLE DIFFERENT_PICKLES
+        )
+
+        # compare source
+        execute_process(
+            COMMAND ${GHERKINEXE} --no-ast --no-pickles ${FEATUREFILE}
+            COMMAND ${JQ} --sort-keys "."
+            OUTPUT_FILE ${PROJECT_ROOT}/acceptance/${FEATUREFILE}.source.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            OUTPUT_QUIET
+        )
+        execute_process(
+            COMMAND ${JQ} --sort-keys "." ${FEATUREFILE}.source.ndjson
+            COMMAND ${DIFF} --unified --strip-trailing-cr - acceptance/${FEATUREFILE}.source.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            RESULT_VARIABLE DIFFERENT_SOURCE
+        )
+
+        if(DIFFERENT_TOKENS OR DIFFERENT_AST OR DIFFERENT_PICKLES OR DIFFERENT_SOURCE)
+            message(FATAL_ERROR "Test failed.")
+        endif()
+    else(NOT EXPECT_ERROR)
+        # compare errors
+        execute_process(
+            COMMAND ${GHERKINEXE} --no-source --no-pickles ${FEATUREFILE}
+            COMMAND ${JQ} --sort-keys "."
+            OUTPUT_FILE ${PROJECT_ROOT}/acceptance/${FEATUREFILE}.errors.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            OUTPUT_QUIET
+        )
+
+        execute_process(
+            COMMAND ${JQ} --sort-keys "." ${FEATUREFILE}.errors.ndjson
+            COMMAND ${DIFF} --unified --strip-trailing-cr - acceptance/${FEATUREFILE}.errors.ndjson
+            WORKING_DIRECTORY ${PROJECT_ROOT}
+            RESULT_VARIABLE DIFFERENT_ERRORS
+        )
+
+        if (DIFFERENT_ERRORS)
+            message(FATAL_ERROR "Test failed.")
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
## Summary
The tests are now run through CTest instead of as a custom build step of `gherkinexe`.
In addition, tests run on CMake builds now also compare the expected results to the actual results just like the Makefile does. 

## Details
- Enabled CTest in the `CMakeLists.txt`
- Added a `TestRunner.cmake` script that runs the tests
- Updated the README

## Motivation and Context
Currently the gherkin-c tests fail due to missing implementations for the `Rule` keyword and for `Scenario` being synonymous with the now deprecated `Scenario Outline`. However, since the tests currently run as a post-build step on the `gherkinexe` target, any test failure causes `gherkinexe` to be deleted again. This is very unfortunate as in this state it is not possible to use `gherkin-c` as a subproject in a larger project that doesn't require these new features yet. Moreover, debugging test failures also is not possible because the executable to debug is not being built.

This also has the added benefit that CTest runs all testcases instead of stopping after the first failed one.

## How Has This Been Tested?
Tested locally with CMake 3.13.1 by running
`cmake -Bbuild -H. && cmake --build build`
and noticing that it correctly builds `gherkinexe` even though `cmake --build build --target test` reports test failures.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
