### PR TITLE
gherkin-c: Fix test failures due to changed JSON serialization format

### DIFF
--- a/gherkin/c/include/doc_string.h
+++ b/gherkin/c/include/doc_string.h
@@ -16,9 +16,10 @@ typedef struct DocString {
     Location location;
     wchar_t* content_type;
     const wchar_t* content;
+    const wchar_t* delimiter;
 } DocString;
 
-const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content);
+const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content, const wchar_t* delimiter);
 
 void DocString_delete(const DocString* doc_string);
 

--- a/gherkin/c/src/ast_builder.c
+++ b/gherkin/c/src/ast_builder.c
@@ -166,7 +166,7 @@ static void* transform_node(AstNode* ast_node, AstBuilder* ast_builder) {
     }
     case Rule_DocString: {
         token = AstNode_get_token(ast_node, Token_DocStringSeparator);
-        const DocString* doc_string = DocString_new(token->location, token->matched_text, get_doc_string_text(ast_node));
+        const DocString* doc_string = DocString_new(token->location, token->matched_text, get_doc_string_text(ast_node), token->matched_keyword);
         Token_delete(token);
         AstNode_delete(ast_node);
         return (void*)doc_string;

--- a/gherkin/c/src/ast_printer.c
+++ b/gherkin/c/src/ast_printer.c
@@ -12,320 +12,438 @@
 #include "print_utilities.h"
 #include <stdlib.h>
 
-static const wchar_t* ast_item_type_to_string(GherkinAstType type) {
-    switch (type) {
-    case Gherkin_GherkinDocument:
-        return L"GherkinDocument";
-    case Gherkin_Feature:
-        return L"Feature";
-    case Gherkin_Background:
-        return L"Background";
-    case Gherkin_Scenario:
-        return L"Scenario";
-    case Gherkin_ScenarioOutline:
-        return L"ScenarioOutline";
-    case Gherkin_Step:
-        return L"Step";
-    case Gherkin_DataTable:
-        return L"DataTable";
-    case Gherkin_DocString:
-        return L"DocString";
-    case Gherkin_Examples:
-        return L"Examples";
-    case Gherkin_TableRow:
-        return L"TableRow";
-    case Gherkin_TableCell:
-        return L"TableCell";
-    case Gherkin_Tag:
-        return L"Tag";
-    case Gherkin_Comment:
-        return L"Comment";
+static void print_location(FILE* file, const Location* location, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
     }
-    return L"";
-}
-
-static void print_location(FILE* file, const Location* location) {
     fprintf(file, "\"location\":{");
     fprintf(file, "\"line\":%d,", location->line);
     fprintf(file, "\"column\":%d", location->column);
-    fprintf(file, "},");
+    fprintf(file, "}");
+    *has_predecessor = true;
+}
+
+static void print_cell_value(FILE* file, const wchar_t* value, bool* has_predecessor) {
+    if (wcslen(value)) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"value\":\"");
+        PrintUtilities_print_json_string(file, value);
+        fprintf(file, "\"");
+        *has_predecessor = true;
+    }
 }
 
 static void print_table_cell(FILE* file, const TableCell* table_cell) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(table_cell->type));
-    print_location(file, &table_cell->location);
-    fprintf(file, "\"value\":\"");
-    if (table_cell->value) {
-        PrintUtilities_print_json_string(file, table_cell->value);
-    }
-    fprintf(file, "\"}");
-}
-
-static void print_table_row(FILE* file, const TableRow* table_row) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(table_row->type));
-    print_location(file, &table_row->location);
-    fprintf(file, "\"cells\":[");
-    int i;
-    for (i = 0; i < table_row->table_cells->cell_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_table_cell(file, &table_row->table_cells->table_cells[i]);
-    }
-    fprintf(file, "]}");
-}
-
-static void print_data_table(FILE* file, const DataTable* data_table) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(data_table->type));
-    print_location(file, &data_table->location);
-    fprintf(file, "\"rows\":[");
-    int i;
-    for (i = 0; i < data_table->rows->row_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_table_row(file, &data_table->rows->table_rows[i]);
-    }
-    fprintf(file, "]}");
-}
-
-static void print_doc_string(FILE* file, const DocString* doc_string) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(doc_string->type));
-    print_location(file, &doc_string->location);
-    if (doc_string->content_type) {
-        fprintf(file, "\"contentType\":\"");
-        PrintUtilities_print_json_string(file, doc_string->content_type);
-        fprintf(file, "\",");
-    }
-    fprintf(file, "\"content\":\"");
-    if (doc_string->content) {
-        PrintUtilities_print_json_string(file, doc_string->content);
-    }
-    fprintf(file, "\"}");
-}
-
-static void print_keyword(FILE* file, const wchar_t* keyword) {
-    fprintf(file, "\"keyword\":\"");
-    PrintUtilities_print_json_string(file, keyword);
-    fprintf(file, "\",");
-}
-
-static void print_text(FILE* file, const wchar_t* text) {
-    fprintf(file, "\"text\":\"");
-    PrintUtilities_print_json_string(file, text);
-    fprintf(file, "\"");
-}
-
-static void print_step(FILE* file, const Step* step) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(step->type));
-    print_location(file, &step->location);
-    print_keyword(file, step->keyword);
-    print_text(file, step->text);
-    if (step->argument) {
-        fprintf(file, ",\"argument\":");
-        if (step->argument->type == Gherkin_DataTable) {
-            print_data_table(file, (DataTable*)step->argument);
-        }
-        else if (step->argument->type == Gherkin_DocString) {
-            print_doc_string(file, (DocString*)step->argument);
-        }
-    }
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &table_cell->location, &has_predecessor);
+    print_cell_value(file, table_cell->value, &has_predecessor);
     fprintf(file, "}");
 }
 
-static void print_name(FILE* file, const wchar_t* name) {
-    fprintf(file, "\"name\":\"");
-    PrintUtilities_print_json_string(file, name);
-    fprintf(file, "\",");
+static void print_table_cells(FILE* file, const TableCells* table_cells, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ", ");
+    }
+    fprintf(file, "\"cells\":[");
+    int i;
+    for (i = 0; i < table_cells->cell_count; ++i) {
+        if (i > 0) {
+            fprintf(file, ",");
+        }
+        print_table_cell(file, &table_cells->table_cells[i]);
+    }
+    fprintf(file, "]");
+    *has_predecessor = true;
 }
 
-static void print_description(FILE* file, const wchar_t* description) {
+static void print_table_row(FILE* file, const TableRow* table_row) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &table_row->location, &has_predecessor);
+    print_table_cells(file, table_row->table_cells, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_table_rows(FILE* file, const TableRows* rows, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"rows\":[");
+    int i;
+    for (i = 0; i < rows->row_count; ++i) {
+        if (i > 0) {
+            fprintf(file, ",");
+        }
+        print_table_row(file, &rows->table_rows[i]);
+    }
+    fprintf(file, "]");
+    *has_predecessor = true;
+}
+
+static void print_data_table(FILE* file, const DataTable* data_table) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &data_table->location, &has_predecessor);
+    print_table_rows(file, data_table->rows, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_doc_string_content_type(FILE* file, const wchar_t* content_type, bool* has_predecessor) {
+    if (content_type) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"contentType\":\"");
+        PrintUtilities_print_json_string(file, content_type);
+        fprintf(file, "\"");
+        *has_predecessor = true;
+    }
+}
+
+static void print_doc_string_content(FILE* file, const wchar_t* content, bool* has_predecessor) {
+    if (content){
+        if (*has_predecessor) {
+           fprintf(file, ","); 
+        }
+        fprintf(file, "\"content\":\"");
+        PrintUtilities_print_json_string(file, content);
+        fprintf(file, "\""); 
+        *has_predecessor = true;
+    }
+}
+
+static void print_doc_string_delimiter(FILE* file, const wchar_t* delimiter, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"delimiter\":\"");
+    PrintUtilities_print_json_string(file, delimiter);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_doc_string(FILE* file, const DocString* doc_string) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &doc_string->location, &has_predecessor);
+    print_doc_string_content_type(file, doc_string->content_type, &has_predecessor);
+    print_doc_string_content(file, doc_string->content, &has_predecessor);
+    print_doc_string_delimiter(file, doc_string->delimiter, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_keyword(FILE* file, const wchar_t* keyword, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"keyword\":\"");
+    PrintUtilities_print_json_string(file, keyword);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_text(FILE* file, const wchar_t* text, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"text\":\"");
+    PrintUtilities_print_json_string(file, text);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_step_argument(FILE* file, const StepArgument* argument, bool* has_predecessor) {
+    if (argument) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        if (argument->type == Gherkin_DataTable) {
+            fprintf(file, "\"dataTable\":");
+            print_data_table(file, (DataTable*)argument);
+        }
+        else if (argument->type == Gherkin_DocString) {
+            fprintf(file, "\"docString\":");
+            print_doc_string(file, (DocString*)argument);
+        }
+        *has_predecessor = true;
+    }
+}
+
+static void print_step(FILE* file, const Step* step) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &step->location, &has_predecessor);
+    print_keyword(file, step->keyword, &has_predecessor);
+    print_text(file, step->text, &has_predecessor);
+    print_step_argument(file, step->argument, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_name(FILE* file, const wchar_t* name, bool* has_predecessor) {
+    if (wcslen(name)) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"name\":\"");
+        PrintUtilities_print_json_string(file, name);
+        fprintf(file, "\"");
+        *has_predecessor = true;
+    }
+}
+
+static void print_description(FILE* file, const wchar_t* description, bool* has_predecessor) {
     if (description) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
         fprintf(file, "\"description\":\"");
         PrintUtilities_print_json_string(file, description);
-        fprintf(file, "\",");
+        fprintf(file, "\"");
+        *has_predecessor = true;
+    }
+}
+
+static void print_steps(FILE* file, const Steps* steps, bool* has_predecessor) {
+    if (steps->step_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"steps\":[");
+        int i;
+        for (i = 0; i < steps->step_count; ++i) {
+            if (i > 0) {
+                fprintf(file, ",");
+            }
+            print_step(file, &steps->steps[i]);
+        }
+        fprintf(file, "]");
+        *has_predecessor = true;
     }
 }
 
 static void print_background(FILE* file, const Background* background) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(background->type));
-    print_location(file, &background->location);
-    print_keyword(file, background->keyword);
-    print_name(file, background->name);
-    print_description(file, background->description);
-    fprintf(file, "\"steps\":[");
-    int i;
-    for (i = 0; i < background->steps->step_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_step(file, &background->steps->steps[i]);
-    }
-    fprintf(file, "]}");
+    fprintf(file, "{");
+    fprintf(file, "\"background\": {");
+    bool has_predecessor = false;
+    print_location(file, &background->location, &has_predecessor);
+    print_keyword(file, background->keyword, &has_predecessor);
+    print_name(file, background->name, &has_predecessor);
+    print_description(file, background->description, &has_predecessor);
+    print_steps(file, background->steps, &has_predecessor);
+    fprintf(file, "}");
+    fprintf(file, "}");
 }
 
 static void print_tag(FILE* file, const Tag* tag) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(tag->type));
-    print_location(file, &tag->location);
-    fprintf(file, "\"name\":\"");
-    PrintUtilities_print_json_string(file, tag->name);
-    fprintf(file, "\"}");
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &tag->location, &has_predecessor);
+    print_name(file, tag->name, &has_predecessor);
+    fprintf(file, "}");
 }
 
-static void print_scenario(FILE* file, const Scenario* scenario) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(scenario->type));
-    fprintf(file, "\"tags\":[");
-    int i;
-    for (i = 0; i < scenario->tags->tag_count; ++i) {
-        if (i > 0) {
+static void print_tags(FILE* file, const Tags* tags, bool* has_predecessor) {
+    if (tags->tag_count) {
+        if (*has_predecessor) {
             fprintf(file, ",");
         }
-        print_tag(file, &scenario->tags->tags[i]);
+        fprintf(file, "\"tags\":[");
+        int i;
+        for (i = 0; i < tags->tag_count; ++i) {
+            if (i > 0) {
+                fprintf(file, ",");
+            }
+            print_tag(file, &tags->tags[i]);
+        }
+        fprintf(file, "]");
+        *has_predecessor = true;
     }
-    fprintf(file, "],");
-    print_location(file, &scenario->location);
-    print_keyword(file, scenario->keyword);
-    print_name(file, scenario->name);
-    print_description(file, scenario->description);
-    fprintf(file, "\"steps\":[");
-    for (i = 0; i < scenario->steps->step_count; ++i) {
-        if (i > 0) {
+}
+
+static void print_example_table_header(FILE* file, const TableRow* header, bool* has_predecessor) {
+    if (header) {
+        if (*has_predecessor) {
             fprintf(file, ",");
         }
-        print_step(file, &scenario->steps->steps[i]);
+        fprintf(file, "\"tableHeader\":");
+        print_table_row(file, header);
+        *has_predecessor = true;
     }
-    fprintf(file, "]}");
+}
+
+static void print_example_table_body(FILE* file, const TableRows* body, bool* has_predecessor) {
+    if (body && body->row_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"tableBody\":[");
+        int i;
+        for (i = 0; i < body->row_count; ++i) {
+            if (i > 0) {
+                fprintf(file, ",");
+            }
+            print_table_row(file, &body->table_rows[i]);
+        }
+        fprintf(file, "]");
+        *has_predecessor = true;
+    }
 }
 
 static void print_example_table(FILE* file, const ExampleTable* example_table) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(example_table->type));
-    print_location(file, &example_table->location);
-    print_description(file, example_table->description);
-    print_keyword(file, example_table->keyword);
-    print_name(file, example_table->name);
-    fprintf(file, "\"tags\":[");
-    int i;
-    for (i = 0; i < example_table->tags->tag_count; ++i) {
-        if (i > 0) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_location(file, &example_table->location, &has_predecessor);
+    print_keyword(file, example_table->keyword, &has_predecessor);
+    print_name(file, example_table->name, &has_predecessor);
+    print_description(file, example_table->description, &has_predecessor);
+    print_tags(file, example_table->tags, &has_predecessor);
+    print_example_table_header(file, example_table->table_header, &has_predecessor);
+    print_example_table_body(file, example_table->table_body, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_scenario(FILE* file, const Scenario* scenario) {
+    fprintf(file, "{\"scenario\":{");
+    bool has_predecessor = false;
+    print_tags(file, scenario->tags, &has_predecessor);
+    print_location(file, &scenario->location, &has_predecessor);
+    print_keyword(file, scenario->keyword, &has_predecessor);
+    print_name(file, scenario->name, &has_predecessor);
+    print_description(file, scenario->description, &has_predecessor);
+    print_steps(file, scenario->steps, &has_predecessor);
+    fprintf(file, "}");
+    fprintf(file, "}");
+}
+
+static void print_examples(FILE* file, const Examples* examples, bool* has_predecessor) {
+    if (examples->example_count) {
+        if (*has_predecessor) {
             fprintf(file, ",");
         }
-        print_tag(file, &example_table->tags->tags[i]);
-    }
-    fprintf(file, "]");
-    if (example_table->table_header) {
-        fprintf(file, ",");
-        fprintf(file, "\"tableHeader\":");
-        print_table_row(file, example_table->table_header);
-        fprintf(file, ",");
-    }
-    if (example_table->table_body) {
-        fprintf(file, "\"tableBody\":[");
-        for (i = 0; i < example_table->table_body->row_count; ++i) {
+        fprintf(file, "\"examples\":[");
+        int i;
+        for (i = 0; i < examples->example_count; ++i) {
             if (i > 0) {
                 fprintf(file, ",");
             }
-            print_table_row(file, &example_table->table_body->table_rows[i]);
+            print_example_table(file, &examples->example_table[i]);
         }
         fprintf(file, "]");
+        *has_predecessor = true;
     }
-    fprintf(file, "}");
 }
 
 static void print_scenario_outline(FILE* file, const ScenarioOutline* scenario_outline) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(scenario_outline->type));
-    fprintf(file, "\"tags\":[");
-    int i;
-    for (i = 0; i < scenario_outline->tags->tag_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_tag(file, &scenario_outline->tags->tags[i]);
-    }
-    fprintf(file, "],");
-    print_location(file, &scenario_outline->location);
-    print_keyword(file, scenario_outline->keyword);
-    print_name(file, scenario_outline->name);
-    print_description(file, scenario_outline->description);
-    fprintf(file, "\"steps\":[");
-    for (i = 0; i < scenario_outline->steps->step_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_step(file, &scenario_outline->steps->steps[i]);
-    }
-    fprintf(file, "],");
-    fprintf(file, "\"examples\":[");
-    for (i = 0; i < scenario_outline->examples->example_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        print_example_table(file, &scenario_outline->examples->example_table[i]);
-    }
-    fprintf(file, "]}");
-}
-
-static void print_comment(FILE* file, const Comment* comment) {
-    fprintf(file, "{\"type\":\"%ls\",", ast_item_type_to_string(comment->type));
-    print_location(file, &comment->location);
-    print_text(file, comment->text);
+    fprintf(file, "{\"scenario\":{");
+    bool has_predecessor = false;
+    print_tags(file, scenario_outline->tags, &has_predecessor);
+    print_location(file, &scenario_outline->location, &has_predecessor);
+    print_keyword(file, scenario_outline->keyword, &has_predecessor);
+    print_name(file, scenario_outline->name, &has_predecessor);
+    print_description(file, scenario_outline->description, &has_predecessor);
+    print_steps(file, scenario_outline->steps, &has_predecessor);
+    print_examples(file, scenario_outline->examples, &has_predecessor);
+    fprintf(file, "}");
     fprintf(file, "}");
 }
 
-void print_feature(FILE* file, const Feature* feature) {
+static void print_comment(FILE* file, const Comment* comment) {
     fprintf(file, "{");
-    fprintf(file, "\"type\":\"%ls\",", ast_item_type_to_string(feature->type));
-    fprintf(file, "\"tags\":[");
-    int i;
-    for (i = 0; i < feature->tags->tag_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-    }
-        print_tag(file, &feature->tags->tags[i]);
-    }
-    fprintf(file, "],");
-    print_location(file, &feature->location);
-    fprintf(file, "\"language\":\"");
-    PrintUtilities_print_json_string(file, feature->language);
-    fprintf(file, "\",");
-    print_keyword(file, feature->keyword);
-    print_name(file, feature->name);
-    print_description(file, feature->description);
-    fprintf(file, "\"children\":[");
-    for (i = 0; i < feature->scenario_definitions->scenario_definition_count; ++i) {
-        if (i > 0) {
-            fprintf(file, ",");
-        }
-        if (feature->scenario_definitions->scenario_definitions[i]->type == Gherkin_Background) {
-            print_background(file, (Background*)feature->scenario_definitions->scenario_definitions[i]);
-        }
-        else if (feature->scenario_definitions->scenario_definitions[i]->type == Gherkin_Scenario) {
-            print_scenario(file, (Scenario*)feature->scenario_definitions->scenario_definitions[i]);
-        } else {
-            print_scenario_outline(file, (ScenarioOutline*)feature->scenario_definitions->scenario_definitions[i]);
-        }
-    }
-    fprintf(file, "]");
-    fprintf(file, "}\n");
+    bool has_predecessor = false;
+    print_location(file, &comment->location, &has_predecessor);
+    print_text(file, comment->text, &has_predecessor);
+    fprintf(file, "}");
 }
 
-void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document) {
-    fprintf(file, "{");
-    fprintf(file, "\"type\":\"%ls\",", ast_item_type_to_string(gherkin_document->type));
-    if (gherkin_document->feature) {
-        fprintf(file, "\"feature\":");
-        print_feature(file, gherkin_document->feature);
+static void print_language(FILE* file, const wchar_t* language, bool* has_predecessor) {
+    if (*has_predecessor) {
         fprintf(file, ",");
     }
-    fprintf(file, "\"comments\":[");
-    if (gherkin_document->comments) {
+    fprintf(file, "\"language\":\"");
+    PrintUtilities_print_json_string(file, language);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_scenario_definitions(FILE* file, const ScenarioDefinitions* scenario_definitions, bool* has_predecessor) {
+    if (scenario_definitions->scenario_definition_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"children\":[");
         int i;
-        for (i = 0; i < gherkin_document->comments->comment_count; ++i) {
+        for (i = 0; i < scenario_definitions->scenario_definition_count; ++i) {
             if (i > 0) {
                 fprintf(file, ",");
             }
-            print_comment(file, &gherkin_document->comments->comments[i]);
+            if (scenario_definitions->scenario_definitions[i]->type == Gherkin_Background) {
+                print_background(file, (Background*)scenario_definitions->scenario_definitions[i]);
+            }
+            else if (scenario_definitions->scenario_definitions[i]->type == Gherkin_Scenario) {
+                print_scenario(file, (Scenario*)scenario_definitions->scenario_definitions[i]);
+            } else {
+                print_scenario_outline(file, (ScenarioOutline*)scenario_definitions->scenario_definitions[i]);
+            }
         }
+        fprintf(file, "]");
+        *has_predecessor = true;
     }
-    fprintf(file, "]");
+}
+
+static void print_feature(FILE* file, const Feature* feature, bool* has_predecessor) {
+    if (feature) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"feature\":{");
+        bool has_predecessor_internal = false;
+        print_tags(file, feature->tags, &has_predecessor_internal);
+        print_location(file, &feature->location, &has_predecessor_internal);
+        print_language(file, feature->language, &has_predecessor_internal);
+        print_keyword(file, feature->keyword, &has_predecessor_internal);
+        print_name(file, feature->name, &has_predecessor_internal);
+        print_description(file, feature->description, &has_predecessor_internal);
+        print_scenario_definitions(file, feature->scenario_definitions, &has_predecessor_internal);
+        fprintf(file, "}\n");
+        *has_predecessor = true;
+    }
+}
+
+static void print_uri(FILE* file, const wchar_t* uri, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"uri\":\"");
+    PrintUtilities_print_json_string(file, uri);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_comments(FILE* file, const Comments* comments, bool* has_predecessor) {
+    if (comments && comments->comment_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"comments\":[");
+        int i;
+        for (i = 0; i < comments->comment_count; ++i) {
+            if (i > 0) {
+                fprintf(file, ",");
+            }
+            print_comment(file, &comments->comments[i]);
+        }
+        fprintf(file, "]");
+    }
+}
+
+void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document, wchar_t* uri) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_uri(file, uri, &has_predecessor);
+    print_feature(file, gherkin_document->feature, &has_predecessor);
+    print_comments(file, gherkin_document->comments, &has_predecessor);
     fprintf(file, "}");
 }

--- a/gherkin/c/src/ast_printer.h
+++ b/gherkin/c/src/ast_printer.h
@@ -2,13 +2,15 @@
 #define GHERKIN_AST_PRINTER_H_
 
 #include "gherkin_document.h"
+
 #include <stdio.h>
+#include <wchar.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document);
+void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document, wchar_t* uri);
 
 #ifdef __cplusplus
 }

--- a/gherkin/c/src/attachment_event.c
+++ b/gherkin/c/src/attachment_event.c
@@ -47,14 +47,19 @@ static void AttachmentEvent_print(const Event* event, FILE* file) {
     }
     const AttachmentEvent* attachment_event = (const AttachmentEvent*)event;
     fprintf(file, "{");
+    fprintf(file, "\"attachment\":{");
     fprintf(file, "\"data\":\"");
     PrintUtilities_print_json_string(file, attachment_event->data);
-    fprintf(file, "\",\"media\":{\"encoding\":\"utf-8\",\"type\":\"text/x.cucumber.stacktrace+plain\"},");
-    fprintf(file, "\"source\":{\"start\":");
-    fprintf(file, "{\"line\":%d,", attachment_event->location.line);
-    fprintf(file, "\"column\":%d},", attachment_event->location.column);
+    fprintf(file, "\",");
+    fprintf(file, "\"source\":{\"location\": {");
+    fprintf(file, "\"line\":%d", attachment_event->location.line);
+    if (attachment_event->location.column > 0) {
+        fprintf(file, ",\"column\":%d", attachment_event->location.column);
+    }
+    fprintf(file, "},");
     fprintf(file, "\"uri\":\"");
     PrintUtilities_print_json_string(file, attachment_event->uri);
-    fprintf(file, "\"},\"type\":\"attachment\"");
+    fprintf(file, "\"}");
+    fprintf(file, "}");
     fprintf(file, "}\n");
 }

--- a/gherkin/c/src/compiler.c
+++ b/gherkin/c/src/compiler.c
@@ -93,7 +93,7 @@ int Compiler_compile(Compiler* compiler, const GherkinDocument* gherkin_document
                 int l;
                 for (l = 0; l < example_table->table_body->row_count; ++l) {
                     const TableRow* table_row = &example_table->table_body->table_rows[l];
-                    const PickleLocations* locations = PickleLocations_new_double(table_row->location.line, table_row->location.column, scenario_outline->location.line, scenario_outline->location.column);
+                    const PickleLocations* locations = PickleLocations_new_double(scenario_outline->location.line, scenario_outline->location.column, table_row->location.line, table_row->location.column);
                     const PickleTags* tags = create_pickle_tags(feature->tags, scenario_outline->tags, example_table->tags);
                     PickleSteps* steps = (PickleSteps*)malloc(sizeof(PickleSteps));
                     if (scenario_outline->steps->step_count == 0) {
@@ -108,7 +108,7 @@ int Compiler_compile(Compiler* compiler, const GherkinDocument* gherkin_document
                         int j;
                         for (j = 0; j < scenario_outline->steps->step_count; ++j) {
                             int column_offset = scenario_outline->steps->steps[j].keyword ? StringUtilities_code_point_length(scenario_outline->steps->steps[j].keyword) : 0;
-                            const PickleLocations* step_locations = PickleLocations_new_double(table_row->location.line, table_row->location.column, scenario_outline->steps->steps[j].location.line, scenario_outline->steps->steps[j].location.column + column_offset);
+                            const PickleLocations* step_locations = PickleLocations_new_double(scenario_outline->steps->steps[j].location.line, scenario_outline->steps->steps[j].location.column + column_offset, table_row->location.line, table_row->location.column);
                             const PickleStep* step = expand_outline_step(&scenario_outline->steps->steps[j], example_table->table_header, table_row, step_locations);
                             PickleStep_transfer(&steps->steps[background_step_count + j], (PickleStep*)step);
                         }

--- a/gherkin/c/src/doc_string.c
+++ b/gherkin/c/src/doc_string.c
@@ -2,7 +2,7 @@
 #include "string_utilities.h"
 #include <stdlib.h>
 
-const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content) {
+const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content, const wchar_t* delimiter) {
     DocString* doc_string = (DocString*)malloc(sizeof(DocString));
     doc_string->doc_string_delete = (item_delete_function)DocString_delete;
     doc_string->type = Gherkin_DocString;
@@ -11,6 +11,9 @@ const DocString* DocString_new(Location location, const wchar_t* content_type, c
     doc_string->content_type = 0;
     if (content_type && wcslen(content_type) > 0) {
         doc_string->content_type = StringUtilities_copy_string(content_type);
+    }
+    if (delimiter && wcslen(delimiter) > 0) {
+        doc_string->delimiter = StringUtilities_copy_string(delimiter);
     }
     doc_string->content = content;
     return doc_string;
@@ -25,6 +28,9 @@ void DocString_delete(const DocString* doc_string) {
     }
     if (doc_string->content) {
         free((void*)doc_string->content);
+    }
+    if (doc_string->delimiter) {
+        free((void*)doc_string->delimiter);
     }
     free((void*)doc_string);
 }

--- a/gherkin/c/src/gherkin_document_event.c
+++ b/gherkin/c/src/gherkin_document_event.c
@@ -42,11 +42,8 @@ static void GherkinDocumentEvent_print(const Event* event, FILE* file) {
     }
     const GherkinDocumentEvent* gherkin_document_event = (const GherkinDocumentEvent*)event;
     fprintf(file, "{");
-    fprintf(file, "\"type\":\"gherkin-document\",");
-    fprintf(file, "\"uri\":\"");
-    PrintUtilities_print_json_string(file, gherkin_document_event->uri);
-    fprintf(file, "\",\"document\":");
-    AstPrinter_print_gherkin_document(file, gherkin_document_event->gherkin_document);
+    fprintf(file, "\"gherkinDocument\":");
+    AstPrinter_print_gherkin_document(file, gherkin_document_event->gherkin_document, gherkin_document_event->uri);
     fprintf(file, "}\n");
 }
 

--- a/gherkin/c/src/pickle_event.c
+++ b/gherkin/c/src/pickle_event.c
@@ -43,11 +43,8 @@ static void PickleEvent_print(const Event* event, FILE* file) {
     const PickleEvent* pickle_event = (const PickleEvent*) event;
     if (pickle_event) {
         fprintf(file, "{");
-        fprintf(file, "\"type\":\"pickle\",");
-        fprintf(file, "\"uri\":\"");
-        PrintUtilities_print_json_string(file, pickle_event->uri);
-        fprintf(file, "\",\"pickle\":");
-        PicklePrinter_print_pickle(file, pickle_event->pickle);
+        fprintf(file, "\"pickle\":");
+        PicklePrinter_print_pickle(file, pickle_event->pickle, pickle_event->uri);
         fprintf(file, "}\n");
     }
 }

--- a/gherkin/c/src/pickle_printer.c
+++ b/gherkin/c/src/pickle_printer.c
@@ -4,13 +4,17 @@
 #include "print_utilities.h"
 #include <wchar.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 static void print_location(FILE* file, const PickleLocation* location) {
     fprintf(file, "{\"line\":%d,", location->line);
     fprintf(file, "\"column\":%d}", location->column);
 }
 
-static void print_locations(FILE* file, const PickleLocations* locations) {
+static void print_locations(FILE* file, const PickleLocations* locations, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
     fprintf(file, "\"locations\":[");
     if (locations) {
         int i;
@@ -21,15 +25,18 @@ static void print_locations(FILE* file, const PickleLocations* locations) {
             print_location(file, &locations->locations[i]);
         }
     }
-    fprintf(file, "],");
+    fprintf(file, "]");
+    *has_predecessor = true;
 }
 
 static void print_table_cell(FILE* file, const PickleCell* pickle_cell) {
     fprintf(file, "{\"location\": ");
     print_location(file, pickle_cell->location);
-    fprintf(file, ",\"value\": \"");
-    PrintUtilities_print_json_string(file, pickle_cell->value);
-    fprintf(file, "\"");
+    if (wcslen(pickle_cell->value)) {
+        fprintf(file, ",\"value\": \"");
+        PrintUtilities_print_json_string(file, pickle_cell->value);
+        fprintf(file, "\"");
+    }
     fprintf(file, "}");
 }
 
@@ -46,7 +53,7 @@ static void print_table_row(FILE* file, const PickleRow* pickle_row) {
 }
 
 static void print_pickle_table(FILE* file, const PickleTable* pickle_table) {
-    fprintf(file, "{\"rows\":[");
+    fprintf(file, "\"dataTable\":{\"rows\":[");
     int i;
     for (i = 0; i < pickle_table->rows->row_count; ++i) {
         if (i > 0) {
@@ -58,7 +65,7 @@ static void print_pickle_table(FILE* file, const PickleTable* pickle_table) {
 }
 
 static void print_pickle_string(FILE* file, const PickleString* pickle_string) {
-    fprintf(file, "{\"location\": ");
+    fprintf(file, "\"docString\":{\"location\": ");
     print_location(file, &pickle_string->location);
     fprintf(file, ",\"content\":\"");
     if (pickle_string->content) {
@@ -73,62 +80,124 @@ static void print_pickle_string(FILE* file, const PickleString* pickle_string) {
     fprintf(file, "}");
 }
 
+static void print_name(FILE* file, const wchar_t* name, bool* has_predecessor) {
+    if (wcslen(name)) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"name\" : \"");
+        PrintUtilities_print_json_string(file, name);
+        fprintf(file, "\"");
+        *has_predecessor = true;
+    }
+}
+
 static void print_tag(FILE* file, const PickleTag* tag) {
     fprintf(file, "{\"location\":");
     print_location(file, &tag->location);
-    fprintf(file, ",\"name\":\"");
-    PrintUtilities_print_json_string(file, tag->name);
-    fprintf(file, "\"}");
+    bool has_predecessor = true;
+    print_name(file, tag->name, &has_predecessor);
+    fprintf(file, "}");
+}
+
+static void print_text(FILE* file, const wchar_t* text, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"text\":\"");
+    PrintUtilities_print_json_string(file, text);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_pickle_argument(FILE* file, const PickleArgument* argument, bool* has_predecessor) {
+    if (argument) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        if (argument->type == Argument_String) {
+            print_pickle_string(file, (const PickleString*)argument);
+        }
+        if (argument->type == Argument_Table) {
+            print_pickle_table(file, (const PickleTable*)argument);
+        }
+        *has_predecessor = true;
+    }
 }
 
 static void print_pickle_step(FILE* file, const PickleStep* step) {
     fprintf(file, "{");
-    print_locations(file, step->locations);
-    fprintf(file, "\"arguments\" : [");
-    if (step->argument) {
-        if (step->argument->type == Argument_String) {
-            print_pickle_string(file, (const PickleString*)step->argument);
-        }
-        if (step->argument->type == Argument_Table) {
-            print_pickle_table(file, (const PickleTable*)step->argument);
-        }
-    }
-    fprintf(file, "],");
-    fprintf(file, "\"text\":\"");
-    PrintUtilities_print_json_string(file, step->text);
-    fprintf(file, "\"}");
+    bool has_predecessor = false;
+    print_locations(file, step->locations, &has_predecessor);
+    print_pickle_argument(file, step->argument, &has_predecessor);
+    print_text(file, step->text, &has_predecessor);
+    fprintf(file, "}");
 }
 
-void PicklePrinter_print_pickle(FILE* file, const Pickle* pickle) {
-    fprintf(file, "{");
+static void print_uri(FILE* file, const wchar_t* uri, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
+    fprintf(file, "\"uri\":\"");
+    PrintUtilities_print_json_string(file, uri);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_language(FILE* file, const wchar_t* language, bool* has_predecessor) {
+    if (*has_predecessor) {
+        fprintf(file, ",");
+    }
     fprintf(file, "\"language\" : \"");
-    PrintUtilities_print_json_string(file, pickle->language);
-    fprintf(file, "\",");
-    fprintf(file, "\"name\" : \"");
-    PrintUtilities_print_json_string(file, pickle->name);
-    fprintf(file, "\",");
-    print_locations(file, pickle->locations);
-    fprintf(file, "\"tags\":[");
-    if (pickle->tags) {
+    PrintUtilities_print_json_string(file, language);
+    fprintf(file, "\"");
+    *has_predecessor = true;
+}
+
+static void print_tags(FILE* file, const PickleTags* tags, bool* has_predecessor) {
+    if (tags && tags->tag_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"tags\":[");
         int i;
-        for (i = 0; i < pickle->tags->tag_count; ++i) {
+        for (i = 0; i < tags->tag_count; ++i) {
             if (i > 0) {
                 fprintf(file, ",");
             }
-            print_tag(file, &pickle->tags->tags[i]);
+            print_tag(file, &tags->tags[i]);
         }
+        fprintf(file, "]");
+        *has_predecessor = true;
     }
-    fprintf(file, "],");
-    fprintf(file, "\"steps\":[");
-    if (pickle->steps) {
+}
+
+static void print_steps(FILE* file, const PickleSteps* steps, bool* has_predecessor) {
+    if (steps && steps->step_count) {
+        if (*has_predecessor) {
+            fprintf(file, ",");
+        }
+        fprintf(file, "\"steps\":[");
         int i;
-        for (i = 0; i < pickle->steps->step_count; ++i) {
+        for (i = 0; i < steps->step_count; ++i) {
             if (i > 0) {
                 fprintf(file, ",");
             }
-            print_pickle_step(file, &pickle->steps->steps[i]);
+            print_pickle_step(file, &steps->steps[i]);
         }
+        fprintf(file, "]");
+        *has_predecessor = true;
     }
-    fprintf(file, "]");
+}
+
+void PicklePrinter_print_pickle(FILE* file, const Pickle* pickle, const wchar_t* uri) {
+    fprintf(file, "{");
+    bool has_predecessor = false;
+    print_uri(file, uri, &has_predecessor);
+    print_language(file, pickle->language, &has_predecessor);
+    print_name(file, pickle->name, &has_predecessor);
+    print_locations(file, pickle->locations, &has_predecessor);
+    print_tags(file, pickle->tags, &has_predecessor);
+    print_steps(file, pickle->steps, &has_predecessor);
     fprintf(file, "}");
 }

--- a/gherkin/c/src/pickle_printer.h
+++ b/gherkin/c/src/pickle_printer.h
@@ -2,13 +2,15 @@
 #define GHERKIN_PICKLE_PRINTER_H_
 
 #include "pickle.h"
+
 #include <stdio.h>
+#include <wchar.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void PicklePrinter_print_pickle(FILE* file, const Pickle* pickle);
+void PicklePrinter_print_pickle(FILE* file, const Pickle* pickle, const wchar_t* uri);
 
 #ifdef __cplusplus
 }

--- a/gherkin/c/src/source_event.c
+++ b/gherkin/c/src/source_event.c
@@ -41,12 +41,15 @@ static void SourceEvent_print(const Event* event, FILE* file) {
     }
     const SourceEvent* source_event = (const SourceEvent*)event;
     fprintf(file, "{");
-    fprintf(file, "\"type\":\"source\",");
-    fprintf(file, "\"media\":{\"encoding\":\"utf-8\",\"type\":\"text/x.cucumber.gherkin+plain\"},");
+    fprintf(file, "\"source\": {");
+    fprintf(file, "\"media\":{\"encoding\":\"UTF-8\",\"contentType\":\"text/x.cucumber.gherkin+plain\"},");
     fprintf(file, "\"uri\":\"");
     PrintUtilities_print_json_string(file, source_event->uri);
-    fprintf(file, "\",\"data\":\"");
-    PrintUtilities_print_json_string(file, source_event->source);
-    fprintf(file, "\"}\n");
+    if (wcslen(source_event->source)) {
+        fprintf(file, "\",\"data\":\"");
+        PrintUtilities_print_json_string(file, source_event->source);
+    }
+    fprintf(file, "\"}");
+    fprintf(file, "}\n");
 }
 

--- a/gherkin/c/src/token_formatter_builder.c
+++ b/gherkin/c/src/token_formatter_builder.c
@@ -102,7 +102,7 @@ const char* token_type_to_string(TokenType token_type) {
     case Token_ScenarioLine:
         return "ScenarioLine";
     case Token_ScenarioOutlineLine:
-        return "ScenarioOutlineLine";
+        return "ScenarioLine";
     case Token_ExamplesLine:
         return "ExamplesLine";
     case Token_BackgroundLine:

--- a/gherkin/c/src/token_matcher.c
+++ b/gherkin/c/src/token_matcher.c
@@ -237,7 +237,7 @@ static bool match_DocStringSeparator(TokenMatcher* token_matcher, Token* token, 
             token_matcher->active_doc_string_separator = 0;
             token_matcher->indent_to_remove = 0;
         }
-        set_token_matched(token, Token_DocStringSeparator, content_type, 0, -1, 0);
+        set_token_matched(token, Token_DocStringSeparator, content_type, separator, -1, 0);
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary
Fix tests failing due to changes to the JSON output format of pickles, ast and the source. 

## Details
- Updated the ast printer
- Updated the pickle printer
- Updated the source printer
- Updated the error message format
- QuickFix: Use the same name for `Scenario` and `Scenario Outline` when printing tokens
- Fixed a bug where the ordering of location data in pickles of scenarios with examples was wrong

## Motivation and Context
This is one of the changes required to get `gherkin-c` to build without failures again. In my opinion it makes sense to fix the tests in two sets of changes, this one and #552. By merging this PR first it will be easier to verify that #552 (which touches a lot of code) does indeed not cause regressions and makes all tests pass again.

## How Has This Been Tested?
Using the changes in #555 it is possible to run all tests instead of stopping after the first failure as running `make` does. When doing so one can see that there are now only three tests of the "good" test data set (`incomplete_scenario_outline`, `rule`, `scenario_outline`) and two of the tests in the "bad" test data set (`multiple_parser_errors`, `unexpected_eof`) which fail.

For both "bad" test cases as well as the `rule` and `scenario_outline` test cases failure is expected until #552 is merged. `incomplete_scenario_outline` however shows a real bug that incidentally also got fixed in #552. That bug has been around since at least v5.1.0, yet it wasn't caught because the reference pickles were also incorrect.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
