### PR TITLE
Correct Azerbijani scenario translation

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -262,7 +262,7 @@
       "Rule"
     ],
     "scenario": [
-      "Nümunələr",
+      "Nümunə",
       "Ssenari"
     ],
     "scenarioOutline": [


### PR DESCRIPTION
## Summary

Fix the translation of ``scenario`` in Azerbaijani to use the singular for ``example``

## Details

The translations of ``scenario`` has extra entries added so that the word "Example" could be used as well as "Scenario". There are also existing translations of ``examples`` which make an examples table within an scenario/example.

The Azerbaijani translation of ``scenario`` included "Nümunələr" which is the plural, and the same as the translation of ``examples``. Fix it to use the singular.

## Motivation and Context

If the translations of ``examples`` and ``scenarios`` translate to the same thing then there is trouble. e.g. when parsing a feature and seeing (in Azerbaijani) the keyword "Nümunələr", the parser is not going to know if it has reached an ``examples``` or ``scenario`` section.

This was noticed because of a warning in unit tests in ``Bhat/Gherkin`` see issue https://github.com/Behat/Gherkin/issues/145

## How Has This Been Tested?

See ``Behat/Gherkin`` PR https://github.com/Behat/Gherkin/pull/146 which demonstrates that the equivalent change there fixes the unit test warning.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
