### PR TITLE
Fix ruby issue 1337: Brackets/Integer/CukeExp compatibility

### DIFF
--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -10,6 +10,7 @@ module Cucumber
       PARAMETER_REGEXP = /(\\\\)?{([^}]*)}/
       OPTIONAL_REGEXP = /(\\\\)?\(([^)]+)\)/
       ALTERNATIVE_NON_WHITESPACE_TEXT_REGEXP = /([^\s^\/]+)((\/[^\s^\/]+)+)/
+      BRACKETS_WANTED_REGEXP = /\\\\\({.+}\)/
       DOUBLE_ESCAPE = '\\\\'
       PARAMETER_TYPES_CANNOT_BE_ALTERNATIVE = 'Parameter types cannot be alternative: '
       PARAMETER_TYPES_CANNOT_BE_OPTIONAL = 'Parameter types cannot be optional: '
@@ -19,7 +20,7 @@ module Cucumber
       def initialize(expression, parameter_type_registry)
         @source = expression
         @parameter_types = []
-        
+
         expression = process_escapes(expression)
         expression = process_optional(expression)
         expression = process_alternation(expression)
@@ -51,7 +52,7 @@ module Cucumber
         # Create non-capturing, optional capture groups from parenthesis
         expression.gsub(OPTIONAL_REGEXP) do
           g2 = $2
-          check_no_parameter_type(g2, PARAMETER_TYPES_CANNOT_BE_OPTIONAL)
+          check_no_parameter_type(g2, PARAMETER_TYPES_CANNOT_BE_OPTIONAL) unless brackets_wanted?(expression)
           # look for double-escaped parentheses
           $1 == DOUBLE_ESCAPE ? "\\(#{g2}\\)" : "(?:#{g2})?"
         end
@@ -100,6 +101,10 @@ module Cucumber
         if PARAMETER_REGEXP =~ s
           raise CucumberExpressionError.new("#{message}#{source}")
         end
+      end
+
+      def brackets_wanted?(expression)
+        expression =~ BRACKETS_WANTED_REGEXP
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -10,7 +10,7 @@ module Cucumber
       PARAMETER_REGEXP = /(\\\\)?{([^}]*)}/
       OPTIONAL_REGEXP = /(\\\\)?\(([^)]+)\)/
       ALTERNATIVE_NON_WHITESPACE_TEXT_REGEXP = /([^\s^\/]+)((\/[^\s^\/]+)+)/
-      BRACKETS_WANTED_REGEXP = /\\\\\({.+}\)/
+      BRACKETS_WANTED_REGEXP = /\\\\\(.*{.+}.*\)/
       DOUBLE_ESCAPE = '\\\\'
       PARAMETER_TYPES_CANNOT_BE_ALTERNATIVE = 'Parameter types cannot be alternative: '
       PARAMETER_TYPES_CANNOT_BE_OPTIONAL = 'Parameter types cannot be optional: '

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -52,6 +52,15 @@ module Cucumber
         # Create non-capturing, optional capture groups from parenthesis
         expression.gsub(OPTIONAL_REGEXP) do
           g2 = $2
+          # When using Parameter Types, the () characters are used to represent an optional
+          # item such as (a ) which would be equivalent to (?:a )? in regex
+          #
+          # You cannot have optional Parameter Types i.e. ({int}) as this causes
+          # problems during the conversion phase to regex. So we check for that here
+          #
+          # One exclusion to this rule is if you actually want the brackets i.e. you
+          # want to capture (3) then we still permit this as an individual rule
+          # See: https://github.com/cucumber/cucumber-ruby/issues/1337 for more info
           check_no_parameter_type(g2, PARAMETER_TYPES_CANNOT_BE_OPTIONAL) unless brackets_wanted?(expression)
           # look for double-escaped parentheses
           $1 == DOUBLE_ESCAPE ? "\\(#{g2}\\)" : "(?:#{g2})?"
@@ -103,6 +112,9 @@ module Cucumber
         end
       end
 
+      # Permit the user to define a Parameter type that is wrapped in parentheses ()
+      # If they define the parentheses as actual ones and not to represent an optional
+      # capture group. I.e. a user could define \({int}) which would capture (3)
       def brackets_wanted?(expression)
         expression =~ BRACKETS_WANTED_REGEXP
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -63,6 +63,10 @@ module Cucumber
         expect(match('\\({int}) blind mice', '(3) blind mice')).to eq([3])
       end
 
+      it 'can capture an expression inside escaped parentheses with additional content' do
+        expect(match('\\(those huge {int} grey) blind mice', '(those huge 3 grey) blind mice')).to eq([3])
+      end
+
       it "matches escaped slash" do
         expect(match("12\\/2020", "12/2020")).to eq([])
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -59,6 +59,10 @@ module Cucumber
         expect(match('three \\(exceptionally) {string} mice', 'three (exceptionally) "blind" mice')).to eq(['blind'])
       end
 
+      it 'can capture an expression inside escaped parentheses' do
+        expect(match('\\({int}) blind mice', '(3) blind mice')).to eq([3])
+      end
+
       it "matches escaped slash" do
         expect(match("12\\/2020", "12/2020")).to eq([])
       end


### PR DESCRIPTION
## Summary

When using Integers captured using the {int} cucumber expression, issues crop up when trying to sanitize the brackets which are being read as an optional parameter.

The issue is occurring due to interoperability between brackets being partially escapable (To represent these are brackets and not a capture group), and cucumber expressions (Which have a different meaning for brackets)

## Details

I've allowed brackets to be used in a very specific context (As notified by the constant definition), when being used inside a Cucumber Expression Generator method (Which would previously crash erroneously)

## Motivation and Context

Fixes Ruby issue #1337 https://github.com/cucumber/cucumber-ruby/issues/1337

## How Has This Been Tested?

This code is likely to need porting and is only meant as a first draft. It's probably going to need some stern eyes to work out if this is desired.