### PR TITLE
docker config: Use `md5` rather than `md5sum`

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -35,7 +35,13 @@ function echo_blue
 function docker_image() {
   dockerfile=$1
   image_name=$(basename ${dockerfile} | cut -d '.' -f 2)
-  tag=$(cat ${dockerfile} | md5sum | cut -d ' ' -f 1)
+
+  if hash md5sum 2>/dev/null; then
+    tag=$(cat ${dockerfile} | md5sum | cut -d ' ' -f 1)
+  else
+    tag=$(cat ${dockerfile} | md5 -r | cut -d ' ' -f 1)
+  fi
+
   echo "cucumber/${image_name}:${tag}"
 }
 


### PR DESCRIPTION
## Summary

`md5sum` is not installed by default on a Mac, and using `md5` avoids the need to further filter the output

## Motivation and Context

Mac users should be able to use the docker build without installing tools locally