### PR TITLE
cucumber-expressions: limit explosion of generated expressions to 256

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
-
+* Limit generated expressions to 256
+ ([#576](https://github.com/cucumber/cucumber/issues/576)
+   [#574](https://github.com/cucumber/cucumber/pull/574)
+   [mpkorstanje])
 ### Deprecated
 
 ### Removed

--- a/cucumber-expressions/go/combinatorial_generated_expression_factory.go
+++ b/cucumber-expressions/go/combinatorial_generated_expression_factory.go
@@ -1,5 +1,8 @@
 package cucumberexpressions
 
+// 256 generated expressions ought to be enough for anybody
+const maxExpressions = 256
+
 type CombinatorialGeneratedExpressionFactory struct {
 	expressionTemplate        string
 	parameterTypeCombinations [][]*ParameterType
@@ -19,6 +22,10 @@ func (c *CombinatorialGeneratedExpressionFactory) GenerateExpressions() []*Gener
 }
 
 func (c *CombinatorialGeneratedExpressionFactory) generatePermutations(generatedExpressions *GeneratedExpressionList, depth int, currentParameterTypes []*ParameterType) {
+	if len(generatedExpressions.elements) >= maxExpressions {
+		return
+	}
+
 	if depth == len(c.parameterTypeCombinations) {
 		generatedExpressions.Push(
 			NewGeneratedExpression(c.expressionTemplate, currentParameterTypes),
@@ -27,6 +34,11 @@ func (c *CombinatorialGeneratedExpressionFactory) generatePermutations(generated
 	}
 
 	for _, parameterType := range c.parameterTypeCombinations[depth] {
+		// Avoid recursion if no elements can be added.
+		if len(generatedExpressions.elements) >= maxExpressions {
+			return
+		}
+
 		c.generatePermutations(
 			generatedExpressions,
 			depth+1,

--- a/cucumber-expressions/go/cucumber_expression_generator_test.go
+++ b/cucumber-expressions/go/cucumber_expression_generator_test.go
@@ -216,6 +216,27 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 		generatedExpression := generator.GenerateExpressions("I reach Stage4: 1st flight-1st hotel")[0]
 		require.Equal(t, generatedExpression.Source(), "I reach Stage{int}: {int}st flight{int}st hotel")
 	})
+
+	t.Run("generates at most 256 expressions", func(t *testing.T) {
+		parameterTypeRegistry := NewParameterTypeRegistry()
+		for i := 1; i <= 4; i++ {
+			myType, err := NewParameterType(
+				"my-type-"+string(i),
+				[]*regexp.Regexp{regexp.MustCompile("[a-z]")},
+				"string",
+				nil,
+				true,
+				false,
+			)
+			require.NoError(t, err)
+			parameterTypeRegistry.DefineParameterType(myType)
+		}
+
+		generator := NewCucumberExpressionGenerator(parameterTypeRegistry)
+		// This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
+		generatedExpressions := generator.GenerateExpressions("a simple step")
+		require.Equal(t, len(generatedExpressions), 256)
+	})
 }
 
 func assertExpression(t *testing.T, expectedExpression string, expectedArgumentNames []string, text string) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
@@ -273,6 +273,29 @@ public class CucumberExpressionGeneratorTest {
         assertEquals("I reach Stage{int}: {int}st flight{int}st hotl", generatedExpressions.get(0).getSource());
     }
 
+    @Test
+    public void generates_at_most_256_expressions() {
+        for (int i = 0; i < 4; i++) {
+            ParameterType<String> myType = new ParameterType<>(
+                    "my-type-" + i,
+                    "[a-z]",
+                    String.class,
+                    new Transformer<String>() {
+                        @Override
+                        public String transform(String arg) {
+                            return arg;
+                        }
+                    },
+                    true,
+                    false
+            );
+            parameterTypeRegistry.defineParameterType(myType);
+
+        }
+        // This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
+        assertEquals(256, generator.generateExpressions("a simple step").size());
+    }
+
     private void assertExpression(String expectedExpression, List<String> expectedArgumentNames, String text) {
         GeneratedExpression generatedExpression = generator.generateExpressions(text).get(0);
         assertEquals(expectedExpression, generatedExpression.getSource());

--- a/cucumber-expressions/javascript/src/combinatorial_generated_expression_factory.js
+++ b/cucumber-expressions/javascript/src/combinatorial_generated_expression_factory.js
@@ -1,5 +1,8 @@
 const GeneratedExpression = require('./generated_expression')
 
+// 256 generated expressions ought to be enough for anybody
+const MAX_EXPRESSIONS = 256;
+
 class CombinatorialGeneratedExpressionFactory {
   constructor(expressionTemplate, parameterTypeCombinations) {
     this._expressionTemplate = expressionTemplate
@@ -13,6 +16,10 @@ class CombinatorialGeneratedExpressionFactory {
   }
 
   _generatePermutations(generatedExpressions, depth, currentParameterTypes) {
+    if(generatedExpressions.length >= MAX_EXPRESSIONS){
+      return
+    }
+
     if (depth === this._parameterTypeCombinations.length) {
       generatedExpressions.push(
         new GeneratedExpression(this._expressionTemplate, currentParameterTypes)
@@ -21,6 +28,11 @@ class CombinatorialGeneratedExpressionFactory {
     }
 
     for (let i = 0; i < this._parameterTypeCombinations[depth].length; ++i) {
+      // Avoid recursion if no elements can be added.
+      if(generatedExpressions.length >= MAX_EXPRESSIONS){
+        return
+      }
+
       const newCurrentParameterTypes = currentParameterTypes.slice() // clone
       newCurrentParameterTypes.push(this._parameterTypeCombinations[depth][i])
       this._generatePermutations(

--- a/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
@@ -212,4 +212,23 @@ describe('CucumberExpressionGenerator', () => {
       'I reach Stage{int}: {int}st flight{int}st hotl'
     )
   })
+
+  it('generates at most 256 expressions', () => {
+    for (let i = 0; i < 4; i++){
+      parameterTypeRegistry.defineParameterType(
+        new ParameterType(
+            'my-type-' + i,
+            /[a-z]/,
+            null,
+            s => s,
+            true,
+            false
+        )
+      )
+    }
+    // This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
+    const expressions = generator.generateExpressions('a simple step')
+    assert.equal(expressions.length, 256)
+  })
+
 })

--- a/cucumber-expressions/ruby/.gitignore
+++ b/cucumber-expressions/ruby/.gitignore
@@ -2,3 +2,4 @@ coverage/
 Gemfile.lock
 pkg/
 .tested
+.rake_tasks~

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/combinatorial_generated_expression_factory.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/combinatorial_generated_expression_factory.rb
@@ -15,9 +15,14 @@ module Cucumber
         generated_expressions
       end
 
-      private
+      # 256 generated expressions ought to be enough for anybody
+      MAX_EXPRESSIONS = 256
 
       def generate_permutations(generated_expressions, depth, current_parameter_types)
+        if generated_expressions.length >= MAX_EXPRESSIONS
+          return
+        end
+
         if depth == @parameter_type_combinations.length
           generated_expression = GeneratedExpression.new(@expression_template, current_parameter_types)
           generated_expressions.push(generated_expression)
@@ -25,6 +30,10 @@ module Cucumber
         end
 
         (0...@parameter_type_combinations[depth].length).each do |i|
+          # Avoid recursion if no elements can be added.
+          if generated_expressions.length >= MAX_EXPRESSIONS
+            return
+          end
           new_current_parameter_types = current_parameter_types.dup # clone
           new_current_parameter_types.push(@parameter_type_combinations[depth][i])
           generate_permutations(

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
@@ -120,11 +120,28 @@ module Cucumber
         expect(expression.source).to eq("I reach Stage{int}: {int}st flight{int}st hotl")
       end
 
+      it "generates at most 256 expressions" do
+        for i in 0..3
+          @parameter_type_registry.define_parameter_type(ParameterType.new(
+              "my-type-#{i}",
+              /[a-z]/,
+              String,
+              lambda {|s| s},
+              true,
+              false
+          ))
+        end
+        # This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
+        expressions = @generator.generate_expressions("a simple step")
+        expect(expressions.length).to eq(256)
+      end
+
+
       def assert_expression(expected_expression, expected_argument_names, text)
         generated_expression = @generator.generate_expression(text)
         expect(generated_expression.parameter_names).to eq(expected_argument_names)
         expect(generated_expression.source).to eq(expected_expression)
-        
+
         cucumber_expression = CucumberExpression.new(generated_expression.source, @parameter_type_registry)
         match = cucumber_expression.match(text)
         if match.nil?


### PR DESCRIPTION
## Summary

Using only small input values it is possible make
`CucumberExpressionGenerator` generate 1.5GB worth of generated
expressions.

For example: the step `a simple step` -a total of 11 letters- and 4
parameters with a the regular expression of [a-z] will generate a
4^11=419430 possible cucumber expressions. As each GeneratedExpression
takes up approximately 11*32 bytes this totals just shy of 1.5GB.

While this can be avoided by not using parameter types with overly
generic expressions for snippet generation, snippet generation is
enabled by default and once we run out memory it is impossible to
inform or warn anyone about this problem.

So 256 cucumber expressions should be enough for anyone.

## Motivation and Context

Fixes: #574

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
