### PR TITLE
gherkin: Enable in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /usr/bin/env bash
 MAKEFILES=c21e/Makefile \
 	cucumber-messages/Makefile \
 	dots-formatter/Makefile \
+	gherkin/Makefile \
 	datatable/Makefile \
 	config/Makefile \
 	cucumber-expressions/Makefile \


### PR DESCRIPTION
## Summary
Adds `gherkin` back to build. Disabled gherkin because it fails the entire mono repo which makes it impossible to verify if pull requests to other modules are done right.
