### PR TITLE
cucumber-messages: Add stricter gem restrictions for google-protobuf

### DIFF
--- a/cucumber-messages/CHANGELOG.md
+++ b/cucumber-messages/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fix Project struggling to build across JRuby and Ruby 2.6
+  ([#578](https://github.com/cucumber/cucumber/pull/578)
+  [luke-hill])
+   
 ## [2.1.1] - 2018-11-02
 
 ### Fixed
@@ -64,3 +68,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [aslakhellesoy]:    https://github.com/aslakhellesoy
 [brasmusson]:       https://github.com/brasmusson
 [charlierudolph]:   https://github.com/charlierudolph
+[luke-hill]:        https://github.com/luke-hill

--- a/cucumber-messages/ruby/Gemfile
+++ b/cucumber-messages/ruby/Gemfile
@@ -1,6 +1,3 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 gemspec
-
-# Pick a known-good version when running builds for cucumber-messages on JRuby.
-gem 'google-protobuf', '~> 3.2.0.2', platform: :jruby

--- a/cucumber-messages/ruby/Gemfile
+++ b/cucumber-messages/ruby/Gemfile
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
+
+# Pick a known-good version when running builds for cucumber-messages on JRuby.
+gem 'google-protobuf', '~> 3.2.0.2', platform: :jruby
+
 gemspec

--- a/cucumber-messages/ruby/cucumber-messages.gemspec
+++ b/cucumber-messages/ruby/cucumber-messages.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/cucumber-messages/ruby',
                   }
 
-  # As of this writing (28 June 2018), the latest version is
-  # 3.6.0, which doesn't works with JRuby. 
+  # As of this writing (12 March 2019), the latest version is
+  # 3.7.0, which doesn't work with JRuby.
   # See https://github.com/google/protobuf/issues/1594 
   # 3.1.0 works with JRuby, but fails with MRI 2.4.4 and above.
   #
@@ -29,8 +29,15 @@ Gem::Specification.new do |s|
   # pick the appropriate one in their bundle.
   #
   # Users of JRuby would probably install 3.2.0, while users of MRI would use
-  # 3.6.0.
-  s.add_dependency 'google-protobuf', '~> 3.2'
+  # a version either around 3.2 (If they are on an old Ruby), or 3.7 if they
+  # are running on Ruby 2.6. This is due to some extensions failing to compile
+  # which has only been recently fixed and won't be backported
+  #
+  if RbConfig::CONFIG["MINOR"] == "6"
+    s.add_dependency('google-protobuf', '~> 3.7')
+  else
+    s.add_dependency('google-protobuf', ['>= 3.2', '< 3.6'])
+  end
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake',      '~> 12.3'


### PR DESCRIPTION
## Summary
As the comments elude to; this gem is a key runtime dependency. And on Ruby 2.6 this only works when using the latest version

## Details
Stricter gemspec restrictions as per the different ruby requirements

## Motivation and Context

For Running on JRuby and a couple of other environments, a weaker requirement is required (And not the latest), due to some issues with those environments.

Once the team maintaining this has done some additional work, we can probably relax this requirement. But for now this makes cucumber build properly again X-Ruby Versions

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
