### PR TITLE
cucumber-expressions: Prefer expression with the longest non-empty match

### DIFF
--- a/cucumber-expressions/go/parameter_type_matcher.go
+++ b/cucumber-expressions/go/parameter_type_matcher.go
@@ -29,7 +29,13 @@ func (p *ParameterTypeMatcher) ParameterType() *ParameterType {
 }
 
 func (p *ParameterTypeMatcher) AdvanceTo(newMatchPosition int) *ParameterTypeMatcher {
-	return NewParameterTypeMatcher(p.parameterType, p.regexp, p.text, newMatchPosition)
+	for advancedPos := newMatchPosition; advancedPos < len(p.text); advancedPos++ {
+		var matcher = NewParameterTypeMatcher(p.parameterType, p.regexp, p.text, advancedPos)
+		if matcher.Find() {
+			return matcher
+		}
+	}
+	return NewParameterTypeMatcher(p.parameterType, p.regexp, p.text, len(p.text))
 }
 
 func (p *ParameterTypeMatcher) Find() bool {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionGenerator.java
@@ -27,9 +27,8 @@ public class CucumberExpressionGenerator {
             List<ParameterTypeMatcher> matchingParameterTypeMatchers = new ArrayList<>();
 
             for (ParameterTypeMatcher parameterTypeMatcher : parameterTypeMatchers) {
-                ParameterTypeMatcher advancedParameterTypeMatcher = parameterTypeMatcher.advanceTo(pos);
-                if (advancedParameterTypeMatcher.find()) {
-                    matchingParameterTypeMatchers.add(advancedParameterTypeMatcher);
+                if (parameterTypeMatcher.advanceToAndFind(pos)) {
+                    matchingParameterTypeMatchers.add(parameterTypeMatcher);
                 }
             }
 

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
@@ -13,12 +13,16 @@ class ParameterTypeMatcher implements Comparable<ParameterTypeMatcher> {
         this.textLength = textLength;
     }
 
-    public ParameterTypeMatcher advanceTo(int newMatchPos) {
-        return new ParameterTypeMatcher(parameterType, matcher.region(newMatchPos, textLength), textLength);
-    }
-
-    public boolean find() {
-        return matcher.find() && !group().isEmpty();
+    public boolean advanceToAndFind(int newMatchPos) {
+        // Unlike js, ruby and go, the matcher is stateful
+        // so we can't use the immutable semantics.
+        matcher.region(newMatchPos, textLength);
+        while (matcher.find()) {
+            if (!group().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public int start() {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
@@ -3,8 +3,6 @@ package io.cucumber.cucumberexpressions;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.text.NumberFormat;
-import java.util.Arrays;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
@@ -18,8 +16,6 @@ public class NumberParserTest {
     public void can_parse_float() {
         assertEquals(1042.2f, english.parseFloat("1,042.2"), 0);
         assertEquals(1042.2f, german.parseFloat( "1.042,2"), 0);
-
-        System.out.println(Arrays.toString(NumberFormat.getAvailableLocales()));
     }
 
     @Test

--- a/cucumber-expressions/javascript/src/parameter_type_matcher.js
+++ b/cucumber-expressions/javascript/src/parameter_type_matcher.js
@@ -14,11 +14,24 @@ class ParameterTypeMatcher {
   }
 
   advanceTo(newMatchPosition) {
+    for (let advancedPos = newMatchPosition; advancedPos < this._text.length; advancedPos++) {
+      let matcher = new ParameterTypeMatcher(
+          this._parameterType,
+          this._treeRegexp,
+          this._text,
+          advancedPos
+      );
+
+      if(matcher.find){
+        return matcher;
+      }
+    }
+
     return new ParameterTypeMatcher(
       this._parameterType,
       this._treeRegexp,
       this._text,
-      newMatchPosition
+      this._text.length
     )
   }
 

--- a/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
+++ b/cucumber-expressions/javascript/test/cucumber_expression_generator_test.js
@@ -182,7 +182,7 @@ describe('CucumberExpressionGenerator', () => {
     assert.deepEqual(typeNames, ['int', 'float'])
   })
 
-  it('ignores parameter types with optional capture groups', () => {
+  it('matches parameter types with optional capture groups', () => {
     parameterTypeRegistry.defineParameterType(
       new ParameterType(
         'optional-flight',
@@ -205,11 +205,13 @@ describe('CucumberExpressionGenerator', () => {
     )
 
     const expression = generator.generateExpressions(
-      'I reach Stage4: 1st flight-1st hotl'
+      'I reach Stage4: 1st flight-1st hotel'
     )[0]
+    // While you would expect this to be `I reach Stage{int}: {optional-flight}-{optional-hotel}` the `-1` causes
+    // {int} to match just before {optional-hotel}.
     assert.equal(
       expression.source,
-      'I reach Stage{int}: {int}st flight{int}st hotl'
+      'I reach Stage{int}: {optional-flight}{int}st hotel'
     )
   })
 
@@ -229,6 +231,42 @@ describe('CucumberExpressionGenerator', () => {
     // This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
     const expressions = generator.generateExpressions('a simple step')
     assert.equal(expressions.length, 256)
+  })
+
+  it('prefers expression with longest non empty match', () => {
+    parameterTypeRegistry.defineParameterType(
+        new ParameterType(
+            'zero-or-more',
+            /[a-z]*/,
+            null,
+            s => s,
+            true,
+            false
+        )
+    )
+    parameterTypeRegistry.defineParameterType(
+        new ParameterType(
+            'exactly-one',
+            /[a-z]/,
+            null,
+            s => s,
+            true,
+            false
+        )
+    )
+
+    const expressions = generator.generateExpressions(
+        'a simple step'
+    )
+    assert.equal(expressions.length, 2)
+    assert.equal(
+        expressions[0].source,
+        '{exactly-one} {zero-or-more} {zero-or-more}'
+    )
+    assert.equal(
+        expressions[1].source,
+        '{zero-or-more} {zero-or-more} {zero-or-more}'
+    )
   })
 
 })

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
@@ -9,7 +9,14 @@ module Cucumber
       end
 
       def advance_to(new_match_position)
-        self.class.new(parameter_type, @regexp, @text, new_match_position)
+        (new_match_position...@text.length).each {|advancedPos|
+          matcher = self.class.new(parameter_type, @regexp, @text, advancedPos)
+          if matcher.find
+            return matcher
+          end
+        }
+
+        self.class.new(parameter_type, @regexp, @text, @text.length)
       end
 
       def find


### PR DESCRIPTION
## Summary

Given `a simple step` and a parameter type that matches zero or more
characters `[a-z]*` and a parameter type that matches exactly one
character `[a-z]` two expressions will be generated. Neither very useful.

```
{exactly-one} {exactly-one}{zero-or-more} {exactly-one}{zero-or-more}
{zero-or-more} {exactly-one}{zero-or-more} {exactly-one}{zero-or-more}
```

This result is generated because after advancing `ParameterTypeMatcher`
to just after `a` the zero-or-more expression will match the empty
string between `a` and the following space. The `exactly-one-expression`
will proceed and match the first character after that space.

By advancing `ParameterTypeMatcher` until a non empty match is
found we can avoid expressions that match the empty string from getting
stuck.

This will generate:

```
{exactly-one} {zero-or-more} {zero-or-more}
{zero-or-more} {zero-or-more} {zero-or-more}
```

## Motivation and Context

Fixes:  #575

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
