### PR TITLE
cucumber-expressions: Simplify java heuristic

### DIFF
--- a/cucumber-expressions/java/heuristics.adoc
+++ b/cucumber-expressions/java/heuristics.adoc
@@ -21,13 +21,4 @@ The table below describes the heuristics, along with some examples
 |RegularExpression
 |Forward slashes always assumes Regular Expression. The slashes themselves are removed.
 
-|this (.+) like a regexp
-|RegularExpression
-|If there are capture groups, assume Regular Expression.
-
-|this look(s) like a cukexp
-|CucumberExpression
-|Parenthesis containing only alphabetic characters are not considered Regular Expression capture groups,
-but Cucumber Expression optional text.
-
 |===

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ExpressionFactory.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ExpressionFactory.java
@@ -14,8 +14,6 @@ public class ExpressionFactory {
     private static final Pattern BEGIN_ANCHOR = Pattern.compile("^\\^.*");
     private static final Pattern END_ANCHOR = Pattern.compile(".*\\$$");
     private static final Pattern SCRIPT_STYLE_REGEXP = Pattern.compile("^/(.*)/$");
-    private static final Pattern PARENS = Pattern.compile("\\(([^)]+)\\)");
-    private static final Pattern REGEXP_CHARS = Pattern.compile("[\\[\\].+*]+");
     private final ParameterTypeRegistry parameterTypeRegistry;
 
     public ExpressionFactory(ParameterTypeRegistry parameterTypeRegistry) {
@@ -26,20 +24,9 @@ public class ExpressionFactory {
         if (BEGIN_ANCHOR.matcher(expressionString).find() || END_ANCHOR.matcher(expressionString).find()) {
             return createRegularExpressionWithAnchors(expressionString);
         }
-        Matcher m = END_ANCHOR.matcher(expressionString);
-        if (m.find()) {
-            return new RegularExpression(Pattern.compile(expressionString), parameterTypeRegistry);
-        }
-        m = SCRIPT_STYLE_REGEXP.matcher(expressionString);
+        Matcher m = SCRIPT_STYLE_REGEXP.matcher(expressionString);
         if (m.find()) {
             return new RegularExpression(Pattern.compile(m.group(1)), parameterTypeRegistry);
-        }
-        m = PARENS.matcher(expressionString);
-        if (m.find()) {
-            String insideParens = m.group(1);
-            if (REGEXP_CHARS.matcher(insideParens).find()) {
-                return new RegularExpression(Pattern.compile(expressionString), parameterTypeRegistry);
-            }
         }
         return new CucumberExpression(expressionString, parameterTypeRegistry);
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ExpressionFactoryTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ExpressionFactoryTest.java
@@ -34,6 +34,21 @@ public class ExpressionFactoryTest {
     }
 
     @Test
+    public void creates_cucumber_expression_for_escaped_parenthesis_with_regex_symbols() {
+        assertCucumberExpression("this looks\\( i.e: no regex symbols) like a cukexp");
+    }
+
+    @Test
+    public void creates_cucumber_expression_for_escaped_parenthesis_with_alpha() {
+        assertCucumberExpression("a heavy storm forecast \\(BF {int}+)");
+    }
+
+    @Test
+    public void creates_cucumber_expression_for_parenthesis_with_regex_symbols() {
+        assertCucumberExpression("the temperature is (\\+){int} degrees celsius");
+    }
+
+    @Test
     public void creates_cucumber_expression_for_only_begin_anchor() {
         assertRegularExpression("^this looks like a regexp");
     }
@@ -41,16 +56,6 @@ public class ExpressionFactoryTest {
     @Test
     public void creates_cucumber_expression_for_only_end_anchor() {
         assertRegularExpression("this looks like a regexp$");
-    }
-
-    @Test
-    public void creates_regular_expression_for_parenthesis_with_non_alpha() {
-        assertRegularExpression("this (.+) like a regexp");
-    }
-
-    @Test
-    public void creates_regular_expression_for_parenthesis_with_regexp_digits() {
-        assertRegularExpression("this (\\d+) like a regexp");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Explaining when a string is interpreted as a cucumber expression should
be rather straight forward. In essence the explanation should be:

    If you surround a string with `^` and `$` it will be a regular
    expression. If not, it is a cucumber expression.

However the heuristic complicates this by checking if a capture group
contains regular expression symbols `[]+.*` with the assumption that
these are not used in normal writing.

This allows us to write little marvels like:

    this looks\( i.e: no regex symbols) like a cukexp
    a heavy storm forecast \(BF {int}+)
    the temperature is (\+){int} degrees celsius

Which look deceptively like cucumber expressions but are in fact regular
expressions. Simplifying the heuristic remove this ambiguity. This does
comes at the cost of being able to recognize obvious regular
expressions.

    this (.+) like a regexp
    this (\d+) like a regexp
    this ([a-z]+) like a regexp

But I think the simplicity is worth it.

## Motivation and Context
  * https://github.com/cucumber/cucumber-jvm/issues/1581
  * https://github.com/cucumber/cucumber/issues/515
  * https://github.com/cucumber/cucumber-jvm/issues/1581

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
