### PR TITLE
cucumber-expressions: Allow ?! as a non-capturing negative lookahead in TreeRegexp

### DIFF
--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
@@ -17,13 +17,22 @@ module Cucumber
         expect(group.children[1].value).to eq('c')
       end
 
-      it 'ignores non-capturing groups' do
-        tr = TreeRegexp.new(/(a(?:b)?)(c)/)
-        group = tr.match('ac')
-        expect(group.value).to eq('ac')
-        expect(group.children[0].value).to eq('a')
-        expect(group.children[0].children).to eq([])
-        expect(group.children[1].value).to eq('c')
+      context 'non-capturing groups' do
+        it 'ignores `?:` as a non-capturing group' do
+          tr = TreeRegexp.new(/a(?:b)(c)/)
+          group = tr.match('abc')
+          expect(group.value).to eq('abc')
+          expect(group.children[0].value).to eq('c')
+          expect(group.children[0].children).to eq([])
+        end
+
+        it 'ignores `?!` as a non-capturing group' do
+          tr = TreeRegexp.new(/a(?!b)(c)/)
+          group = tr.match('aBc')
+          expect(group.value).to eq('aBc')
+          expect(group.children[0].value).to eq('c')
+          expect(group.children[0].children).to eq([])
+        end
       end
 
       it 'matches optional group' do


### PR DESCRIPTION
This is considered to be a regression from 2.4. However I need a little help understanding the `?!` nuances as one of the tests fails and I don't understand why.

Attempts to close #481 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code. - But they need looking at as one fails.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
