### PR TITLE
cucumber-expressions: Support Boolean in BuiltInParameterTransformer

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
@@ -63,6 +63,10 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
             return numberParser.parseDouble(fromValue);
         }
 
+        if (Boolean.class.equals(toValueClass) || boolean.class.equals(toValueClass)) {
+            return Boolean.parseBoolean(fromValue);
+        }
+
         if (toValueClass.isEnum()) {
             @SuppressWarnings("unchecked")
             Class<? extends Enum<?>> enumClass = (Class<? extends Enum<?>>) toValueClass;

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 
 import static java.util.Locale.ENGLISH;
@@ -44,6 +45,14 @@ public class BuiltInParameterTransformerTest {
                 "Can't transform 'something' to class io.cucumber.cucumberexpressions.BuiltInParameterTransformerTest$TestEnum. " +
                 "Not an enum constant");
         objectMapper.transform("something", TestEnum.class);
+    }
+
+
+    @Test
+    public void should_transform_boolean() {
+      for (String value : Arrays.asList("true", "True", "false", "False")){
+        objectMapper.transform(value, Boolean.class);
+      }
     }
 
     private enum TestEnum {


### PR DESCRIPTION
## Summary

Converting to Boolean was supported by default in older cucumber version. 
This PR restores it.

## Details

## Motivation and Context

Boolean is a basic type and supporting it will ease the upgrade of cucumber from previous versions

## How Has This Been Tested?
Unit tests + manual checks

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
