### PR TITLE
Remove failing dots formatter from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL := /usr/bin/env bash
 MAKEFILES=c21e/Makefile \
 	cucumber-messages/Makefile \
 	gherkin/Makefile \
-	dots-formatter/Makefile \
 	datatable/Makefile \
 	config/Makefile \
 	cucumber-expressions/Makefile \


### PR DESCRIPTION

## Summary

Remove failing dots formatter from build

## Details
```
bundle exec rspec --color
F
Failures:
  1) Cucumber::Formatter::Dots prints coloured dots
     Failure/Error: @stdin, stdout, _stderr, @wait_thread = Open3.popen3(@exe)
     
     Errno::ENOENT:
       No such file or directory - /app/dots-formatter/ruby/dots-formatter-go/dots-formatter-go-linux-amd64
     # ./lib/cucumber/formatter/dots.rb:21:in `on_test_run_started'
     # ./spec/cucumber/formatter/dots_spec.rb:20:in `method_missing'
     # ./spec/cucumber/formatter/dots_spec.rb:40:in `block (2 levels) in <module:Formatter>'
Finished in 0.00531 seconds (files took 0.20413 seconds to load)
1 example, 1 failure
Failed examples:
rspec ./spec/cucumber/formatter/dots_spec.rb:36 # Cucumber::Formatter::Dots prints coloured dots
```