### PR TITLE
Allow google-protobuf 3.8

### DIFF
--- a/cucumber-messages/ruby/Gemfile
+++ b/cucumber-messages/ruby/Gemfile
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-# Use an older protobuf on JRuby and MRI < 2.5
-if ((RbConfig::CONFIG['MAJOR'].to_i == 2 && RbConfig::CONFIG['MINOR'].to_i < 5) || RUBY_PLATFORM == "java")
-  gem 'google-protobuf', '~> 3.2.0.2'
-end
+# Use an older protobuf on JRuby
+gem 'google-protobuf', '~> 3.2.0.2' if RUBY_PLATFORM == 'java'
 
 gemspec

--- a/cucumber-messages/ruby/cucumber-messages.gemspec
+++ b/cucumber-messages/ruby/cucumber-messages.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/cucumber-messages/ruby',
                   }
 
-  # Users of JRuby and MRI < 2.6 will have to specify google-protobuf=3.2 (later versions don't work)
-  s.add_dependency 'google-protobuf', ['>= 3.2', '<= 3.7']
+  # Users of JRuby should use google-protobuf 3.2.0.2 (later versions don't work)
+  s.add_dependency('google-protobuf', ['>= 3.2', '<= 3.8'])
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake',      '~> 12.3'
   s.add_development_dependency 'rspec',     '~> 3.7'


### PR DESCRIPTION
## Summary

Allow protobuf 3.8

## Details

This allows 3.8, which "should" fix all builds aside from JRuby (According to their maintainers). JRuby is something which isn't fully on their roadmap yet, so we're still on our own for that.

## Motivation and Context

Should fix any niggling issues with 2.3-2.6 (Note that 3.8 forces Ruby 2.3, but we're already doing that)

## How Has This Been Tested?

CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
