### PR TITLE
Add quick note about running Docker [ci skip]

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -36,6 +36,16 @@ Occasionally you want to sync to multiple subrepos. For example, if you are maki
 in two modules (say `messages` and `gherkin`), prefix the branch with both module names, 
 separated by an underscore. For example, `messages_gherkin-use-protobuf`.
 
+### Local Testing / Development checks
+
+To run a copy of the CI locally simply run the command below. **NB: This will require docker being installed.**
+
+    ./scripts/docker-run Dockerfile.cucumber-build make
+    
+This will create a localised version of the Docker image used on CI to build cucumber then run through
+all of the associated make tasks in each of the sub-repos. This can take a while, but it saves you needing
+to push each individual commit up to the repo and then wait for the CI tests to finish.
+
 ### Adding a new subrepo
 
 Occasionally, a sub directory is promoted to a separate subrepo. The process for doing this is:


### PR DESCRIPTION
## Summary

Provide a quick note to show people how to run docker in the HACKING.md file.

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
