### PR TITLE
Refactor/bugfix: Docker tweaks to default makefiles for Ruby

### DIFF
--- a/.templates/ruby/default.mk
+++ b/.templates/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/c21e/ruby/default.mk
+++ b/c21e/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/cucumber-expressions/ruby/default.mk
+++ b/cucumber-expressions/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/cucumber-messages/ruby/default.mk
+++ b/cucumber-messages/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/dots-formatter/ruby/default.mk
+++ b/dots-formatter/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/gherkin/ruby/default.mk
+++ b/gherkin/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby

--- a/tag-expressions/ruby/default.mk
+++ b/tag-expressions/ruby/default.mk
@@ -18,7 +18,7 @@ Gemfile.lock: Gemfile $(GEMSPECS)
 	touch $@
 
 .tested: .deps $(RUBY_SOURCE_FILES)
-	bundle exec rspec --color
+	bundle install && bundle exec rspec --color
 	touch $@
 
 clean: clean-ruby


### PR DESCRIPTION
## Summary

Try to alleviate some missing gem failures whilst running docker tasks

## Details

Use a double-check bundle before running rspec (gem), command

## Motivation and Context

When running Docker locally I often get an issue that rspec isn't installed, when I add `bundle` infront of the rspec command it fixes it.

This won't affect things if they're already installed, as `bundle install` or `bundle` only install missing gems and always adhere to the lock file.

## How Has This Been Tested?

Locally / CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
