### PR TITLE
Replace OracleJDK with OpenJDK

### DIFF
--- a/c21e/java/.travis.yml
+++ b/c21e/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/config/java/.travis.yml
+++ b/config/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/cucumber-expressions/java/.travis.yml
+++ b/cucumber-expressions/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/cucumber-messages/java/.travis.yml
+++ b/cucumber-messages/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/datatable/java/.travis.yml
+++ b/datatable/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/gherkin/java/.travis.yml
+++ b/gherkin/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script

--- a/tag-expressions/java/.travis.yml
+++ b/tag-expressions/java/.travis.yml
@@ -2,13 +2,13 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 script: make default
 jobs:
   include:
   - stage: mvn deploy
-    jdk: oraclejdk8
+    jdk: openjdk8
     deploy:
       skip_cleanup: true
       provider: script


### PR DESCRIPTION
OracleJDK 8 is no longer provided as a Unix package and no longer
available as part of Travis CI.