### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-# The language isn't really ruby (it's polyglot) - this is just to avoid travis lint warnings
-language: ruby
+language: minimal
 services:
 - docker
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ services:
 - docker
 before_script:
 - export PATH=$PATH:$PWD/bin/linux/amd64
-script:
-- scripts/push_subrepos.sh
-- "./scripts/docker-run Dockerfile.cucumber-build make"
-#- cd gherkin/dotnet && ../../scripts/docker-run ../../Dockerfile.cucumber-build-dotnet
-#  make
+
+jobs:
+  include:
+    - script: scripts/push_subrepos.sh
+    - script: scripts/docker-run Dockerfile.cucumber-build make
+
 env:
   global:
     secure: VjDLkqUkJz6N13YExt6zGll83LneH7p6zzpCrzNYwzXDRjIDtc7mQs371O6L76EFYgfOib+E6mi5kLchWm87o5vnz0q2cK3xfwiJa27XENpLWJ7os7JXwhKUZTyg0n/bkvj6eUeLEGtYccZYihpjmgWZqf2fYLqedGfYB7X28IDV5ZqKuN0m8LgX8a+5pHwMt9j+BfN9JK8lZtggbAAjrEtb/myi5vhTc90GE/afliipIjQoc1/MZ8Mc4X/+Navfgl+uYtXUxNxB3ae2oQ8/75Pl4BAlBFTuXfUaooKNb9GXOL8zFKRp0AM4I66Xe0LrzJ+6XuuD4hh/BrG5cyFvTxNBJZYXPSzt4j8WwB8nSG0a9VwzDXWYLKoTwhA0Ey+lz55JkxlyWazXpgA8Itk8R1SocALT9qQ5I1Sltm17s8DAr4iTbGncIqjN0A4S2nezKHINKvsLanFEgooWOatLRcCPd3gZ9dsGt6b1v5MYV1kmv8HUXB1xLsU4VWPZoo+a8l+42DXr3pBHJdD7z/hBzSJnhAiPZO1ZeDFheqXPRs0YpECl6kDZYut632g5xdE3XlamUCiEkKLyUP5CdW8KoXvU2Lba8Cc6LfrPctflXde6ayutt9MFR4zKvGuTvZz8wZf1bggVWIflXTutP003YEhjhNXDUggpIlWwwYnIWfY=


### PR DESCRIPTION
## Summary

Improve the build by using a smaller CI image and separating the build from updating the mono repo.

## Language Minimal

Use language minimal

> https://docs.travis-ci.com/user/languages/minimal-and-generic/
>
> Travis CI supports many popular programming languages, but can never
> hope to support them all. language: minimal and language: generic are
> images available in Ubuntu Xenial dist: xenialand Ubuntu Trusty
> `dist:trusty`, that are not tailored to any particular programming
> language. As their names suggest, one is optimized be faster and use
> less disk space, the other to have more languages and services
> available.

# Multiple Jobs

Put push and build into separate build jobs. This makes it more clear that this build does multiple things
and that failure of one is not a complete failure

