### PR TITLE
gherkin: fix: ExeFile not a constructor, issue #634

### DIFF
--- a/c21e/javascript/src/ExeFile.ts
+++ b/c21e/javascript/src/ExeFile.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 
-export default class ExeFile {
+export class ExeFile {
   constructor(
     private readonly fileNamePattern: string,
     private readonly props: { os: string; arch: string } = {

--- a/c21e/javascript/test/ExeFileTest.ts
+++ b/c21e/javascript/test/ExeFileTest.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import ExeFile from '../src/ExeFile'
+import { ExeFile } from '../src/ExeFile'
 
 describe('ExeFile', () => {
   it('detects macos', () => {

--- a/gherkin/javascript/src/index.ts
+++ b/gherkin/javascript/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import { statSync } from 'fs'
-import * as ExeFile from 'c21e'
+import { ExeFile } from 'c21e'
 import { messages, ProtobufMessageStream } from 'cucumber-messages'
 
 const defaultOptions = {

--- a/gherkin/javascript/src/index.ts
+++ b/gherkin/javascript/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import { statSync } from 'fs'
-import ExeFile from 'c21e'
+import * as ExeFile from 'c21e'
 import { messages, ProtobufMessageStream } from 'cucumber-messages'
 
 const defaultOptions = {


### PR DESCRIPTION
## Summary

Imports the default export `ExeFile` from c21e in a way that doesn't result in an undefined constructor.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

fixes https://github.com/cucumber/cucumber/issues/634

## How Has This Been Tested?

Will add tests, if necessary for a trivial change like that, once established that this is the fix we want: https://github.com/cucumber/cucumber/issues/634#issuecomment-502896358

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
