### PR TITLE
Specifications for the sender part of Cucumber-Messages

### DIFF
--- a/cucumber-messages/specs/TestCaseFinished.feature
+++ b/cucumber-messages/specs/TestCaseFinished.feature
@@ -4,7 +4,9 @@ Feature: Sending TestCaseFinished Messages
 
         Given there are <NumberOfScenarios> scenarios
         And all steps are bound and pass
+
         When the test suite is executed
+
         Then <NumberOfTestCaseFinishedMessages> TestCaseFinished messages have been sent
 
         Examples:
@@ -17,7 +19,9 @@ Feature: Sending TestCaseFinished Messages
 
         Given there is a scenario with PickleId 'ff981b6f-b11e-4149-baa1-9794940ac8bf'
         And all steps are bound and pass
+
         When the scenario is finished at '2019-05-13 13:09:46'
+
         Then a TestCaseFinished message has been sent with the following attributes
             | Attribute | Value                                |
             | timestamp | '2019-05-13 13:09:46'                |
@@ -29,6 +33,7 @@ Feature: Sending TestCaseFinished Messages
         And with step definitions in the following order: '<bindings and step result>'
 
         When the test suite is executed
+
         Then a TestCaseFinished message has been sent with the following TestResult
             | Attribute | Value             |
             | status    | <Scenario Status> |
@@ -40,3 +45,22 @@ Feature: Sending TestCaseFinished Messages
             | one pending step definition                  | Step1Binding (pending)                   | Pending         |
             | no step definition                           |                                          | Undefined       |
             | two step definitions with identical bindings | Step1Binding (pass), Step1Binding (pass) | Ambiguous       |
+
+    Scenario Outline: TestCaseFinished message with status Skipped is send, if the scenario is ignored
+
+        Given there is an ignored scenario with the following steps: 'Step1'
+        And with step definitions in the following order: '<bindings and step result>'
+
+        When the test suite is executed
+        
+        Then a TestCaseFinished message has been sent with the following TestResult
+            | Attribute | Value             |
+            | status    | Skipped           |
+
+        Examples:
+            | Description                                  | bindings and step result                 |
+            | one passing step definition                  | Step1Binding (pass)                      |
+            | one failing step definition                  | Step1Binding (fail)                      |
+            | one pending step definition                  | Step1Binding (pending)                   |
+            | no step definition                           |                                          |
+            | two step definitions with identical bindings | Step1Binding (pass), Step1Binding (pass) |

--- a/cucumber-messages/specs/TestCaseFinished.feature
+++ b/cucumber-messages/specs/TestCaseFinished.feature
@@ -1,0 +1,42 @@
+Feature: Sending TestCaseFinished Messages
+
+    Scenario Outline: Ending test cases sends a message per test case
+
+        Given there are <NumberOfScenarios> scenarios
+        And all steps are bound and pass
+        When the test suite is executed
+        Then <NumberOfTestCaseFinishedMessages> TestCaseFinished messages have been sent
+
+        Examples:
+            | Case             | NumberOfScenarios | NumberOfTestCaseFinishedMessages |
+            | empty test suite | 0                 | 0                                |
+            | Single scenario  | 1                 | 1                                |
+            | Two scenarios    | 2                 | 2                                |
+
+    Scenario: Test case end time and PickleId is included in the message
+
+        Given there is a scenario with PickleId 'ff981b6f-b11e-4149-baa1-9794940ac8bf'
+        And all steps are bound and pass
+        When the scenario is finished at '2019-05-13 13:09:46'
+        Then a TestCaseFinished message has been sent with the following attributes
+            | Attribute | Value                                |
+            | timestamp | '2019-05-13 13:09:46'                |
+            | pickleId  | ff981b6f-b11e-4149-baa1-9794940ac8bf |
+
+    Scenario Outline: TestCase Result depends on binding and execution result
+
+        Given there is a scenario with the following steps: 'Step1'
+        And with step definitions in the following order: '<bindings and step result>'
+
+        When the test suite is executed
+        Then a TestCaseFinished message has been sent with the following TestResult
+            | Attribute | Value             |
+            | status    | <Scenario Status> |
+
+        Examples:
+            | Description                                  | bindings and step result                 | Scenario Status |
+            | one passing step definition                  | Step1Binding (pass)                      | Passed          |
+            | one failing step definition                  | Step1Binding (fail)                      | Failed          |
+            | one pending step definition                  | Step1Binding (pending)                   | Pending         |
+            | no step definition                           |                                          | Undefined       |
+            | two step definitions with identical bindings | Step1Binding (pass), Step1Binding (pass) | Ambiguous       |

--- a/cucumber-messages/specs/TestCaseFinished.feature
+++ b/cucumber-messages/specs/TestCaseFinished.feature
@@ -1,5 +1,9 @@
 Feature: Sending TestCaseFinished Messages
 
+    - Message is send after all AfterScenario hooks
+    - Timestamp is in local time zone
+    - The durationNanoseconds are the duration between timestamp of the TestCaseStarted and TestCaseFinished messages
+
     Scenario Outline: Ending test cases sends a message per test case
 
         Given there are <NumberOfScenarios> scenarios

--- a/cucumber-messages/specs/TestCaseStarted.feature
+++ b/cucumber-messages/specs/TestCaseStarted.feature
@@ -1,5 +1,8 @@
 Feature: Sending TestCaseStarted Messages
 
+    - Message is send before all BeforeScenario hooks
+    - Timestamp is in local time zone
+
     Scenario Outline: Starting test cases sends a message per test case
 
         Given there are '<NumberOfScenarios>' scenarios

--- a/cucumber-messages/specs/TestCaseStarted.feature
+++ b/cucumber-messages/specs/TestCaseStarted.feature
@@ -23,7 +23,7 @@ Feature: Sending TestCaseStarted Messages
 
     Scenario Outline: Cucumber implementation and version is included in the message
 
-        Given the cucumber implementation is <implementation> in version <Version>
+        Given the cucumber implementation is '<implementation>' in version '<Version>'
         When the test suite is executed
         Then a TestCaseStarted message has been sent with the following platform information
           | Attribute      | Value              |

--- a/cucumber-messages/specs/TestCaseStarted.feature
+++ b/cucumber-messages/specs/TestCaseStarted.feature
@@ -20,3 +20,18 @@ Feature: Sending TestCaseStarted Messages
           | Attribute | Value                                |
           | pickleId  | ff981b6f-b11e-4149-baa1-9794940ac8bf |
           | timestamp | '2019-05-13 13:09:46'                |
+
+    Scenario Outline: Cucumber implementation and version is included in the message
+
+        Given the cucumber implementation is <implementation> in version <Version>
+        When the test suite is executed
+        Then a TestCaseStarted message has been sent with the following platform information
+          | Attribute      | Value              |
+          | implementation | <ImplementationId> |
+          | version        | <Version>          |
+
+        @SpecFlow
+        Examples:
+          | implementation | ImplementationId | Version |
+          | SpecFlow 3.1   | SpecFlow         | 3.1     |
+

--- a/cucumber-messages/specs/TestCaseStarted.feature
+++ b/cucumber-messages/specs/TestCaseStarted.feature
@@ -1,0 +1,22 @@
+Feature: Sending TestCaseStarted Messages
+
+    Scenario Outline: Starting test cases sends a message per test case
+
+        Given there are '<NumberOfScenarios>' scenarios
+        When the test suite is executed
+        Then '<NumberOfTestCaseStartedMessages>' TestCaseStarted messages have been sent
+
+        Examples:
+          | Case             | NumberOfScenarios | NumberOfTestCaseStartedMessages |
+          | empty test suite | 0                 | 0                               |
+          | Single scenario  | 1                 | 1                               |
+          | Two scenarios    | 2                 | 2                               |
+
+    Scenario: Test case end time and PickleId is included in the message
+
+        Given there is a scenario with PickleId 'ff981b6f-b11e-4149-baa1-9794940ac8bf'
+        When the scenario is started at '2019-05-13 13:09:46'
+        Then a TestCaseStarted message has been sent with the following attributes
+          | Attribute | Value                                |
+          | pickleId  | ff981b6f-b11e-4149-baa1-9794940ac8bf |
+          | timestamp | '2019-05-13 13:09:46'                |

--- a/cucumber-messages/specs/TestRunFinished.feature
+++ b/cucumber-messages/specs/TestRunFinished.feature
@@ -10,9 +10,9 @@ Feature: Sending TestRunFinished messages
         Then '<NumberOfTestRunFinishedMessages>' TestRunFinished messages have been sent
 
         Examples:
-          | Case                              | NumberOfFeatureFiles | NumberOfTestRunFinishedMessages |
-          | empty test suite                  | 0                    | 0                              |
-          | test suite contains feature files | 1                    | 1                              |
+            | Case                              | NumberOfFeatureFiles | NumberOfTestRunFinishedMessages |
+            | empty test suite                  | 0                    | 0                               |
+            | test suite contains feature files | 1                    | 1                               |
 
     @SpecFlow
     Scenario: Parallel test runs can send multiple messages
@@ -23,11 +23,29 @@ Feature: Sending TestRunFinished messages
         When the test suite is executed with a testThreadCount of '3'
         Then '3' TestRunFinished messages have been sent
 
-    Scenario: Test suite result is included in the message
+    Scenario: Testrun end time is included in the message
         Given there are '2' feature files
         And all steps are bound and fail
         When the test suite is started at '2019-05-13 13:09:46'
         Then a TestRunStarted message has been sent with the following attributes
-          | Attribute | Value               |
-          | timestamp | 2019-05-13 13:09:46 |
+            | Attribute | Value               |
+            | timestamp | 2019-05-13 13:09:46 |
 
+    Scenario Outline: TestRun Result depends on execution result of scenarios
+
+        Given there are following scenarios:
+            | Successful | Failing                       | Ambiguous                       |
+            | 1          | <Number of failing Scenarios> | <Number of ambiguous Scenarios> |
+
+        When the test suite is executed
+
+        Then a TestRunFinished message has been sent with the following attributes
+            | Attribute | Value             |
+            | success   | <TestRun Success> |
+
+        Examples:
+            | Description                            | Number of failing Scenarios | Number of ambiguous Scenarios | TestRun Success |
+            | No failing or ambigous Scenarios       | 0                           | 0                             | true            |
+            | One failing Scenario                   | 1                           | 0                             | false           |
+            | One ambiguous Scenario                 | 0                           | 1                             | false           |
+            | one failing and one ambiguous Scenario | 1                           | 1                             | false           |

--- a/cucumber-messages/specs/TestRunFinished.feature
+++ b/cucumber-messages/specs/TestRunFinished.feature
@@ -1,0 +1,33 @@
+Feature: Sending TestRunFinished messages
+
+    - Message is send before all BeforeTestRun hooks
+    - Timestamp is in local time zone
+
+    Scenario Outline: Finishing test suite sends a message (independent of feature file exist)
+
+        Given there are '<NumberOfFeatureFiles>' feature files
+        When the test suite is executed
+        Then '<NumberOfTestRunFinishedMessages>' TestRunFinished messages have been sent
+
+        Examples:
+          | Case                              | NumberOfFeatureFiles | NumberOfTestRunFinishedMessages |
+          | empty test suite                  | 0                    | 0                              |
+          | test suite contains feature files | 1                    | 1                              |
+
+    @SpecFlow
+    Scenario: Parallel test runs can send multiple messages
+
+        Given the test runner is 'SpecFlow+Runner'
+        And there are '3' feature files
+        And all steps are bound and pass
+        When the test suite is executed with a testThreadCount of '3'
+        Then '3' TestRunFinished messages have been sent
+
+    Scenario: Test suite result is included in the message
+        Given there are '2' feature files
+        And all steps are bound and fail
+        When the test suite is started at '2019-05-13 13:09:46'
+        Then a TestRunStarted message has been sent with the following attributes
+          | Attribute | Value               |
+          | timestamp | 2019-05-13 13:09:46 |
+

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -1,0 +1,41 @@
+Feature: Sending TestRunStarted messages
+
+    Scenario Outline: Starting test suite sends a message (independent of feature file exist)
+
+        Given there are '<NumberOfFeatureFiles>' feature files
+        When the test suite is executed
+        Then '<NumberOfTestRunStartedMessages>' TestRunStarted messages have been sent
+
+        Examples:
+          | Case                              | NumberOfFeatureFiles | NumberOfTestRunStartedMessages |
+          | empty test suite                  | 0                    | 0                              |
+          | test suite contains feature files | 1                    | 1                              |
+
+    @SpecFlow
+    Scenario: Parallel test runs can send multiple messages
+
+        Given the test runner is 'SpecFlow+Runner'
+        And there are '3' feature files
+        When the test suite was executed with a testThreadCount of '3'
+        Then '3' TestRunStarted messages have been sent
+
+    Scenario: Test suite starting time is included in the message
+
+        When the test suite is started at '2019-05-13 13:09:46'
+        And the test suite was executed
+        Then a TestRunStarted message has been sent with the following attributes
+          | Attribute | Value               |
+          | timestamp | 2019-05-13 13:09:46 |
+
+    Scenario Outline: Cucumber implementation is included in message
+
+        Given the cucumber implementation is <implementation>
+        When the test suite is executed
+        Then a TestRunStarted message has been sent with the following attributes
+          | Attribute              | Value              |
+          | cucumberImplementation | <ImplementationId> |
+
+        @SpecFlow
+        Examples:
+          | implementation | ImplementationId |
+          | SpecFlow       | SpecFlow         |

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -8,7 +8,7 @@ Feature: Sending TestRunStarted messages
 
         Examples:
           | Case                              | NumberOfFeatureFiles | NumberOfTestRunStartedMessages |
-          | empty test suite                  | 0                    | 0                              |
+          | empty test suite                  | 0                    | 1                              |
           | test suite contains feature files | 1                    | 1                              |
 
     @SpecFlow
@@ -16,6 +16,7 @@ Feature: Sending TestRunStarted messages
 
         Given the test runner is 'SpecFlow+Runner'
         And there are '3' feature files
+        And all steps are bound and pass
         When the test suite was executed with a testThreadCount of '3'
         Then '3' TestRunStarted messages have been sent
 

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -1,5 +1,8 @@
 Feature: Sending TestRunStarted messages
 
+    - Message is send before all BeforeTestRun hooks
+    - Timestamp is in local time zone
+
     Scenario Outline: Starting test suite sends a message (independent of feature file exist)
 
         Given there are '<NumberOfFeatureFiles>' feature files

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -27,15 +27,3 @@ Feature: Sending TestRunStarted messages
           | Attribute | Value               |
           | timestamp | 2019-05-13 13:09:46 |
 
-    Scenario Outline: Cucumber implementation is included in message
-
-        Given the cucumber implementation is <implementation>
-        When the test suite is executed
-        Then a TestRunStarted message has been sent with the following attributes
-          | Attribute              | Value              |
-          | cucumberImplementation | <ImplementationId> |
-
-        @SpecFlow
-        Examples:
-          | implementation | ImplementationId |
-          | SpecFlow       | SpecFlow         |

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -8,7 +8,7 @@ Feature: Sending TestRunStarted messages
 
         Examples:
           | Case                              | NumberOfFeatureFiles | NumberOfTestRunStartedMessages |
-          | empty test suite                  | 0                    | 1                              |
+          | empty test suite                  | 0                    | 0                              |
           | test suite contains feature files | 1                    | 1                              |
 
     @SpecFlow

--- a/cucumber-messages/specs/TestRunStarted.feature
+++ b/cucumber-messages/specs/TestRunStarted.feature
@@ -17,13 +17,12 @@ Feature: Sending TestRunStarted messages
         Given the test runner is 'SpecFlow+Runner'
         And there are '3' feature files
         And all steps are bound and pass
-        When the test suite was executed with a testThreadCount of '3'
+        When the test suite is executed with a testThreadCount of '3'
         Then '3' TestRunStarted messages have been sent
 
     Scenario: Test suite starting time is included in the message
 
         When the test suite is started at '2019-05-13 13:09:46'
-        And the test suite was executed
         Then a TestRunStarted message has been sent with the following attributes
           | Attribute | Value               |
           | timestamp | 2019-05-13 13:09:46 |


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

These are the scenarios we use to test the Cucumber-message implementation of SpecFlow.


## Motivation and Context

All implementations of Cucumber should behave the same way.

