### PR TITLE
tag-expressions (python): Fix python3 warning

### DIFF
--- a/tag-expressions/python/.bumpversion.cfg
+++ b/tag-expressions/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.2.dev0
+current_version = 1.1.2
 files = setup.py cucumber_tag_expressions/__init__.py .bumpversion.cfg pytest.ini
 commit = False
 tag = False

--- a/tag-expressions/python/DEVELOPMENT.rst
+++ b/tag-expressions/python/DEVELOPMENT.rst
@@ -60,6 +60,7 @@ Running the Tests
     pytest --html=report.html   # Run tests and create HTML test report.
 
 SEE ALSO:
+
 * https://pytest.org/
 * https://pypi.python.org/pypi/pytest-html
 
@@ -73,9 +74,10 @@ virtual environments, one for each version.
 To run the tests, use::
 
     tox -e py27     # Run tests in a virtual environment with python2.7
-    tox -e py36     # Run tests in a virtual environment with python3.6
+    tox -e py37     # Run tests in a virtual environment with python3.7
 
 SEE ALSO:
+
 * https://tox.readthedocs.io/
 * https://pypi.python.org/pypi/tox
 
@@ -105,6 +107,7 @@ ALTERNATIVE: Run tools in a tox environment::
     tox -e bandit         # Run bandit security checks.
 
 SEE ALSO:
+
 * https://pypi.python.org/pypi/pylint
 * https://pypi.python.org/pypi/bandit
 * https://pylint.readthedocs.io/
@@ -116,5 +119,5 @@ Cleanup the Workspace
 
 To cleanup the local workspace and development environment, use::
 
-    invoke clean        # Cleanup common temporary files.
-    invoke clean-all    # Cleanup everything (.venv, .tox, ...)
+    invoke cleanup        # Cleanup common temporary files.
+    invoke cleanup.all    # Cleanup everything (.venv, .tox, ...)

--- a/tag-expressions/python/cucumber_tag_expressions/__init__.py
+++ b/tag-expressions/python/cucumber_tag_expressions/__init__.py
@@ -16,4 +16,4 @@ Theses selected items are normally included in a test run.
 from __future__ import absolute_import
 from .parser import parse, TagExpressionParser, TagExpressionError
 
-__version__ = "1.1.2.dev0"
+__version__ = "1.1.2"

--- a/tag-expressions/python/cucumber_tag_expressions/parser.py
+++ b/tag-expressions/python/cucumber_tag_expressions/parser.py
@@ -10,7 +10,8 @@ Provides parsing of boolean tag expressions.
     assert "( a and ( b or not (c) ) )" == str(expression)
 
 UNSUPPORTED:
-* Support special tags w/ escaped-parens: ``@reqid\(10\)``
+
+* Support special tags w/ escaped-parens: ``@reqid\\(10\\)``
 """
 
 from __future__ import absolute_import

--- a/tag-expressions/python/invoke.yaml
+++ b/tag-expressions/python/invoke.yaml
@@ -14,9 +14,13 @@ project:
 
 run:
     echo: true
-    pty:  true
-
-clean_all:
+    # DISABLED: pty:  true
+cleanup:
     extra_directories:
-      - .pytest_cache
+      - "build"
+      - "dist"
+
+cleanup_all:
+    extra_directories:
       - .hypothesis
+      - .pytest_cache

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -19,11 +19,12 @@
 minversion    = 3.2
 testpaths     = tests
 python_files  = test_*.py
-addopts = --metadata PACKAGE_UNDER_TEST cucumber-tag-expressions
+addopts =
+    --metadata PACKAGE_UNDER_TEST cucumber-tag-expressions
     --metadata PACKAGE_VERSION 1.1.2.dev0
     --html=build/testing/report.html --self-contained-html
     --junit-xml=build/testing/report.xml
 
 # -- BACKWARD COMPATIBILITY: pytest < 2.8
-norecursedirs = .git .tox attic build dist py.requirements tmp* _WORKSPACE
+# norecursedirs = .git .tox attic build dist py.requirements tmp* _WORKSPACE
 

--- a/tag-expressions/python/pytest.ini
+++ b/tag-expressions/python/pytest.ini
@@ -21,7 +21,7 @@ testpaths     = tests
 python_files  = test_*.py
 addopts =
     --metadata PACKAGE_UNDER_TEST cucumber-tag-expressions
-    --metadata PACKAGE_VERSION 1.1.2.dev0
+    --metadata PACKAGE_VERSION 1.1.2
     --html=build/testing/report.html --self-contained-html
     --junit-xml=build/testing/report.xml
 

--- a/tag-expressions/python/setup.py
+++ b/tag-expressions/python/setup.py
@@ -54,7 +54,7 @@ def find_packages_by_root_package(where):
 # -----------------------------------------------------------------------------
 setup(
     name = "cucumber-tag-expressions",
-    version = "1.1.2.dev0",
+    version = "1.1.2",
     author = "Jens Engel",
     author_email = "jenisys@noreply.github.com",
     url = "https://github.com/cucumber/tag-expressions-python",

--- a/tag-expressions/python/tasks/__init__.py
+++ b/tag-expressions/python/tasks/__init__.py
@@ -18,9 +18,15 @@ from __future__ import absolute_import
 # BOOTSTRAP PATH: Use provided vendor bundle if "invoke" is not installed
 # -----------------------------------------------------------------------------
 from . import _setup    # pylint: disable=wrong-import-order
-INVOKE_MINVERSION = "0.21.0"
+import os.path
+import sys
+INVOKE_MINVERSION = "1.2.0"
 _setup.setup_path()
 _setup.require_invoke_minversion(INVOKE_MINVERSION)
+
+TOPDIR = os.path.join(os.path.dirname(__file__), "..")
+TOPDIR = os.path.abspath(TOPDIR)
+sys.path.insert(0, TOPDIR)
 
 # -----------------------------------------------------------------------------
 # IMPORTS:
@@ -29,7 +35,7 @@ import sys
 from invoke import Collection
 
 # -- TASK-LIBRARY:
-from . import _tasklet_cleanup as clean
+from . import _tasklet_cleanup as cleanup
 from . import test
 from . import release
 
@@ -43,15 +49,18 @@ from . import release
 # TASK CONFIGURATION:
 # -----------------------------------------------------------------------------
 namespace = Collection()
-namespace.add_task(clean.clean)
-namespace.add_task(clean.clean_all)
+namespace.add_collection(Collection.from_module(cleanup), name="cleanup")
 namespace.add_collection(Collection.from_module(test))
 namespace.add_collection(Collection.from_module(release))
 
+cleanup.cleanup_tasks.add_task(cleanup.clean_python)
+
 # -- INJECT: clean configuration into this namespace
-namespace.configure(clean.namespace.configuration())
+namespace.configure(cleanup.namespace.configuration())
 if sys.platform.startswith("win"):
     # -- OVERRIDE SETTINGS: For platform=win32, ... (Windows)
     from ._compat_shutil import which
     run_settings = dict(echo=True, pty=False, shell=which("cmd"))
     namespace.configure({"run": run_settings})
+else:
+    namespace.configure({"run": dict(echo=True, pty=True)})

--- a/tag-expressions/python/tasks/_tasklet_cleanup.py
+++ b/tag-expressions/python/tasks/_tasklet_cleanup.py
@@ -39,7 +39,7 @@ EXAMPLE::
     # -- FILE: tasks/docs.py
     from __future__ import absolute_import
     from invoke import task, Collection
-    from invoke_tasklet_cleanup import cleanup_tasks, cleanup_dirs
+    from tasklet_cleanup import cleanup_tasks, cleanup_dirs
 
     @task
     def clean(ctx, dry_run=False):
@@ -54,19 +54,31 @@ EXAMPLE::
     cleanup_tasks.configure(namespace.configuration())
 """
 
-# NOT-NEEDED: from invoke.exceptions import Failure
 from __future__ import absolute_import, print_function
 import os.path
 import sys
 import pathlib
 from invoke import task, Collection
 from invoke.executor import Executor
+from invoke.exceptions import Exit, Failure, UnexpectedExit
 from path import Path
 
 
 # -----------------------------------------------------------------------------
 # CLEANUP UTILITIES:
 # -----------------------------------------------------------------------------
+def cleanup_accept_old_config(ctx):
+    ctx.cleanup.directories.extend(ctx.clean.directories or [])
+    ctx.cleanup.extra_directories.extend(ctx.clean.extra_directories or [])
+    ctx.cleanup.files.extend(ctx.clean.files or [])
+    ctx.cleanup.extra_files.extend(ctx.clean.extra_files or [])
+
+    ctx.cleanup_all.directories.extend(ctx.clean_all.directories or [])
+    ctx.cleanup_all.extra_directories.extend(ctx.clean_all.extra_directories or [])
+    ctx.cleanup_all.files.extend(ctx.clean_all.files or [])
+    ctx.cleanup_all.extra_files.extend(ctx.clean_all.extra_files or [])
+
+
 def execute_cleanup_tasks(ctx, cleanup_tasks, dry_run=False):
     """Execute several cleanup tasks as part of the cleanup.
 
@@ -78,9 +90,17 @@ def execute_cleanup_tasks(ctx, cleanup_tasks, dry_run=False):
     """
     # pylint: disable=redefined-outer-name
     executor = Executor(cleanup_tasks, ctx.config)
+    failure_count = 0
     for cleanup_task in cleanup_tasks.tasks:
-        print("CLEANUP TASK: %s" % cleanup_task)
-        executor.execute((cleanup_task, dict(dry_run=dry_run)))
+        try:
+            print("CLEANUP TASK: %s" % cleanup_task)
+            executor.execute((cleanup_task, dict(dry_run=dry_run)))
+        except (Exit, Failure, UnexpectedExit) as e:
+            print("FAILURE in CLEANUP TASK: %s (GRACEFULLY-IGNORED)" % cleanup_task)
+            failure_count += 1
+
+    if failure_count:
+        print("CLEANUP TASKS: %d failure(s) occured" % failure_count)
 
 
 def cleanup_dirs(patterns, dry_run=False, workdir="."):
@@ -108,6 +128,10 @@ def cleanup_dirs(patterns, dry_run=False, workdir="."):
                 warn2_counter += 1
                 continue
 
+            if not directory.isdir():
+                print("RMTREE: %s (SKIPPED: Not a directory)" % directory)
+                continue
+
             if dry_run:
                 print("RMTREE: %s (dry-run)" % directory)
             else:
@@ -131,6 +155,9 @@ def cleanup_files(patterns, dry_run=False, workdir="."):
         for file_ in path_glob(file_pattern, current_dir):
             if file_.abspath().startswith(python_basedir):
                 # -- PROTECT CURRENTLY USED VIRTUAL ENVIRONMENT:
+                continue
+            if not file_.isfile():
+                print("REMOVE: %s (SKIPPED: Not a file)" % file_)
                 continue
 
             if dry_run:
@@ -174,17 +201,11 @@ def path_glob(pattern, current_dir=None):
 @task
 def clean(ctx, dry_run=False):
     """Cleanup temporary dirs/files to regain a clean state."""
-    # -- VARIATION-POINT 1: Allow user to override in configuration-file
-    directories = ctx.clean.directories
-    files = ctx.clean.files
-
-    # -- VARIATION-POINT 2: Allow user to add more files/dirs to be removed.
-    extra_directories = ctx.clean.extra_directories or []
-    extra_files = ctx.clean.extra_files or []
-    if extra_directories:
-        directories.extend(extra_directories)
-    if extra_files:
-        files.extend(extra_files)
+    cleanup_accept_old_config(ctx)
+    directories = ctx.cleanup.directories or []
+    directories.extend(ctx.cleanup.extra_directories or [])
+    files = ctx.cleanup.files or []
+    files.extend(ctx.cleanup.extra_files or [])
 
     # -- PERFORM CLEANUP:
     execute_cleanup_tasks(ctx, cleanup_tasks, dry_run=dry_run)
@@ -192,20 +213,26 @@ def clean(ctx, dry_run=False):
     cleanup_files(files, dry_run=dry_run)
 
 
-@task(name="clean-all", aliases=("distclean",))
+@task(name="all", aliases=("distclean",))
 def clean_all(ctx, dry_run=False):
     """Clean up everything, even the precious stuff.
     NOTE: clean task is executed first.
     """
-    cleanup_dirs(ctx.clean_all.directories or [], dry_run=dry_run)
-    cleanup_dirs(ctx.clean_all.extra_directories or [], dry_run=dry_run)
-    cleanup_files(ctx.clean_all.files or [], dry_run=dry_run)
-    cleanup_files(ctx.clean_all.extra_files or [], dry_run=dry_run)
+    cleanup_accept_old_config(ctx)
+    directories = ctx.config.cleanup_all.directories or []
+    directories.extend(ctx.config.cleanup_all.extra_directories or [])
+    files = ctx.config.cleanup_all.files or []
+    files.extend(ctx.config.cleanup_all.extra_files or [])
+
+    # -- PERFORM CLEANUP:
+    # HINT: Remove now directories, files first before cleanup-tasks.
+    cleanup_dirs(directories, dry_run=dry_run)
+    cleanup_files(files, dry_run=dry_run)
     execute_cleanup_tasks(ctx, cleanup_all_tasks, dry_run=dry_run)
     clean(ctx, dry_run=dry_run)
 
 
-@task
+@task(name="python")
 def clean_python(ctx, dry_run=False):
     """Cleanup python related files/dirs: *.pyc, *.pyo, ..."""
     # MAYBE NOT: "**/__pycache__"
@@ -219,24 +246,32 @@ def clean_python(ctx, dry_run=False):
 # -----------------------------------------------------------------------------
 # TASK CONFIGURATION:
 # -----------------------------------------------------------------------------
-namespace = Collection(clean, clean_all)
+CLEANUP_EMPTY_CONFIG = {
+    "directories": [],
+    "files": [],
+    "extra_directories": [],
+    "extra_files": [],
+}
+def make_cleanup_config(**kwargs):
+    config_data = CLEANUP_EMPTY_CONFIG.copy()
+    config_data.update(kwargs)
+    return config_data
+
+
+namespace = Collection(clean_all, clean_python)
+namespace.add_task(clean, default=True)
 namespace.configure({
-    "clean": {
-        "directories": [],
-        "files": [
-            "*.bak", "*.log", "*.tmp",
-            "**/.DS_Store", "**/*.~*~",     # -- MACOSX
-        ],
-        "extra_directories": [],
-        "extra_files": [],
-    },
-    "clean_all": {
-        "directories": [".venv*", ".tox", "downloads", "tmp"],
-        "files": [],
-        "extra_directories": [],
-        "extra_files": [],
-    },
+    "cleanup": make_cleanup_config(
+        files=["*.bak", "*.log", "*.tmp", "**/.DS_Store", "**/*.~*~"]
+    ),
+    "cleanup_all": make_cleanup_config(
+        directories=[".venv*", ".tox", "downloads", "tmp"]
+    ),
+    # -- BACKWARD-COMPATIBLE: OLD-STYLE
+    "clean":     CLEANUP_EMPTY_CONFIG.copy(),
+    "clean_all": CLEANUP_EMPTY_CONFIG.copy(),
 })
+
 
 # -- EXTENSION-POINT: CLEANUP TASKS (called by: clean, clean_all task)
 # NOTE: Can be used by other tasklets to register cleanup tasks.

--- a/tag-expressions/python/tasks/py.requirements.txt
+++ b/tag-expressions/python/tasks/py.requirements.txt
@@ -8,7 +8,7 @@
 #  * http://www.pip-installer.org/
 # ============================================================================
 
-invoke >= 0.21.0
+invoke >= 1.2.0
 six >= 1.11.0
 path.py >= 10.1
 pathlib;    python_version <= '3.4'

--- a/tag-expressions/python/tests/unit/test_parser.py
+++ b/tag-expressions/python/tests/unit/test_parser.py
@@ -215,6 +215,21 @@ class TestTagExpressionParser(object):
         # -- NOTE: RPN parsebility due to Shunting-yard algorithm (stack-based).
         self.assert_parse_with_error_contains_message(text, expected)
 
+    # -- TODO:
+    # @pytest.mark.parametrize("text, expected", [
+    #     ("@a\\(1\\)", "@a(1)"),
+    #     ("@a\\(1\\) and @b\\(2\\)", "( @a(1) and @b(2) )"),
+    # ])
+    # def test_parse__with_escaped_chars(self, text, expected):
+    #     self.assert_parse_expression_equals_expression_string(text, expected)
+    #
+    # -- FROM: TagExpressionParserTest.java
+    # public void evaluates_expr_with_escaped_chars() {
+    #     Expression expr = parser.parse("((not @a\\(1\\) or @b\\(2\\)) and not @c\\(3\\) or not @d\\(4\\) or @e\\(5\\) and @f\\(6\\))");
+    #     assertFalse(expr.evaluate(asList("@a(1) @c(3) @d(4)".split(" "))));
+    #     assertTrue(expr.evaluate(asList("@b(2) @e(5) @f(6)".split(" "))));
+    # }
+
 
     # -- BAD CASES: Too few operands
     @pytest.mark.parametrize("text, error_message", [

--- a/tag-expressions/python/tox.ini
+++ b/tag-expressions/python/tox.ini
@@ -22,7 +22,7 @@
 
 [tox]
 minversion   = 2.8
-envlist      = py27, py37, py36, py36, py35, pypy
+envlist      = py27, py37, py36, py35, pypy
 skip_missing_interpreters = True
 
 


### PR DESCRIPTION
## Summary

Removes a DeprecationWarning while using python3.7 (or newer) when running the tests.

## Details

* Primary issue above (minor issue in docstring)
* BUMP-VERSION: 1.1.2 (was: 1.1.2.dev0)
* Additional cleanups (invoke, tox.ini)

## Motivation and Context

Removes the annoying DeprecationWarning when tests are run with python3.

## How Has This Been Tested?

Using the test suite.

## Types of changes

- [x] Bug fix (minor issue in doctoring; non-breaking change which fixes an issue).

## Checklist:

Only python implementation of tag-expressions is affected.

- [x] The change has been ported to Python.
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.