### PR TITLE
cucumber-expressions: Prefer Java type hint over parameter type

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#515](https://github.com/cucumber/cucumber/issues/515)
    [#581](https://github.com/cucumber/cucumber/pull/581)
    [mpkorstanje])
+* [Java/Go] cucumber-expressions: Prefer language type hint over parameter type
+  ([#658](https://github.com/cucumber/cucumber/pull/658)
+   [#659](https://github.com/cucumber/cucumber/pull/659)
+   [mpkorstanje])
 
 ### Deprecated
 

--- a/cucumber-expressions/go/combinatorial_generated_expression_factory_test.go
+++ b/cucumber-expressions/go/combinatorial_generated_expression_factory_test.go
@@ -15,6 +15,7 @@ func TestCombinatorialGeneratedExpressionFactory(t *testing.T) {
 			func(arg3 ...*string) interface{} { return *arg3[0] },
 			false,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		csscolorParameterType, err := NewParameterType(
@@ -24,6 +25,7 @@ func TestCombinatorialGeneratedExpressionFactory(t *testing.T) {
 			func(arg3 ...*string) interface{} { return *arg3[0] },
 			false,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		dateParameterType, err := NewParameterType(
@@ -33,6 +35,7 @@ func TestCombinatorialGeneratedExpressionFactory(t *testing.T) {
 			func(arg3 ...*string) interface{} { return *arg3[0] },
 			false,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		datetimeParameterType, err := NewParameterType(
@@ -42,6 +45,7 @@ func TestCombinatorialGeneratedExpressionFactory(t *testing.T) {
 			func(arg3 ...*string) interface{} { return *arg3[0] },
 			false,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		timestampParameterType, err := NewParameterType(
@@ -51,6 +55,7 @@ func TestCombinatorialGeneratedExpressionFactory(t *testing.T) {
 			func(arg3 ...*string) interface{} { return *arg3[0] },
 			false,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		parameterTypeCombinations := [][]*ParameterType{

--- a/cucumber-expressions/go/cucumber_expression_generator_test.go
+++ b/cucumber-expressions/go/cucumber_expression_generator_test.go
@@ -92,6 +92,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			},
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		require.NoError(t, parameterTypeRegistry.DefineParameterType(currencyParameterType))
@@ -114,6 +115,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		require.NoError(t, parameterTypeRegistry.DefineParameterType(parameterType1))
@@ -123,6 +125,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			"type2",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)
@@ -148,6 +151,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		require.NoError(t, parameterTypeRegistry.DefineParameterType(parameterType1))
@@ -157,6 +161,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			"type2",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)
@@ -199,6 +204,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		require.NoError(t, parameterTypeRegistry.DefineParameterType(optionalFlightParameterType))
@@ -208,6 +214,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			"optional-hotel",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)
@@ -229,6 +236,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 				nil,
 				true,
 				false,
+				false,
 			)
 			require.NoError(t, err)
 			require.NoError(t, parameterTypeRegistry.DefineParameterType(myType))
@@ -249,6 +257,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		require.NoError(t, parameterTypeRegistry.DefineParameterType(zeroOrMore))
@@ -258,6 +267,7 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 			"string",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)

--- a/cucumber-expressions/go/cucumber_expression_test.go
+++ b/cucumber-expressions/go/cucumber_expression_test.go
@@ -175,7 +175,7 @@ func TestCucumberExpression(t *testing.T) {
 		parameterTypeRegistry := NewParameterTypeRegistry()
 		_, err := NewCucumberExpression("{[string]}", parameterTypeRegistry)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), "Illegal character '[' in parameter name {[string]}")
+		require.Equal(t, err.Error(), "illegal character '[' in parameter name {[string]}")
 	})
 
 	t.Run("does not allow optional parameter types", func(t *testing.T) {

--- a/cucumber-expressions/go/custom_parameter_type_test.go
+++ b/cucumber-expressions/go/custom_parameter_type_test.go
@@ -30,6 +30,7 @@ func CreateParameterTypeRegistry(t *testing.T) *ParameterTypeRegistry {
 		func(args ...*string) interface{} { return &Color{name: *args[0]} }, // transformer
 		false, // useForSnippets
 		true,  // preferForRegexpMatch
+		false,
 	)
 	require.NoError(t, err)
 	err = parameterTypeRegistry.DefineParameterType(colorParameterType)
@@ -49,9 +50,10 @@ func TestCustomParameterTypes(t *testing.T) {
 			},
 			false,
 			false,
+			false,
 		)
 		require.Error(t, err)
-		require.Equal(t, "Illegal character '[' in parameter name {[string]}", err.Error())
+		require.Equal(t, "illegal character '[' in parameter name {[string]}", err.Error())
 	})
 
 	t.Run("CucumberExpression", func(t *testing.T) {
@@ -92,6 +94,7 @@ func TestCustomParameterTypes(t *testing.T) {
 				},
 				true,
 				true,
+				false,
 			)
 			require.NoError(t, err)
 			err = parameterTypeRegistry.DefineParameterType(coordinateParameterType)
@@ -117,6 +120,7 @@ func TestCustomParameterTypes(t *testing.T) {
 				func(args ...*string) interface{} { return &Color{name: *args[0]} },
 				false,
 				true,
+				false,
 			)
 			require.NoError(t, err)
 			err = parameterTypeRegistry.DefineParameterType(colorParameterType)
@@ -137,6 +141,7 @@ func TestCustomParameterTypes(t *testing.T) {
 				func(args ...*string) interface{} { panic(fmt.Sprintf("Can't transform [%s]", *args[0])) },
 				false,
 				true,
+				false,
 			)
 			require.NoError(t, err)
 			err = parameterTypeRegistry.DefineParameterType(colorParameterType)
@@ -161,6 +166,7 @@ func TestCustomParameterTypes(t *testing.T) {
 					func(args ...*string) interface{} { return &CSSColor{name: *args[0]} },
 					false,
 					true,
+					false,
 				)
 				require.NoError(t, err)
 				err = parameterTypeRegistry.DefineParameterType(colorParameterType)
@@ -177,6 +183,7 @@ func TestCustomParameterTypes(t *testing.T) {
 					func(args ...*string) interface{} { return &Color{name: *args[0]} },
 					false,
 					false,
+					false,
 				)
 				require.NoError(t, err)
 				err = parameterTypeRegistry.DefineParameterType(colorParameterType)
@@ -191,6 +198,7 @@ func TestCustomParameterTypes(t *testing.T) {
 					"CSSColor",
 					func(args ...*string) interface{} { return &CSSColor{name: *args[0]} },
 					true,
+					false,
 					false,
 				)
 				require.NoError(t, err)
@@ -223,6 +231,7 @@ func TestCustomParameterTypes(t *testing.T) {
 					func(args ...*string) interface{} { return &Color{name: *args[0]} },
 					false,
 					true,
+					false,
 				)
 				require.NoError(t, err)
 				err = parameterTypeRegistry.DefineParameterType(colorParameterType)

--- a/cucumber-expressions/go/parameter_type_registry.go
+++ b/cucumber-expressions/go/parameter_type_registry.go
@@ -49,6 +49,7 @@ func NewParameterTypeRegistry() *ParameterTypeRegistry {
 		},
 		true,
 		true,
+		false,
 	)
 	if err != nil {
 		panic(err)
@@ -67,6 +68,7 @@ func NewParameterTypeRegistry() *ParameterTypeRegistry {
 		},
 		true,
 		false,
+		false,
 	)
 	if err != nil {
 		panic(err)
@@ -83,6 +85,7 @@ func NewParameterTypeRegistry() *ParameterTypeRegistry {
 			}
 			return i
 		},
+		false,
 		false,
 		false,
 	)
@@ -109,6 +112,7 @@ func NewParameterTypeRegistry() *ParameterTypeRegistry {
 			return i
 		},
 		true,
+		false,
 		false,
 	)
 	if err != nil {

--- a/cucumber-expressions/go/parameter_type_registry_test.go
+++ b/cucumber-expressions/go/parameter_type_registry_test.go
@@ -22,6 +22,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(nameParameterType)
@@ -32,6 +33,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			"person",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)
@@ -44,6 +46,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(placeParameterType)
@@ -57,6 +60,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			CAPITALISED_WORD_REGEXPS,
 			"anonymous",
 			nil,
+			false,
 			false,
 			false,
 		)
@@ -73,6 +77,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(nameParameterType)
@@ -84,6 +89,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(personParameterType)
@@ -94,6 +100,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			"place",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)
@@ -113,6 +120,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(nameParameterType)
@@ -124,6 +132,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			nil,
 			true,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 		err = parameterTypeRegistry.DefineParameterType(personParameterType)
@@ -134,6 +143,7 @@ func TestParameterTypeRegistry(t *testing.T) {
 			"place",
 			nil,
 			true,
+			false,
 			false,
 		)
 		require.NoError(t, err)

--- a/cucumber-expressions/go/parameter_type_test.go
+++ b/cucumber-expressions/go/parameter_type_test.go
@@ -16,6 +16,7 @@ func TestParameterType(t *testing.T) {
 			nil,
 			true,
 			true,
+			false,
 		)
 		require.EqualError(t, err, "ParameterType Regexps can't use flags")
 	})

--- a/cucumber-expressions/go/regular_expression_test.go
+++ b/cucumber-expressions/go/regular_expression_test.go
@@ -38,12 +38,67 @@ func TestRegularExpression(t *testing.T) {
 		require.Equal(t, Match(t, `(.*)`, "22")[0], "22")
 	})
 
+	t.Run("ignores type hint when parameter type has strong type hint", func(t *testing.T) {
+		parameterTypeRegistry := NewParameterTypeRegistry()
+		parameterType2, err := NewParameterType(
+			"type2",
+			[]*regexp.Regexp{regexp.MustCompile("one|two|three")},
+			"type2",
+			func(args ...*string) interface{} {
+				return 42
+			},
+			false,
+			false,
+			true,
+		)
+		require.NoError(t, err)
+		err = parameterTypeRegistry.DefineParameterType(parameterType2)
+		require.NoError(t, err)
+		expr := regexp.MustCompile(`(one|two|three)`)
+		expression := NewRegularExpression(expr, parameterTypeRegistry)
+		args, err := expression.Match("one", reflect.TypeOf(""))
+		require.NoError(t, err)
+		require.Equal(t, args[0].GetValue(), 42)
+	})
+
+	t.Run("follows type hint when parameter type has does not have strong type hint", func(t *testing.T) {
+		parameterTypeRegistry := NewParameterTypeRegistry()
+		parameterType2, err := NewParameterType(
+			"type2",
+			[]*regexp.Regexp{regexp.MustCompile("one|two|three")},
+			"type2",
+			func(args ...*string) interface{} {
+				return 42
+			},
+			true,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		err = parameterTypeRegistry.DefineParameterType(parameterType2)
+		require.NoError(t, err)
+		expr := regexp.MustCompile(`(one|two|three)`)
+		expression := NewRegularExpression(expr, parameterTypeRegistry)
+		args, err := expression.Match("one", reflect.TypeOf(""))
+		require.NoError(t, err)
+		require.Equal(t, args[0].GetValue(), "one")
+	})
+
+
 	t.Run("transforms negative int", func(t *testing.T) {
 		require.Equal(t, Match(t, `(-?\d+)`, "-22")[0], -22)
 	})
 
 	t.Run("transforms positive int", func(t *testing.T) {
 		require.Equal(t, Match(t, `(-?\d+)`, "22")[0], 22)
+	})
+
+	t.Run("transforms positive int with hint", func(t *testing.T) {
+		require.Equal(t, Match(t, `(-?\d+)`, "22", reflect.TypeOf(int(0)))[0], 22)
+	})
+
+	t.Run("transforms positive int with conflicting hint", func(t *testing.T) {
+		require.Equal(t, Match(t, `(-?\d+)`, "22", reflect.TypeOf(""))[0], "22")
 	})
 
 	t.Run("transforms float without integer part", func(t *testing.T) {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
@@ -3,7 +3,6 @@ package io.cucumber.cucumberexpressions;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.NumberFormat;
 import java.util.Locale;
 
 import static java.util.Objects.requireNonNull;
@@ -35,7 +34,7 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
             return new BigInteger(fromValue);
         }
 
-        if (BigDecimal.class.equals(toValueClass)) {
+        if (BigDecimal.class.equals(toValueClass) || Number.class.equals(toValueClass)) {
             return numberParser.parseBigDecimal(fromValue);
         }
 

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -48,55 +48,55 @@ public final class ParameterTypeRegistry {
             public BigInteger transform(String arg) throws Throwable {
                 return (BigInteger) internalParameterTransformer.transform(arg, BigInteger.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("bigdecimal", FLOAT_REGEXPS, BigDecimal.class, new Transformer<BigDecimal>() {
             @Override
             public BigDecimal transform(String arg) throws Throwable {
                 return (BigDecimal) internalParameterTransformer.transform(arg, BigDecimal.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("byte", INTEGER_REGEXPS, Byte.class, new Transformer<Byte>() {
             @Override
             public Byte transform(String arg) throws Throwable {
                 return (Byte) internalParameterTransformer.transform(arg, Byte.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("short", INTEGER_REGEXPS, Short.class, new Transformer<Short>() {
             @Override
             public Short transform(String arg) throws Throwable {
                 return (Short) internalParameterTransformer.transform(arg, Short.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("int", INTEGER_REGEXPS, Integer.class, new Transformer<Integer>() {
             @Override
             public Integer transform(String arg) throws Throwable {
                 return (Integer) internalParameterTransformer.transform(arg, Integer.class);
             }
-        }, true, true));
+        }, true, true, false));
         defineParameterType(new ParameterType<>("long", INTEGER_REGEXPS, Long.class, new Transformer<Long>() {
             @Override
             public Long transform(String arg) throws Throwable {
                 return (Long) internalParameterTransformer.transform(arg, Long.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("float", FLOAT_REGEXPS, Float.class, new Transformer<Float>() {
             @Override
             public Float transform(String arg) throws Throwable {
                 return (Float) internalParameterTransformer.transform(arg, Float.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("double", FLOAT_REGEXPS, Double.class, new Transformer<Double>() {
             @Override
             public Double transform(String arg) throws Throwable {
                 return (Double) internalParameterTransformer.transform(arg, Double.class);
             }
-        }, true, true));
+        }, true, true, false));
         defineParameterType(new ParameterType<>("word", WORD_REGEXPS, String.class, new Transformer<String>() {
             @Override
             public String transform(String arg) throws Throwable {
                 return (String) internalParameterTransformer.transform(arg, String.class);
             }
-        }, false, false));
+        }, false, false, false));
         defineParameterType(new ParameterType<>("string", STRING_REGEXPS, String.class, new Transformer<String>() {
             @Override
             public String transform(String arg) throws Throwable {
@@ -105,7 +105,7 @@ public final class ParameterTypeRegistry {
                                 .replaceAll("\\\\'", "'"),
                         String.class);
             }
-        }, true, false));
+        }, true, false, false));
 
         defineParameterType(createAnonymousParameterType(ANONYMOUS_REGEX));
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -36,6 +36,19 @@ public class RegularExpressionTest {
     }
 
     @Test
+    public void matches_positive_int_with_hint() {
+        List<?> match = match(compile("(\\d+)"), "22", Integer.class);
+        assertEquals(singletonList(22), match);
+    }
+
+    @Test
+    public void matches_positive_int_with_conflicting_type_hint() {
+        List<?> match = match(compile("(\\d+)"), "22", String.class);
+        assertEquals(singletonList("22"), match);
+    }
+
+
+    @Test
     public void matches_nested_capture_group_without_match() {
         List<?> match = match(compile("^a user( named \"([^\"]*)\")?$"), "a user");
         assertEquals(singletonList(null), match);
@@ -125,6 +138,39 @@ public class RegularExpressionTest {
         ));
         List<?> match = match(compile("a quote ([\"a-z ]+)"), "a quote \" and quote \"", String.class);
         assertEquals(asList("\" AND QUOTE \""), match);
+    }
+
+    @Test
+    public void ignores_type_hint_when_parameter_type_has_strong_type_hint() {
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                "test",
+                "one|two|three",
+                Integer.class,
+                new Transformer<Integer>() {
+                    @Override
+                    public Integer transform(String s) {
+                        return 42;
+                    }
+                }, false, false, true
+        ));
+        assertEquals(asList(42), match(compile("(one|two|three)"), "one", String.class));
+    }
+
+
+    @Test
+    public void follows_type_hint_when_parameter_type_does_not_have_strong_type_hint() {
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                "test",
+                "one|two|three",
+                Integer.class,
+                new Transformer<Integer>() {
+                    @Override
+                    public Integer transform(String s) {
+                        return 42;
+                    }
+                }, false, false, false
+        ));
+        assertEquals(asList("one"), match(compile("(one|two|three)"), "one", String.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

When there is a conflict between the type hint from the regular expression
and the method prefer the the parameter type associated with the regular
expression. This ensures we will use the internal/user registered parameter
transformer rather then the default.

Unless the parameter type indicates it is the stronger type hint.

## Details

Reasoning:
1. Pure cucumber expression users will not notice this in either scenario.
2. Pure regular expression users will benefit because 
   `BuiltInParameterTransformer` can now seamlessly transform any captured
   values. (For all built in types `useRegexpMatchAsStrongTypeHint` is
   explicitly set to false.)
2. Regular expression users that define a default transformer have little
   need to define parameter types. The default transformer should be
   sufficiently powerful to meet their needs and will often allow users to
   add custom creation methods e.g. Jacksons @JsonFactory.
3. Users who mix regular and cucumber expressions may run into conflicts
   when a registered cucumber expression and unregistered happens to
   collide. However this was the situation before this flag was added.
4. Regular expression users who define custom parameter types do so with
   the expectation that the parameter will be matched. Subverting this
   expectation when the method signature does not match may result in a
   parameter transformer that is unable to convert to the desired type.
   Leaving the user puzzled as to why his transform was ignored.

## Motivation and Context   

Fixes: https://github.com/cucumber/cucumber/issues/658

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [x] The change has been ported to Go.
- [X] I've added tests for my code.
