### PR TITLE
Add Timestamp property and comments to TestRunFinished message

### DIFF
--- a/cucumber-messages/messages.proto
+++ b/cucumber-messages/messages.proto
@@ -461,7 +461,10 @@ message TestResult {
 }
 
 message TestRunFinished {
+  // success = StrictModeEnabled ? (failed_count == 0 && ambiguous_count == 0 && undefined_count == 0 && pending_count == 0) : (failed_count == 0 && ambiguous_count == 0)
   bool success = 1;
+  // Timestamp when the TestRun is finished
+  google.protobuf.Timestamp timestamp = 2;
 }
 
 ////// Commands


### PR DESCRIPTION
## Summary

Add timestamp property to TestRunFinished message so that we know when the TestRun is finished.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Do I need to update all messages.proto files in the repo or only that one and that is synced in the build?