### PR TITLE
cucumber-expressions: Tailor decimal pattern to number parser

### DIFF
--- a/cucumber-expressions/go/cucumber_expression_regexp_test.go
+++ b/cucumber-expressions/go/cucumber_expression_regexp_test.go
@@ -35,7 +35,7 @@ func TestCucumberExpressionRegExpTranslation(t *testing.T) {
 		assertRegexp(
 			t,
 			"I have {float} cukes at {int} o'clock",
-			`^I have ([-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*[.,]?[0-9]+(?:[0-9]+[E][-+]?[0-9]+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$`,
+			`^I have ([-+]?\d*\.?\d+) cukes at ((?:-?\d+)|(?:\d+)) o'clock$`,
 		)
 	})
 

--- a/cucumber-expressions/go/cucumber_expression_test.go
+++ b/cucumber-expressions/go/cucumber_expression_test.go
@@ -132,16 +132,38 @@ func TestCucumberExpression(t *testing.T) {
 	})
 
 	t.Run("matches float", func(t *testing.T) {
-		require.Equal(
-			t,
-			MatchCucumberExpression(t, "{float}", "0.22"),
-			[]interface{}{0.22},
-		)
-		require.Equal(
-			t,
-			MatchCucumberExpression(t, "{float}", ".22"),
-			[]interface{}{0.22},
-		)
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ""), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "."), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ","), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "E"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ",1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1."), []interface{}(nil))
+
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1"), []interface{}{1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-1"), []interface{}{-1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1.1"), []interface{}{1.1})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,000"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,000,0"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,000.1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,000,10"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,0.1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1,000,000.1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-1.1"), []interface{}{-1.1})
+
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1"), []interface{}{0.1})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1"), []interface{}{-0.1})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10000001"), []interface{}{-0.10000001})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "1e1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "E1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+2"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10E2"), []interface{}(nil))
 	})
 
 	t.Run("matches float with zero", func(t *testing.T) {

--- a/cucumber-expressions/go/parameter_type_registry.go
+++ b/cucumber-expressions/go/parameter_type_registry.go
@@ -12,7 +12,7 @@ var INTEGER_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`\d+`),
 }
 var FLOAT_REGEXPS = []*regexp.Regexp{
-	regexp.MustCompile(`[-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*[.,]?[0-9]+(?:[0-9]+[E][-+]?[0-9]+)?`),
+	regexp.MustCompile(`[-+]?\d*\.?\d+`),
 }
 var WORD_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`[^\s]+`),

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -27,10 +27,10 @@ public final class ParameterTypeRegistry {
             Pattern.compile("\\d+").pattern()
     );
     private static final String SIGN = "[-+]?";
-    private static final String MUST_CONTAIN_NUMBER = "(?=.*[0-9].*)";
-    private static final String SCIENTIFIC_NUMBER = "(?:[0-9]+[{expnt}][-+]?[0-9]+)?";
-    private static final String DECIMAL_FRACTION = "(?:[{decimal}](?=[0-9].*))?[0-9]*";
-    private static final String INTEGER = "(?:[0-9]+(?:[{group}]?[0-9]+)*)*";
+    private static final String MUST_CONTAIN_NUMBER = "(?=.*\\d.*)";
+    private static final String SCIENTIFIC_NUMBER = "(?:\\d+[{expnt}]-?\\d+)?";
+    private static final String DECIMAL_FRACTION = "(?:[{decimal}](?=\\d.*))?\\d*";
+    private static final String INTEGER = "(?:\\d+(?:[{group}]?\\d+)*)*";
     private static final String FLOAT_REGEXPS =
             Pattern.compile(MUST_CONTAIN_NUMBER + SIGN + INTEGER + DECIMAL_FRACTION + SCIENTIFIC_NUMBER).pattern();
     private static final List<String> WORD_REGEXPS = singletonList(

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
@@ -40,11 +40,11 @@ public class CucumberExpressionPatternTest {
         assertPattern(
                 "I have {float} cukes at {int} o'clock",
                 "^I have (" +
-                        "(?=.*[0-9].*)" +
+                        "(?=.*\\d.*)" +
                         "[-+]?" +
-                        "(?:[0-9]+(?:[,]?[0-9]+)*)*" +
-                        "(?:[.](?=[0-9].*))?[0-9]*" +
-                        "(?:[0-9]+[E][-+]?[0-9]+)?) cukes at ((?:-?\\d+)|(?:\\d+)) o'clock$"
+                        "(?:\\d+(?:[,]?\\d+)*)*" +
+                        "(?:[.](?=\\d.*))?\\d*" +
+                        "(?:\\d+[E]-?\\d+)?) cukes at ((?:-?\\d+)|(?:\\d+)) o'clock$"
         );
     }
 

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
@@ -32,5 +32,8 @@ public class NumberParserTest {
         assertEquals(new BigDecimal("1042.0000000000000000000002"), english.parseBigDecimal("1,042.0000000000000000000002"));
         assertEquals(new BigDecimal("1042.0000000000000000000002"), german.parseBigDecimal( "1.042,0000000000000000000002"));
         assertEquals(new BigDecimal("1042.0000000000000000000002"), canadianFrench.parseBigDecimal( "1\u00A0042,0000000000000000000002"));
+
+        assertEquals(new BigDecimal("100"), english.parseBigDecimal("1.00E2"));
+        assertEquals(new BigDecimal("0.01"), english.parseBigDecimal("1E-2"));
     }
 }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
@@ -186,8 +186,11 @@ public class ParameterTypeRegistryTest {
         assertThat(expression.match(".1E1").get(0).getValue(), is(new BigDecimal("1")));
         assertThat(expression.match("E1"), nullValue());
         assertThat(expression.match("-.1E-1").get(0).getValue(), is(new BigDecimal("-0.01")));
-        assertThat(expression.match("-.1E+1").get(0).getValue(), is(new BigDecimal("-0.1")));
+        assertThat(expression.match("-.1E-2").get(0).getValue(), is(new BigDecimal("-0.001")));
+        assertThat(expression.match("-.1E+1"), nullValue());
+        assertThat(expression.match("-.1E+2"), nullValue());
         assertThat(expression.match("-.1E1").get(0).getValue(), is(new BigDecimal("-1")));
+        assertThat(expression.match("-.10E2").get(0).getValue(), is(new BigDecimal("-10")));
     }
 
     @Test

--- a/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
@@ -1,20 +1,17 @@
 import ParameterType from './ParameterType'
 
 import CucumberExpressionGenerator from './CucumberExpressionGenerator'
-import { AmbiguousParameterTypeError, CucumberExpressionError } from './Errors'
+import {AmbiguousParameterTypeError, CucumberExpressionError} from './Errors'
 
 export default class ParameterTypeRegistry {
   public static readonly INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-  public static readonly FLOAT_REGEXP = /(?=.*[0-9].*)[-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*(?:[.,](?=[0-9].*))?[0-9]*(?:[0-9]+[E][-+]?[0-9]+)?/
+  public static readonly FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+\-]?\d+)?/
   public static readonly WORD_REGEXP = /[^\s]+/
   public static readonly STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/
   public static readonly ANONYMOUS_REGEXP = /.*/
 
   private readonly parameterTypeByName = new Map<string, ParameterType<any>>()
-  private readonly parameterTypesByRegexp = new Map<
-    string,
-    Array<ParameterType<any>>
-  >()
+  private readonly parameterTypesByRegexp = new Map<string, Array<ParameterType<any>>>()
 
   constructor() {
     this.defineParameterType(

--- a/cucumber-expressions/javascript/test/CucumberExpressionRegExpTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionRegExpTest.ts
@@ -25,7 +25,7 @@ describe('CucumberExpression', () => {
     it('translates parameters', () => {
       assertRegexp(
         "I have {float} cukes at {int} o'clock",
-          /^I have ((?=.*[0-9].*)[-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*(?:[.,](?=[0-9].*))?[0-9]*(?:[0-9]+[E][-+]?[0-9]+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$/
+        /^I have ((?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+\-]?\d+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$/
       )
     })
 

--- a/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
@@ -118,8 +118,38 @@ describe('CucumberExpression', () => {
   })
 
   it('matches float', () => {
-    assert.deepStrictEqual(match('{float}', '0.22'), [0.22])
-    assert.deepStrictEqual(match('{float}', '.22'), [0.22])
+    assert.deepStrictEqual(match('{float}', ""), null);
+    assert.deepStrictEqual(match('{float}', "."), null);
+    assert.deepStrictEqual(match('{float}', ","), null);
+    assert.deepStrictEqual(match('{float}', "-"), null);
+    assert.deepStrictEqual(match('{float}', "E"), null);
+    assert.deepStrictEqual(match('{float}', "1,"), null);
+    assert.deepStrictEqual(match('{float}', ",1"), null);
+    assert.deepStrictEqual(match('{float}', "1."), null);
+
+    assert.deepStrictEqual(match('{float}', "1"), [1]);
+    assert.deepStrictEqual(match('{float}', "-1"), [-1]);
+    assert.deepStrictEqual(match('{float}', "1.1"), [1.1]);
+    assert.deepStrictEqual(match('{float}', "1,000"), null);
+    assert.deepStrictEqual(match('{float}', "1,000,0"), null);
+    assert.deepStrictEqual(match('{float}', "1,000.1"), null);
+    assert.deepStrictEqual(match('{float}', "1,000,10"), null);
+    assert.deepStrictEqual(match('{float}', "1,0.1"), null);
+    assert.deepStrictEqual(match('{float}', "1,000,000.1"), null);
+    assert.deepStrictEqual(match('{float}', "-1.1"), [-1.1]);
+
+    assert.deepStrictEqual(match('{float}', ".1"), [0.1]);
+    assert.deepStrictEqual(match('{float}', "-.1"), [-0.1]);
+    assert.deepStrictEqual(match('{float}', "-.10000001"), [-0.10000001]);
+    assert.deepStrictEqual(match('{float}', "1E1"), [1E1]); // precision 1 with scale -1, can not be expressed as a decimal
+    assert.deepStrictEqual(match('{float}', ".1E1"), [1]);
+    assert.deepStrictEqual(match('{float}', "E1"), null);
+    assert.deepStrictEqual(match('{float}', "-.1E-1"), [-0.01]);
+    assert.deepStrictEqual(match('{float}', "-.1E-2"), [-0.001]);
+    assert.deepStrictEqual(match('{float}', "-.1E+1"), [-1]);
+    assert.deepStrictEqual(match('{float}', "-.1E+2"), [-10]);
+    assert.deepStrictEqual(match('{float}', "-.1E1"), [-1]);
+    assert.deepStrictEqual(match('{float}', "-.10E2"), [-10]);
   })
 
   it('matches float with zero', () => {
@@ -210,7 +240,7 @@ describe('CucumberExpression', () => {
         'widget',
         /\w+/,
         null,
-        function(s: string) {
+        function (s: string) {
           return this.createWidget(s)
         },
         false,

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -6,7 +6,7 @@ module Cucumber
   module CucumberExpressions
     class ParameterTypeRegistry
       INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-      FLOAT_REGEXP = /(?=.*[0-9].*)[-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*(?:[.,](?=[0-9].*))?[0-9]*(?:[0-9]+[E][-+]?[0-9]+)?/
+      FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?/
       WORD_REGEXP = /[^\s]+/
       STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/
       ANONYMOUS_REGEXP = /.*/

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
@@ -34,7 +34,7 @@ module Cucumber
         it "translates parameters" do
           assert_regexp(
             "I have {float} cukes at {int} o'clock",
-            /^I have ((?=.*[0-9].*)[-+]?(?:[0-9]+(?:[,.]?[0-9]+)*)*(?:[.,](?=[0-9].*))?[0-9]*(?:[0-9]+[E][-+]?[0-9]+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$/
+            /^I have ((?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$/
           )
         end
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -76,9 +76,38 @@ module Cucumber
       end
 
       it "matches float" do
-        expect(match("{float}", "0.22")).to eq([0.22])
-        expect(match("{float}", ".22")).to eq([0.22])
-        expect(match("{float}", "-1.22")).to eq([-1.22])
+        expect(match("{float}", "")).to eq(nil)
+        expect(match("{float}", ".")).to eq(nil)
+        expect(match("{float}", ",")).to eq(nil)
+        expect(match("{float}", "-")).to eq(nil)
+        expect(match("{float}", "E")).to eq(nil)
+        expect(match("{float}", "1,")).to eq(nil)
+        expect(match("{float}", ",1")).to eq(nil)
+        expect(match("{float}", "1.")).to eq(nil)
+
+        expect(match("{float}", "1")).to eq([1])
+        expect(match("{float}", "-1")).to eq([-1])
+        expect(match("{float}", "1.1")).to eq([1.1])
+        expect(match("{float}", "1,000")).to eq(nil)
+        expect(match("{float}", "1,000,0")).to eq(nil)
+        expect(match("{float}", "1,000.1")).to eq(nil)
+        expect(match("{float}", "1,000,10")).to eq(nil)
+        expect(match("{float}", "1,0.1")).to eq(nil)
+        expect(match("{float}", "1,000,000.1")).to eq(nil)
+        expect(match("{float}", "-1.1")).to eq([-1.1])
+
+        expect(match("{float}", ".1")).to eq([0.1])
+        expect(match("{float}", "-.1")).to eq([-0.1])
+        expect(match("{float}", "-.1000001")).to eq([-0.1000001])
+        expect(match("{float}", "1E1")).to eq([10.0])
+        expect(match("{float}", ".1E1")).to eq([1])
+        expect(match("{float}", "E1")).to eq(nil)
+        expect(match("{float}", "-.1E-1")).to eq([-0.01])
+        expect(match("{float}", "-.1E-2")).to eq([-0.001])
+        expect(match("{float}", "-.1E+1")).to eq([-1])
+        expect(match("{float}", "-.1E+2")).to eq([-10])
+        expect(match("{float}", "-.1E1")).to eq([-1])
+        expect(match("{float}", "-.1E2")).to eq([-10])
       end
 
       it "matches anonymous" do


### PR DESCRIPTION
Different languages provided different degrees of support for number
parsing. Additionally when confronted with invalid input they also deal
this differently. Tailoring the regex to match the capabilities of the
language specific parser avoids nasty surprises later on.

Assumes number has been parsed when encountering unknown tokens
 - Java
 - JavaScript
 - Ruby

Throws exception when encountering unknown tokens
 - Go

Supports thousands separator
 - Java

Supports scientific notation
 - Java
 - JavaScript
 - Ruby

Supports positive exponential in scientific notation
 - JavaScript
 - Ruby

Closes: #675

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [X] The change has been ported to Ruby.
- [X] The change has been ported to JavaScript.
- [X] The change has been ported to Go.
- [X] I've added tests for my code.
