### PR TITLE
build: Check if prepare release is done in docker

### DIFF
--- a/scripts/prepare_release_env.sh
+++ b/scripts/prepare_release_env.sh
@@ -6,6 +6,11 @@ then
   exit 1
 fi
 
+if [ ! -d "/app/RELEASE_PROCESS.md" ]; then
+  >&2 echo "Are you running in docker?"
+  exit 1
+fi
+
 if [ -z ${GIT_CRYPT_KEY_BASE64} ]; then
   echo "Not decrypting secrets - hopefully this is already done"
 else


### PR DESCRIPTION
## Summary

Checks if the `prepare_release_env.sh` is executed in the docker container. Prevents the script from overwriting important information (ssh keys, gem credentials, ect).
