### PR TITLE
gherkin-perl: Add Perl infrastructure to the CI docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apk add --no-cache \
   openjdk8 \
   openssh \
   openssl-dev \
+  perl \
+  perl-dev \
   protobuf \
   python2 \
   python2-dev \
@@ -66,6 +68,10 @@ RUN pip install pipenv
 RUN pip install twine
 RUN chown -R cukebot:cukebot /usr/lib/python2.7/site-packages
 RUN mkdir -p /usr/man && chown -R cukebot:cukebot /usr/man
+
+# Configure Perl
+RUN curl -L https://cpanmin.us/ -o /usr/local/bin/cpanm
+RUN chmod +x /usr/local/bin/cpanm
 
 # Fix Protobuf - the apk package doesn't include google/protobuf/timestamp.proto
 RUN mkdir -p mkdir -p /usr/local/include/google/protobuf

--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -19,7 +19,7 @@ default: .compared
 	touch $@
 
 .cpanfile_dependencies:
-	cpanm --installdeps .
+	cpanm --installdeps --notest .
 	touch $@
 
 .built: .cpanfile_dependencies lib/Gherkin/Generated/Parser.pm lib/Gherkin/Generated/Languages.pm $(PERL_FILES) bin/gherkin-generate-tokens bin/gherkin-generate-ast LICENSE.txt


### PR DESCRIPTION
## Summary

Add Perl infrastructure required to start testing Perl implementation.

## Details

Before this change, there's insufficient Perl in the images
(none, actually) to run the Perl tests and thus to verify
validity of PR #694.

Incidentally add `--notest` flag to cpanm to stop it from
downloading half of CPAN in order to test *dependencies* it's
building.

## How Has This Been Tested?

In my local Docker environment I verified that this change is enough to run Perl and install dependencies using the module installer `cpanm` on which the gherkin-perl Makefile depends.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

None of the above are applicable.