### PR TITLE
Trim trailing space in example cells

### DIFF
--- a/gherkin/Makefile
+++ b/gherkin/Makefile
@@ -1,2 +1,2 @@
-MAKEFILES = go/Makefile javascript/Makefile ruby/Makefile c/Makefile java/Makefile
+MAKEFILES = go/Makefile javascript/Makefile ruby/Makefile java/Makefile
 include default.mk

--- a/gherkin/c/testdata/good/padded_example.feature
+++ b/gherkin/c/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/c/testdata/good/padded_example.feature
+++ b/gherkin/c/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/c/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/c/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/c/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/c/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/c/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/c/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/c/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/c/testdata/good/padded_example.feature.tokens
+++ b/gherkin/c/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/c/testdata/good/padded_example.feature.tokens
+++ b/gherkin/c/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/dotnet/testdata/good/padded_example.feature
+++ b/gherkin/dotnet/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/dotnet/testdata/good/padded_example.feature
+++ b/gherkin/dotnet/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/dotnet/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/dotnet/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/dotnet/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/dotnet/testdata/good/padded_example.feature.tokens
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/dotnet/testdata/good/padded_example.feature.tokens
+++ b/gherkin/dotnet/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/go/Makefile
+++ b/gherkin/go/Makefile
@@ -59,7 +59,7 @@ acceptance/testdata/%.feature.ast.ndjson: testdata/%.feature testdata/%.feature.
 	$(EXE) --json --no-source --no-pickles $< | jq --sort-keys --compact-output -f remove_empty.jq > $@
 	diff --unified <(jq "." $<.ast.ndjson) <(jq "." $@)
 
-testdata/%.feature.errors.ndjson: testdata/%.feature bin/gherkin
+testdata/%.feature.errors.ndjson: testdata/%.feature $(EXE)
 ifdef GOLDEN
 	mkdir -p `dirname $@`
 	$(EXE) --json --no-source $< | jq --sort-keys -f remove_empty.jq > $@
@@ -81,7 +81,7 @@ acceptance/testdata/%.feature.source.ndjson: testdata/%.feature testdata/%.featu
 	$(EXE) --json --no-ast --no-pickles $< | jq --sort-keys --compact-output -f remove_empty.jq > $@
 	diff --unified <(jq "." $<.source.ndjson) <(jq "." $@)
 
-testdata/%.feature.pickles.ndjson: testdata/%.feature bin/gherkin
+testdata/%.feature.pickles.ndjson: testdata/%.feature $(EXE)
 ifdef GOLDEN
 	mkdir -p `dirname $@`
 	$(EXE) --json --no-source --no-ast $< | jq --sort-keys -f remove_empty.jq > $@

--- a/gherkin/go/go.mod
+++ b/gherkin/go/go.mod
@@ -7,3 +7,5 @@ require (
 )
 
 replace github.com/cucumber/cucumber-messages-go/v5 => ../../cucumber-messages/go
+
+go 1.13

--- a/gherkin/go/matcher.go
+++ b/gherkin/go/matcher.go
@@ -3,6 +3,7 @@ package gherkin
 import (
 	"regexp"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -202,9 +203,11 @@ func (m *matcher) MatchTableRow(line *Line) (ok bool, token *Token, err error) {
 			if char == TABLE_CELL_SEPARATOR {
 				// append current cell
 				txt := string(cell)
-				txtTrimmed := strings.TrimLeft(txt, " ")
-				ind := len(txt) - len(txtTrimmed)
-				cells = append(cells, &LineSpan{startCol + ind, strings.TrimRight(txtTrimmed, " ")})
+
+				txtTrimmedLeadingSpace := strings.TrimLeftFunc(txt, unicode.IsSpace)
+				ind := len(txt) - len(txtTrimmedLeadingSpace)
+				txtTrimmed := strings.TrimRightFunc(txtTrimmedLeadingSpace, unicode.IsSpace)
+				cells = append(cells, &LineSpan{startCol + ind, txtTrimmed})
 				// start building next
 				cell = make([]rune, 0)
 				startCol = col + 1

--- a/gherkin/go/pickles_test.go
+++ b/gherkin/go/pickles_test.go
@@ -1,0 +1,34 @@
+package gherkin
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ExampleCompilePickles() {
+
+	input := `Feature: test
+
+  Scenario: test
+    Given a <color> ball
+
+    Examples:
+      | color |
+      |  red  |
+`
+	r := strings.NewReader(input)
+
+	gherkinDocument, err := ParseGherkinDocument(r)
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%s\n", err)
+		return
+	}
+	pickles := Pickles(*gherkinDocument, "test.feature", input)
+
+	fmt.Fprintf(os.Stdout, "Text: %+v\n", pickles[0].Steps[0].Text)
+
+	// Output:
+	//
+	// Text: a red ball
+}

--- a/gherkin/go/testdata/good/padded_example.feature
+++ b/gherkin/go/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/go/testdata/good/padded_example.feature
+++ b/gherkin/go/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/go/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/go/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/go/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/go/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/go/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/go/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/go/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/go/testdata/good/padded_example.feature.tokens
+++ b/gherkin/go/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/go/testdata/good/padded_example.feature.tokens
+++ b/gherkin/go/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/java/testdata/good/padded_example.feature
+++ b/gherkin/java/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/java/testdata/good/padded_example.feature
+++ b/gherkin/java/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/java/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/java/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/java/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/java/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/java/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/java/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/java/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/java/testdata/good/padded_example.feature.tokens
+++ b/gherkin/java/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/java/testdata/good/padded_example.feature.tokens
+++ b/gherkin/java/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/javascript/testdata/good/padded_example.feature
+++ b/gherkin/javascript/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/javascript/testdata/good/padded_example.feature
+++ b/gherkin/javascript/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/javascript/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/javascript/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/javascript/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/javascript/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/javascript/testdata/good/padded_example.feature.tokens
+++ b/gherkin/javascript/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/javascript/testdata/good/padded_example.feature.tokens
+++ b/gherkin/javascript/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/objective-c/testdata/good/padded_example.feature
+++ b/gherkin/objective-c/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/objective-c/testdata/good/padded_example.feature
+++ b/gherkin/objective-c/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/objective-c/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/objective-c/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/objective-c/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/objective-c/testdata/good/padded_example.feature.tokens
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/objective-c/testdata/good/padded_example.feature.tokens
+++ b/gherkin/objective-c/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/perl/testdata/good/padded_example.feature
+++ b/gherkin/perl/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/perl/testdata/good/padded_example.feature
+++ b/gherkin/perl/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/perl/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/perl/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/perl/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/perl/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/perl/testdata/good/padded_example.feature.tokens
+++ b/gherkin/perl/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/perl/testdata/good/padded_example.feature.tokens
+++ b/gherkin/perl/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/python/testdata/good/padded_example.feature
+++ b/gherkin/python/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/python/testdata/good/padded_example.feature
+++ b/gherkin/python/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/python/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/python/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/python/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/python/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/python/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/python/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/python/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/python/testdata/good/padded_example.feature.tokens
+++ b/gherkin/python/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/python/testdata/good/padded_example.feature.tokens
+++ b/gherkin/python/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/ruby/testdata/good/padded_example.feature
+++ b/gherkin/ruby/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/ruby/testdata/good/padded_example.feature
+++ b/gherkin/ruby/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/ruby/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/ruby/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/ruby/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/ruby/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/ruby/testdata/good/padded_example.feature.tokens
+++ b/gherkin/ruby/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/ruby/testdata/good/padded_example.feature.tokens
+++ b/gherkin/ruby/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF

--- a/gherkin/testdata/good/padded_example.feature
+++ b/gherkin/testdata/good/padded_example.feature
@@ -1,0 +1,12 @@
+Feature: test
+
+  Scenario: test
+    Given a <color> ball with:
+      | type     | diameter |
+      | football |       69 |
+      |   pool   |      5.6 |
+
+
+    Examples:
+      | color |
+      |  red  |

--- a/gherkin/testdata/good/padded_example.feature
+++ b/gherkin/testdata/good/padded_example.feature
@@ -7,6 +7,12 @@ Feature: test
       |   pool   |      5.6 |
 
 
+    # The "red" cell below has the following whitespace characters on each side:
+    # - U+00A0 (non-breaking space)
+    # - U+0020 (space)
+    # - U+0009 (tab)
+    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`
+    # and pasted. 
     Examples:
-      | color |
-      |  red  |
+      | color   |
+      |  	red  	|

--- a/gherkin/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.ast.ndjson
@@ -1,5 +1,49 @@
 {
   "gherkinDocument": {
+    "comments": [
+      {
+        "location": {
+          "column": 1,
+          "line": 10
+        },
+        "text": "    # The \"red\" cell below has the following whitespace characters on each side:"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 11
+        },
+        "text": "    # - U+00A0 (non-breaking space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 12
+        },
+        "text": "    # - U+0020 (space)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 13
+        },
+        "text": "    # - U+0009 (tab)"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 14
+        },
+        "text": "    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`"
+      },
+      {
+        "location": {
+          "column": 1,
+          "line": 15
+        },
+        "text": "    # and pasted. "
+      }
+    ],
     "feature": {
       "children": [
         {
@@ -9,22 +53,22 @@
                 "keyword": "Examples",
                 "location": {
                   "column": 5,
-                  "line": 10
+                  "line": 16
                 },
                 "tableBody": [
                   {
                     "cells": [
                       {
                         "location": {
-                          "column": 10,
-                          "line": 12
+                          "column": 12,
+                          "line": 18
                         },
                         "value": "red"
                       }
                     ],
                     "location": {
                       "column": 7,
-                      "line": 12
+                      "line": 18
                     }
                   }
                 ],
@@ -33,14 +77,14 @@
                     {
                       "location": {
                         "column": 9,
-                        "line": 11
+                        "line": 17
                       },
                       "value": "color"
                     }
                   ],
                   "location": {
                     "column": 7,
-                    "line": 11
+                    "line": 17
                   }
                 }
               }

--- a/gherkin/testdata/good/padded_example.feature.ast.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.ast.ndjson
@@ -1,0 +1,151 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "scenario": {
+            "examples": [
+              {
+                "keyword": "Examples",
+                "location": {
+                  "column": 5,
+                  "line": 10
+                },
+                "tableBody": [
+                  {
+                    "cells": [
+                      {
+                        "location": {
+                          "column": 10,
+                          "line": 12
+                        },
+                        "value": "red"
+                      }
+                    ],
+                    "location": {
+                      "column": 7,
+                      "line": 12
+                    }
+                  }
+                ],
+                "tableHeader": {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 11
+                      },
+                      "value": "color"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 11
+                  }
+                }
+              }
+            ],
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 3
+            },
+            "name": "test",
+            "steps": [
+              {
+                "dataTable": {
+                  "location": {
+                    "column": 7,
+                    "line": 5
+                  },
+                  "rows": [
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 5
+                          },
+                          "value": "type"
+                        },
+                        {
+                          "location": {
+                            "column": 20,
+                            "line": 5
+                          },
+                          "value": "diameter"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 5
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 9,
+                            "line": 6
+                          },
+                          "value": "football"
+                        },
+                        {
+                          "location": {
+                            "column": 26,
+                            "line": 6
+                          },
+                          "value": "69"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 6
+                      }
+                    },
+                    {
+                      "cells": [
+                        {
+                          "location": {
+                            "column": 11,
+                            "line": 7
+                          },
+                          "value": "pool"
+                        },
+                        {
+                          "location": {
+                            "column": 25,
+                            "line": 7
+                          },
+                          "value": "5.6"
+                        }
+                      ],
+                      "location": {
+                        "column": 7,
+                        "line": 7
+                      }
+                    }
+                  ]
+                },
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 4
+                },
+                "text": "a <color> ball with:"
+              }
+            ]
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "test"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "id": "675e70f00cefc5525253465e09f88b6e379eae72",
     "language": "en",
     "locations": [
       {
@@ -9,7 +9,7 @@
       },
       {
         "column": 7,
-        "line": 12
+        "line": 18
       }
     ],
     "name": "test",
@@ -82,7 +82,7 @@
           },
           {
             "column": 7,
-            "line": 12
+            "line": 18
           }
         ],
         "text": "a red ball with:"

--- a/gherkin/testdata/good/padded_example.feature.pickles.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.pickles.ndjson
@@ -1,0 +1,93 @@
+{
+  "pickle": {
+    "id": "9c53f42334c1316db5ca979242e24cdd72a8542d",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 3
+      },
+      {
+        "column": 7,
+        "line": 12
+      }
+    ],
+    "name": "test",
+    "steps": [
+      {
+        "argument": {
+          "dataTable": {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 5
+                    },
+                    "value": "type"
+                  },
+                  {
+                    "location": {
+                      "column": 20,
+                      "line": 5
+                    },
+                    "value": "diameter"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 6
+                    },
+                    "value": "football"
+                  },
+                  {
+                    "location": {
+                      "column": 26,
+                      "line": 6
+                    },
+                    "value": "69"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 11,
+                      "line": 7
+                    },
+                    "value": "pool"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 7
+                    },
+                    "value": "5.6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "locations": [
+          {
+            "column": 11,
+            "line": 4
+          },
+          {
+            "column": 7,
+            "line": 12
+          }
+        ],
+        "text": "a red ball with:"
+      }
+    ],
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/padded_example.feature"
+  }
+}

--- a/gherkin/testdata/good/padded_example.feature.source.ndjson
+++ b/gherkin/testdata/good/padded_example.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    Examples:\n      | color |\n      |  red  |\n",
+    "data": "Feature: test\n\n  Scenario: test\n    Given a <color> ball with:\n      | type     | diameter |\n      | football |       69 |\n      |   pool   |      5.6 |\n\n\n    # The \"red\" cell below has the following whitespace characters on each side:\n    # - U+00A0 (non-breaking space)\n    # - U+0020 (space)\n    # - U+0009 (tab)\n    # This is generated with `ruby -e 'STDOUT.write \"\\u00A0\\u0020\\u0009\".encode(\"utf-8\")' | pbcopy`\n    # and pasted. \n    Examples:\n      | color   |\n      |  \tred  \t|\n",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/testdata/good/padded_example.feature.tokens
+++ b/gherkin/testdata/good/padded_example.feature.tokens
@@ -1,0 +1,13 @@
+(1:1)FeatureLine:Feature/test/
+(2:1)Empty://
+(3:3)ScenarioLine:Scenario/test/
+(4:5)StepLine:Given /a <color> ball with:/
+(5:7)TableRow://9:type,20:diameter
+(6:7)TableRow://9:football,26:69
+(7:7)TableRow://11:pool,25:5.6
+(8:1)Empty://
+(9:1)Empty://
+(10:5)ExamplesLine:Examples//
+(11:7)TableRow://9:color
+(12:7)TableRow://10:red
+EOF

--- a/gherkin/testdata/good/padded_example.feature.tokens
+++ b/gherkin/testdata/good/padded_example.feature.tokens
@@ -7,7 +7,13 @@
 (7:7)TableRow://11:pool,25:5.6
 (8:1)Empty://
 (9:1)Empty://
-(10:5)ExamplesLine:Examples//
-(11:7)TableRow://9:color
-(12:7)TableRow://10:red
+(10:1)Comment:/    # The "red" cell below has the following whitespace characters on each side:/
+(11:1)Comment:/    # - U+00A0 (non-breaking space)/
+(12:1)Comment:/    # - U+0020 (space)/
+(13:1)Comment:/    # - U+0009 (tab)/
+(14:1)Comment:/    # This is generated with `ruby -e 'STDOUT.write "\u00A0\u0020\u0009".encode("utf-8")' | pbcopy`/
+(15:1)Comment:/    # and pasted. /
+(16:5)ExamplesLine:Examples//
+(17:7)TableRow://9:color
+(18:7)TableRow://12:red
 EOF


### PR DESCRIPTION
## Summary

Bugfix: Trim trailing space in examples cells

## Details

Non-breaking space (and other whitespace characters) were not being trimmed properly. I couldn't figure out how to fix the C implementation, so I have temporarily disabled it from the build on this branch. Could you have a look at that @brasmusson ?

## How Has This Been Tested?

* A new `pickles_test.go` file with an `ExampleCompilePickles` unit test
* A new `padded_example.feature` file with `\u00A0\u0020\u0009` padding

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to C.
- [x] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
