### PR TITLE
Improved German keywords

### DIFF
--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -605,7 +605,10 @@
       "Und "
     ],
     "background": [
-      "Grundlage"
+      "Grundlage",
+      "Hintergrund",
+      "Voraussetzungen",
+      "Vorbedingungen"
     ],
     "but": [
       "* ",
@@ -615,7 +618,8 @@
       "Beispiele"
     ],
     "feature": [
-      "Funktionalität"
+      "Funktionalität",
+      "Funktion"
     ],
     "given": [
       "* ",
@@ -626,14 +630,16 @@
     "name": "German",
     "native": "Deutsch",
     "rule": [
-      "Rule"
+      "Rule",
+      "Regel"
     ],
     "scenario": [
       "Beispiel",
       "Szenario"
     ],
     "scenarioOutline": [
-      "Szenariogrundriss"
+      "Szenariogrundriss",
+      "Szenarien"
     ],
     "then": [
       "* ",


### PR DESCRIPTION
## Summary

Revived and enhanced PR #352 (solves #707).

## Motivation and Context

"Szenariogrundriss" literally means "scenario floor plan" while it's meant to be a translation for "scenario outline". This in fact prevented me from using the the German translation at all, because I cannot make myself type this...

Sidenote: it seems that - from a user perspective - "scenario" and "scenario outline" could very well be merged in a single keyword, the distinction is probably only there to simplify parsing, but for a human reader it doesn't really matter.

Sidenote 2: if it's supported to include punctation in keywords, "Angenommen, " would be better than "Angenommen ", because no one writes a space before a comma (and we need a comma here).

## Types of changes

For all keywords, I kept the originally provided translations to be sure not to break existing code.