### PR TITLE
Do not update dependencies with non-final versions

### DIFF
--- a/.templates/java/default.mk
+++ b/.templates/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/.templates/java/maven-versions-rules.xml
+++ b/.templates/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/c21e/java/default.mk
+++ b/c21e/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/c21e/java/maven-versions-rules.xml
+++ b/c21e/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/config/java/default.mk
+++ b/config/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/config/java/maven-versions-rules.xml
+++ b/config/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/cucumber-expressions/java/default.mk
+++ b/cucumber-expressions/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/cucumber-expressions/java/maven-versions-rules.xml
+++ b/cucumber-expressions/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/cucumber-messages/java/default.mk
+++ b/cucumber-messages/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/cucumber-messages/java/maven-versions-rules.xml
+++ b/cucumber-messages/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/datatable/java/datatable/pom.xml
+++ b/datatable/java/datatable/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.3</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/datatable/java/default.mk
+++ b/datatable/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/datatable/java/maven-versions-rules.xml
+++ b/datatable/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/datatable/java/pom.xml
+++ b/datatable/java/pom.xml
@@ -57,14 +57,14 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.5.1</version>
+                <version>5.5.2</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </dependency>
 
             <dependency>

--- a/gherkin/java/default.mk
+++ b/gherkin/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/gherkin/java/maven-versions-rules.xml
+++ b/gherkin/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/tag-expressions/java/default.mk
+++ b/tag-expressions/java/default.mk
@@ -13,7 +13,7 @@ default: .tested
 
 update-dependencies:
 	mvn versions:force-releases
-	mvn versions:use-latest-versions
+	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
 update-version:

--- a/tag-expressions/java/maven-versions-rules.xml
+++ b/tag-expressions/java/maven-versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*pr.*</ignoreVersion>
+    <ignoreVersion type="regex">.*-rc.*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
##  Summary

During release process, ```mvn versions:use-latest-versions``` may pick non-final version (rc1 etc). 
This fixes it.

## Details

There's a new template file called ```maven-versions-rules.xml``` which specifies which releases to exclude when running ```use-latest-versions```.

Maybe this should go to cucumber-parent instead, so less files to manage.

Currently the list is pretty empty (tested with the ones that get picked when running ```use-latest-versions``` for datatable), it could be easily made bigger.

## Motivation and Context

Avoid having to revert to final versions during the release process.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.