### PR TITLE
Use cucumber-messages 6 for Ruby libraries

### DIFF
--- a/dots-formatter/ruby/cucumber-formatter-dots.gemspec
+++ b/dots-formatter/ruby/cucumber-formatter-dots.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
                   }
 
   s.add_dependency 'c21e', '~> 2.0', '>= 2.0.0'
-  s.add_dependency 'cucumber-messages', '~> 5.0', '>= 5.0.1'
+  s.add_dependency 'cucumber-messages', '~> 6.0', '>= 6.0.0'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'

--- a/gherkin/ruby/gherkin.gemspec
+++ b/gherkin/ruby/gherkin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/gherkin/ruby',
                   }
 
-  s.add_dependency 'cucumber-messages', '~> 5.0', '>= 5.0.1'
+  s.add_dependency 'cucumber-messages', '~> 6.0', '>= 6.0.0'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'


### PR DESCRIPTION
## Summary

After Cucumber-messages 6 release, two libraries started to fail on master: gherkin and dots-formatter.
This should fix it.

The other languages do not seem to be impacted the same way. We may have to check the release process somehow.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [X] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.