### PR TITLE
gherkin: js external expose stderr

### DIFF
--- a/gherkin/javascript/src/external/GherkinExe.ts
+++ b/gherkin/javascript/src/external/GherkinExe.ts
@@ -32,7 +32,7 @@ export default class GherkinExe {
       options.push('--no-pickles')
     }
     const args = options.concat(this.paths)
-    const gherkin = spawn(this.gherkinExe, args)
+    const gherkin = spawn(this.gherkinExe, args, {stdio: ['pipe', 'pipe', 'inherit']})
     const protobufMessageStream = new ProtobufMessageStream(
       messages.Envelope.decodeDelimited.bind(messages.Envelope)
     )


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

In the process of trying to update cucumber-js to using gherkin 7.0.4, I ran into an issue where the go binary hit an error and it was hidden from me (the error was caused by passing it an invalid default language).
<!--- Provide a general summary description of your changes -->

## Details

Updating stderr of the gherkin process to be inherited (ie redirected to the parent processes stderr), if the gherkin process hit some error, that will be visible to the calling process.

Docs on the stdio option: https://nodejs.org/api/child_process.html#child_process_options_stdio

<!--- Describe your changes in detail -->

## Motivation and Context

Currently there is no indication the gherkin child process prints anything to stderr. By sending the gherkin child process stderr to the parent process stderr, the stderr is now visible and can be used to debug issues.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

No tests currently, mainly something that should help in debugging.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
