### PR TITLE
c21e: js fix for win-ia32

### DIFF
--- a/c21e/javascript/src/ExeFile.ts
+++ b/c21e/javascript/src/ExeFile.ts
@@ -29,6 +29,7 @@ export default class ExeFile {
     const defaults: { [key: string]: string } = {
       mipsel: 'mipsle',
       x32: '386',
+      ia32: '386',
       x64: 'amd64',
     }
     return defaults[this.props.arch] || this.props.arch

--- a/c21e/javascript/test/ExeFileTest.ts
+++ b/c21e/javascript/test/ExeFileTest.ts
@@ -11,10 +11,19 @@ describe('ExeFile', () => {
     assert.strictEqual(exeFile.fileName, 'gherkin-darwin-amd64')
   })
 
-  it('detects windows', () => {
+  it('detects windows x32', () => {
     const exeFile = new ExeFile('gherkin-{{.OS}}-{{.Arch}}{{.Ext}}', {
       os: 'win32',
       arch: 'x32',
+    })
+
+    assert.strictEqual(exeFile.fileName, 'gherkin-windows-386.exe')
+  })
+
+  it('detects windows ia32', () => {
+    const exeFile = new ExeFile('gherkin-{{.OS}}-{{.Arch}}{{.Ext}}', {
+      os: 'win32',
+      arch: 'ia32',
     })
 
     assert.strictEqual(exeFile.fileName, 'gherkin-windows-386.exe')


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

As part of updating cucumber-js to gherkin 7.0.4 (using the go binary), I'm hitting an issue when trying to run tests on appveyor (see screenshot)
<!--- Provide a general summary description of your changes -->

## Details

Appears ia32 is not properly mapped to 386, the way x32 is.
<!--- Describe your changes in detail -->

## Motivation and Context

Want to be able to use gherkin go binaries as part of gherkin js on win ia32.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Updated tests. Real test will be once this is released and no longer get this error on appveyor.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1072" alt="Screen Shot 2019-10-02 at 3 08 49 PM" src="https://user-images.githubusercontent.com/1676758/66082443-686d7580-e527-11e9-9eb4-74bec1296f3e.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
