### PR TITLE
Update dependencies after release cucumber-message 6.0.1

### DIFF
--- a/c21e/javascript/package.json
+++ b/c21e/javascript/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/cucumber/c21e-javascript",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.7.9",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",

--- a/cucumber-expressions/go/go.mod
+++ b/cucumber-expressions/go/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
 
 go 1.13

--- a/cucumber-expressions/go/go.sum
+++ b/cucumber-expressions/go/go.sum
@@ -17,3 +17,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/cucumber-expressions/java/pom.xml
+++ b/cucumber-expressions/java/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/cucumber/cucumber-expressions-javascript#readme",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.7.9",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",

--- a/cucumber-react/javascript/package.json
+++ b/cucumber-react/javascript/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "color": "^3.1.2",
-    "cucumber-messages": "^5.0.1",
+    "cucumber-messages": "^6.0.1",
     "ramda": "^0.26.1",
     "react-accessible-accordion": "^3.0.0",
     "styled-components": "^4.4.0"
@@ -35,9 +35,9 @@
     "@types/color": "^3.0.0",
     "@types/jsdom": "^12.2.4",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
-    "@types/ramda": "^0.26.25",
-    "@types/react": "^16.9.3",
+    "@types/node": "^12.7.9",
+    "@types/ramda": "^0.26.26",
+    "@types/react": "^16.9.4",
     "@types/react-dom": "^16.9.1",
     "@types/storybook__react": "^4.0.2",
     "@types/styled-components": "^4.1.19",

--- a/dots-formatter/go/go.mod
+++ b/dots-formatter/go/go.mod
@@ -4,10 +4,10 @@ require (
 	github.com/cucumber/cucumber-messages-go/v5 v5.0.1
 	github.com/fatih/color v1.7.0
 	github.com/gogo/protobuf v1.3.0
-	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
+	golang.org/x/sys v0.0.0-20191002091554-b397fe3ad8ed // indirect
 )
 
 replace github.com/cucumber/cucumber-messages-go/v5 => ../../cucumber-messages/go

--- a/dots-formatter/go/go.sum
+++ b/dots-formatter/go/go.sum
@@ -12,8 +12,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
@@ -26,11 +26,13 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190927073244-c990c680b611 h1:q9u40nxWT5zRClI/uU9dHCiYGottAg6Nzz4YUQyHxdA=
-golang.org/x/sys v0.0.0-20190927073244-c990c680b611/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191002091554-b397fe3ad8ed h1:5TJcLJn2a55mJjzYk0yOoqN8X1OdvBDUnaZaKKyQtkY=
+golang.org/x/sys v0.0.0-20191002091554-b397fe3ad8ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/dots-formatter/ruby/cucumber-formatter-dots.gemspec
+++ b/dots-formatter/ruby/cucumber-formatter-dots.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
                   }
 
   s.add_dependency 'c21e', '~> 2.0', '>= 2.0.0'
-  s.add_dependency 'cucumber-messages', '~> 5.0', '>= 5.0.1'
+  s.add_dependency 'cucumber-messages', '~> 6.0', '>= 6.0.1'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'

--- a/fake-cucumber/javascript/package.json
+++ b/fake-cucumber/javascript/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/cucumber/cucumber",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.7.9",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "commander": "^3.0.2",
-    "cucumber-messages": "^5.0.1",
+    "cucumber-messages": "^6.0.1",
     "gherkin": "^7.0.4"
   }
 }

--- a/gherkin/go/go.sum
+++ b/gherkin/go/go.sum
@@ -21,3 +21,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/gherkin/java/pom.xml
+++ b/gherkin/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>messages</artifactId>
-            <version>5.0.1</version>
+            <version>6.0.1</version>
         </dependency>
 
         <dependency>

--- a/gherkin/javascript/package.json
+++ b/gherkin/javascript/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/cucumber/gherkin-javascript",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.7.9",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",
@@ -42,6 +42,6 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "cucumber-messages": "5.0.1"
+    "cucumber-messages": "6.0.1"
   }
 }

--- a/gherkin/ruby/gherkin.gemspec
+++ b/gherkin/ruby/gherkin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/gherkin/ruby',
                   }
 
-  s.add_dependency 'cucumber-messages', '~> 5.0', '>= 5.0.1'
+  s.add_dependency 'cucumber-messages', '~> 6.0', '>= 6.0.1'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'

--- a/html-formatter/javascript/package.json
+++ b/html-formatter/javascript/package.json
@@ -17,7 +17,7 @@
     "pretty-quick": "pretty-quick --staged"
   },
   "dependencies": {
-    "cucumber-messages": "^5.0.1",
+    "cucumber-messages": "^6.0.1",
     "cucumber-react": "^1.1.0",
     "jsdom": "^15.1.1",
     "react": "^16.10.1",
@@ -27,8 +27,8 @@
     "@babel/core": "^7.6.2",
     "@types/jsdom": "^12.2.4",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
-    "@types/react": "^16.9.3",
+    "@types/node": "^12.7.9",
+    "@types/react": "^16.9.4",
     "@types/react-dom": "^16.9.1",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.6",

--- a/json-formatter/go/go.sum
+++ b/json-formatter/go/go.sum
@@ -21,3 +21,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tag-expressions/go/go.mod
+++ b/tag-expressions/go/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
 
 go 1.13

--- a/tag-expressions/go/go.sum
+++ b/tag-expressions/go/go.sum
@@ -17,3 +17,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tag-expressions/javascript/package.json
+++ b/tag-expressions/javascript/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/cucumber/tag-expressions-javascript",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.7.9",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",


### PR DESCRIPTION
## Summary

Temporary PR: ran `make update-dependencies` at root level after release of `cucumber-messages`6.0.1, will be merged as soon as the CI is ok.