### PR TITLE
Update dependencies after release gherkin 8.0

### DIFF
--- a/cucumber-react/javascript/package.json
+++ b/cucumber-react/javascript/package.json
@@ -44,7 +44,7 @@
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.6",
     "fake-cucumber": "^1.1.1",
-    "gherkin": "7.0.4",
+    "gherkin": "8.0.0",
     "jsdom": "^15.1.1",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",

--- a/fake-cucumber/javascript/package.json
+++ b/fake-cucumber/javascript/package.json
@@ -43,6 +43,6 @@
   "dependencies": {
     "commander": "^3.0.2",
     "cucumber-messages": "^6.0.1",
-    "gherkin": "^7.0.4"
+    "gherkin": "^8.0.0"
   }
 }

--- a/gherkin/go/go.mod
+++ b/gherkin/go/go.mod
@@ -1,7 +1,6 @@
 module github.com/cucumber/gherkin-go/v8
 
 require (
-	github.com/aslakhellesoy/gox v1.0.100 // indirect
 	github.com/cucumber/cucumber-messages-go/v6 v6.0.1
 	github.com/gogo/protobuf v1.3.0
 )

--- a/gherkin/go/go.sum
+++ b/gherkin/go/go.sum
@@ -1,14 +1,8 @@
-github.com/aslakhellesoy/gox v1.0.100 h1:IP+x+v9Wya7OHP1OmaetTFZkL4OYY2/9t+7Ndc61mMo=
-github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
-github.com/cucumber/cucumber-messages-go/v6 v6.0.1 h1:N7Ahe12bU7i6vtlqB9bzpfNnD0cRG+ab2TNyG7EgV+I=
-github.com/cucumber/cucumber-messages-go/v6 v6.0.1/go.mod h1:pewNJXhMy4ySjX54p8BYpBBtagPoAWfXLefKis/o6rY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -16,8 +10,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
-github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
##  Summary

Temporary PR: ran make update-dependencies at root level after release of Gherkin 8.0, will be merged as soon as the CI is ok.