### PR TITLE
cucumber-expressions: support node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,15 @@ executors:
     docker:
       - image: circleci/golang:1.12
     working_directory: ~/cucumber
-  docker-circleci-node:
+  docker-circleci-node8:
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/cucumber
+  docker-circleci-node10:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/cucumber
+  docker-circleci-node12:
     docker:
       - image: circleci/node:12
     working_directory: ~/cucumber
@@ -148,7 +156,7 @@ jobs:
 ### JavaScript
 
   c21e-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -163,8 +171,30 @@ jobs:
             - c21e/javascript/dist
             - c21e/javascript/node_modules
 
-  cucumber-expressions-javascript:
-    executor: docker-circleci-node
+  cucumber-expressions-javascript-node8:
+    executor: docker-circleci-node8
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: cucumber-expressions/javascript
+          command: |
+            cd cucumber-expressions/javascript
+            make
+
+  cucumber-expressions-javascript-node10:
+    executor: docker-circleci-node10
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: cucumber-expressions/javascript
+          command: |
+            cd cucumber-expressions/javascript
+            make
+
+  cucumber-expressions-javascript-node12:
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -180,7 +210,7 @@ jobs:
             - cucumber-expressions/javascript/node_modules
 
   cucumber-messages-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -196,7 +226,7 @@ jobs:
             - cucumber-messages/javascript/node_modules
 
   gherkin-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -212,7 +242,7 @@ jobs:
             - gherkin/javascript/node_modules
 
   tag-expressions-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -223,7 +253,7 @@ jobs:
             make
 
   fake-cucumber-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -239,7 +269,7 @@ jobs:
             - fake-cucumber/javascript/node_modules
 
   cucumber-react-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -255,7 +285,7 @@ jobs:
             - cucumber-react/javascript/node_modules
 
   html-formatter-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -266,7 +296,7 @@ jobs:
             make
 
   json-formatter-javascript:
-    executor: docker-circleci-node
+    executor: docker-circleci-node12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -574,7 +604,13 @@ workflows:
       - c21e-javascript:
           requires:
             - checkout
-      - cucumber-expressions-javascript:
+      - cucumber-expressions-javascript-node8:
+          requires:
+            - checkout
+      - cucumber-expressions-javascript-node10:
+          requires:
+            - checkout
+      - cucumber-expressions-javascript-node12:
           requires:
             - checkout
       - cucumber-messages-javascript:

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -44,6 +44,7 @@
     "*"
   ],
   "dependencies": {
-    "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0"
+    "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0",
+    "xregexp": "^4.2.4"
   }
 }

--- a/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
@@ -1,4 +1,10 @@
 import ParameterType from './ParameterType'
+// @ts-ignore
+import XRegExp from 'xregexp';
+
+// Needed for Node8 support, should be able to remove once Node 8 reaches end of life
+// (eta 2019-12-31) https://nodejs.org/en/about/releases/
+const whitespacePunctuationPattern = XRegExp('\\s|\\p{P}', 'u')
 
 export default class ParameterTypeMatcher {
   private readonly match: RegExpExecArray
@@ -52,12 +58,12 @@ export default class ParameterTypeMatcher {
   }
 
   get match_start_word() {
-    return this.start == 0 || this.text[this.start - 1].match(/\s|\p{P}/u)
+    return this.start == 0 || this.text[this.start - 1].match(whitespacePunctuationPattern)
   }
 
   get match_end_word() {
     const next_character_index = this.start + this.group.length
-    return  next_character_index === this.text.length || this.text[next_character_index].match(/\s|\p{P}/u)
+    return  next_character_index === this.text.length || this.text[next_character_index].match(whitespacePunctuationPattern)
   }
 
   get group() {


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Updated CI to run cucumber-expressions against node 8, 10, 12. Currently did not update all other javascript libraries to do this, but it should be easy enough to do.

Resolves #725
<!--- Provide a general summary description of your changes -->

## Details

The regular expression syntax being used is not supported on node 8. Found a library that provides the functionality. Used it and left a comment when we could remove its use (when node 8 reaches end of life).
<!--- Describe your changes in detail -->

## Motivation and Context

cucumber-js wants to upgrade to latest cucumber-expressions but tries to support node 8, 10, 12.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Now running tests on node 8 and made updates to make this pass.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
