### PR TITLE
Simplify go releases

### DIFF
--- a/.templates/c/default.mk
+++ b/.templates/c/default.mk
@@ -4,6 +4,9 @@ update-dependencies:
 	# no-op
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/[0-9]*\.[0-9]*\.[0-9]*/$(NEW_VERSION)/" VERSION

--- a/.templates/default.mk
+++ b/.templates/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/.templates/dotnet/default.mk
+++ b/.templates/dotnet/default.mk
@@ -11,6 +11,9 @@ update-dependencies:
 	@echo -e "\033[0;31mPlease update dependencies for dotnet manually!!\033[0m"
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	./scripts/update-version

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-major update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version
@@ -88,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/.templates/java/default.mk
+++ b/.templates/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/.templates/javascript/default.mk
+++ b/.templates/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/.templates/python/default.mk
+++ b/.templates/python/default.mk
@@ -2,6 +2,9 @@ update-dependencies:
 	@echo "\033[0;31mPlease update dependencies for python manually!!\033[0m"
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i \

--- a/.templates/ruby/default.mk
+++ b/.templates/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -44,15 +44,9 @@ available stable versions.
 
     cd thepackage
 
-Open `go/go.mod` and remove any `replace` directives. When we make a release, we
-must *only* depend on a released versions.
-If you change the major version of the library, also update the first line of the `go.mod` to reflect
-correctly the major version.
+Upgrade the dependencies and also update the references in the code:
 
-Then, upgrade other dependencies:
-
-    make update-dependencies
-    make clean && make
+    NEW_VERSION=X.Y.Z make pre-release
 
 This will typically modify the files where dependencies are declared, *without*
 committing the changes to git. Examine what changed:
@@ -100,13 +94,13 @@ Check that releases show up under:
 
 ## Post release
 
-Open `go/go.mod` and *restore* any `replace` directives you removed in the [update dependencies](#update-dependencies) step above.
 
 Run the following command (using the same NEW_VERSION as you used for the release):
 
     NEW_VERSION=X.Y.Z make post-release
 
-This should update the version in `java/pom.xml` file to use a `-SNAPSHOT` suffix.
+This should update the version in `java/pom.xml` file to use a `-SNAPSHOT` suffix and add
+the `replace`directives in the `go.mod`file.
 This is automatically committed, and pushed along with the tag of the release.
 
 It's also a good practice to update all the dependencies in the monorepo, especially
@@ -114,3 +108,9 @@ when the module you just released is a dependency of other modules:
 
     # Run this in the root directory:
     make update-dependencies
+
+If you did a new major release of a Go package, you can also update all the references in the
+libraries using it:
+
+    # Run this in the root directory
+    source scripts/functions.sh && update_go_library_version libraryName X.Y.Z

--- a/c21e/default.mk
+++ b/c21e/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/c21e/java/default.mk
+++ b/c21e/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/c21e/javascript/default.mk
+++ b/c21e/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/c21e/ruby/default.mk
+++ b/c21e/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/config/default.mk
+++ b/config/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/config/java/default.mk
+++ b/config/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/cucumber-expressions/default.mk
+++ b/cucumber-expressions/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/cucumber-expressions/java/default.mk
+++ b/cucumber-expressions/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/cucumber-expressions/javascript/default.mk
+++ b/cucumber-expressions/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/cucumber-expressions/ruby/default.mk
+++ b/cucumber-expressions/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/cucumber-messages/default.mk
+++ b/cucumber-messages/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/cucumber-messages/dotnet/default.mk
+++ b/cucumber-messages/dotnet/default.mk
@@ -11,6 +11,9 @@ update-dependencies:
 	@echo -e "\033[0;31mPlease update dependencies for dotnet manually!!\033[0m"
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	./scripts/update-version

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/cucumber-messages/java/default.mk
+++ b/cucumber-messages/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/cucumber-messages/javascript/default.mk
+++ b/cucumber-messages/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/cucumber-messages/ruby/default.mk
+++ b/cucumber-messages/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/cucumber-react/default.mk
+++ b/cucumber-react/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/cucumber-react/javascript/default.mk
+++ b/cucumber-react/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/datatable/default.mk
+++ b/datatable/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/datatable/java/default.mk
+++ b/datatable/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/dots-formatter/default.mk
+++ b/dots-formatter/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/dots-formatter/ruby/default.mk
+++ b/dots-formatter/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/fake-cucumber/default.mk
+++ b/fake-cucumber/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/fake-cucumber/javascript/default.mk
+++ b/fake-cucumber/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/gherkin/c/default.mk
+++ b/gherkin/c/default.mk
@@ -4,6 +4,9 @@ update-dependencies:
 	# no-op
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/[0-9]*\.[0-9]*\.[0-9]*/$(NEW_VERSION)/" VERSION

--- a/gherkin/default.mk
+++ b/gherkin/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/gherkin/java/default.mk
+++ b/gherkin/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/gherkin/javascript/default.mk
+++ b/gherkin/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/gherkin/ruby/default.mk
+++ b/gherkin/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/gherkin/ruby/gherkin.gemspec
+++ b/gherkin/ruby/gherkin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cucumber-messages', '~> 6.0', '>= 6.0.1'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
-  s.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'
+  s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
 
   # For coverage reports
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'

--- a/html-formatter/default.mk
+++ b/html-formatter/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/html-formatter/javascript/default.mk
+++ b/html-formatter/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/json-formatter/default.mk
+++ b/json-formatter/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/json-formatter/javascript/default.mk
+++ b/json-formatter/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/json-formatter/ruby/default.mk
+++ b/json-formatter/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -114,7 +114,7 @@ function push_subrepo_branch_maybe()
   subrepo=$1
   remote=$(subrepo_remote "${subrepo}")
   branch=$(git_branch)
-  
+
   if [ -z "${branch}" ]; then
     echo "No branch to push"
   elif [ "${branch}" != "master" ]; then
@@ -146,5 +146,23 @@ function push_subrepo_tag_maybe()
         }
       fi
     done
+  fi
+}
+
+function update_go_library_version()
+{
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: update_go_library_version libraryName version"
+  else
+    libname=$1
+    version=$2
+    major=`echo $version | awk -F'.' '{print $1}'`
+
+    echo "Updating ${libname} to ${version}"
+    pushd ${root_dir}
+    sed -i "s/${libname}-go\/v[[:digit:]]\+ v.*/${libname}-go\/v$major v${version}/" */go/go.mod
+    sed -i "s/${libname}-go\/v[[:digit:]]\+/${libname}-go\/v${major}/" */go/*.go
+    sed -i "s/${libname}-go\/v[[:digit:]]\+/${libname}-go\/v${major}/" */go/**/*.go
+    popd
   fi
 }

--- a/tag-expressions/default.mk
+++ b/tag-expressions/default.mk
@@ -37,6 +37,13 @@ update-version-%: %
 	cd $< && make update-version
 .PHONY: update-version-%
 
+pre-release: $(patsubst %/Makefile,pre-release-%,$(MAKEFILES))
+.PHONY: pre-release
+
+pre-release-%: %
+	cd $< && make pre-release
+.PHONY: pre-release-%
+
 release: update-version clean default create-and-push-release-tag publish
 .PHONY: release
 

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -97,11 +97,11 @@ clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
 
-remove_replaces:
+remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
 
-add_replaces:
+add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
 .PHONY: add_replaces

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -12,6 +12,7 @@ OS := $(shell [[ "$$(uname)" == "Darwin" ]] && echo "darwin" || echo "linux")
 # Determine if we're on 386 or amd64 (ignoring other processors as we're not building on them)
 ARCH := $(shell [[ "$$(uname -m)" == "x86_64" ]] && echo "amd64" || echo "386")
 EXE = dist/$(LIBNAME)-$(OS)-$(ARCH)
+REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')
 
 default: .linted .tested
 .PHONY: default
@@ -98,4 +99,9 @@ clean-go:
 
 remove_replaces:
 	sed -i '/^replace/d' go.mod
+	sed -i 'N;/^\n$$/D;P;D;' go.mod
 .PHONY: remove_replaces
+
+add_replaces:
+	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+.PHONY: add_replaces

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-dependencies clean default
+pre-release: update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:
@@ -91,8 +91,7 @@ dist_compressed/$(LIBNAME)-%: dist/$(LIBNAME)-%
 	go test ./...
 	touch $@
 
-post-release:
-	@echo "No post-release needed for go"
+post-release: add-replaces
 .PHONY: post-release
 
 clean: clean-go

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -95,3 +95,7 @@ clean: clean-go
 clean-go:
 	rm -rf .deps .tested .go-tested .linted dist/ .dist-compressed dist_compressed/ acceptance/
 .PHONY: clean-go
+
+remove_replaces:
+	sed -i '/^replace/d' go.mod
+.PHONY: remove_replaces

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -51,6 +51,9 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 	# no-op
 .PHONY: update-version

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -51,7 +51,7 @@ update-dependencies:
 	cd $(MOD_DIR) && go get -u && go mod tidy
 .PHONY: update-dependencies
 
-pre-release: update-major update-dependencies clean default
+pre-release: remove-replaces update-major update-dependencies clean default
 .PHONY: pre-release
 
 update-version:

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -100,8 +100,8 @@ clean-go:
 remove-replaces:
 	sed -i '/^replace/d' go.mod
 	sed -i 'N;/^\n$$/D;P;D;' go.mod
-.PHONY: remove_replaces
+.PHONY: remove-replaces
 
 add-replaces:
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
-.PHONY: add_replaces
+.PHONY: add-replaces

--- a/tag-expressions/java/default.mk
+++ b/tag-expressions/java/default.mk
@@ -16,6 +16,9 @@ update-dependencies:
 	mvn versions:use-latest-versions -Dmaven.version.rules=file://$(shell pwd)/maven-versions-rules.xml
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	mvn versions:set -DnewVersion=$(NEW_VERSION) -DgenerateBackupPoms=false

--- a/tag-expressions/javascript/default.mk
+++ b/tag-expressions/javascript/default.mk
@@ -34,6 +34,9 @@ update-dependencies:
 	npx npm-check-updates --upgrade
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	npm --no-git-tag-version --allow-same-version version "$(NEW_VERSION)"

--- a/tag-expressions/python/default.mk
+++ b/tag-expressions/python/default.mk
@@ -2,6 +2,9 @@ update-dependencies:
 	@echo "\033[0;31mPlease update dependencies for python manually!!\033[0m"
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i \

--- a/tag-expressions/ruby/default.mk
+++ b/tag-expressions/ruby/default.mk
@@ -20,6 +20,9 @@ update-dependencies:
 	./scripts/update-gemspec
 .PHONY: update-dependencies
 
+pre-release: update-dependencies clean default
+.PHONY: pre-release
+
 update-version:
 ifdef NEW_VERSION
 	sed -i "s/\(s\.version *= *'\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$(NEW_VERSION)\2/" $(GEMSPEC)


### PR DESCRIPTION
## Summary

There are still some manual changes that need to be done when releasing Go modules. This PR tries to automate them.
For example, `cucumber-messages 6.0.0` can not be used due to a missing manual step.

## Details

- [x] remove the `replace` lines in `go.mod` before the release
- [x] add back the `replace` lines in `go.mod` after the release
- [x] change major version in `go.mod` before release
- [x] change major version in imports in `*.go`files

## Motivation and Context

The less manual steps, the less errors (logically)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.