### PR TITLE
cucumber-expressions: fix captured empty strings being undefined

### DIFF
--- a/cucumber-expressions/go/cucumber_expression_test.go
+++ b/cucumber-expressions/go/cucumber_expression_test.go
@@ -100,6 +100,38 @@ func TestCucumberExpression(t *testing.T) {
 		)
 	})
 
+	t.Run("matches single quoted empty string as empty string", func(t *testing.T) {
+		require.Equal(
+			t,
+			MatchCucumberExpression(t, "three {string} mice", `three '' mice`),
+			[]interface{}{""},
+		)
+	})
+
+	t.Run("matches double quoted empty string as empty string", func(t *testing.T) {
+		require.Equal(
+			t,
+			MatchCucumberExpression(t, "three {string} mice", `three "" mice`),
+			[]interface{}{""},
+		)
+	})
+
+	t.Run("matches single quoted empty string as empty string along with other strings", func(t *testing.T) {
+		require.Equal(
+			t,
+			MatchCucumberExpression(t, "three {string} and {string} mice", `three '' and 'handsome' mice`),
+			[]interface{}{"", "handsome"},
+		)
+	})
+
+	t.Run("matches double quoted empty string as empty string along with other strings", func(t *testing.T) {
+		require.Equal(
+			t,
+			MatchCucumberExpression(t, "three {string} and {string} mice", `three "" and "handsome" mice`),
+			[]interface{}{"", "handsome"},
+		)
+	})
+
 	t.Run("matches escaped parenthesis", func(t *testing.T) {
 		require.Equal(
 			t,

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionTest.java
@@ -83,6 +83,26 @@ public class CucumberExpressionTest {
     }
 
     @Test
+    public void matches_single_quoted_empty_string_as_empty_string() {
+        assertEquals(singletonList(""), match("three {string} mice", "three '' mice"));
+    }
+
+    @Test
+    public void matches_double_quoted_empty_string_as_empty_string() {
+        assertEquals(singletonList(""), match("three {string} mice", "three \"\" mice"));
+    }
+
+    @Test
+    public void matches_single_quoted_empty_string_as_empty_string_along_with_other_strings() {
+        assertEquals(asList("", "handsome"), match("three {string} and {string} mice", "three '' and 'handsome' mice"));
+    }
+
+    @Test
+    public void matches_double_quoted_empty_string_as_empty_string_along_with_other_strings() {
+        assertEquals(asList("", "handsome"), match("three {string} and {string} mice", "three \"\" and \"handsome\" mice"));
+    }
+
+    @Test
     public void matches_escaped_parenthesis() {
         assertEquals(singletonList("blind"), match("three \\(exceptionally) {string} mice", "three (exceptionally) \"blind\" mice"));
     }

--- a/cucumber-expressions/javascript/src/Group.ts
+++ b/cucumber-expressions/javascript/src/Group.ts
@@ -8,7 +8,7 @@ export default class Group {
 
   get values(): string[] {
     return (this.children.length === 0 ? [this] : this.children)
+      .filter(g => typeof g.start !== 'undefined')
       .map(g => g.value)
-      .filter(v => v !== null)
   }
 }

--- a/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
@@ -49,7 +49,7 @@ export default class ParameterTypeRegistry {
         'string',
         ParameterTypeRegistry.STRING_REGEXP,
         String,
-        s => s.replace(/\\"/g, '"').replace(/\\'/g, "'"),
+        s => (s || '').replace(/\\"/g, '"').replace(/\\'/g, "'"),
         true,
         false
       )

--- a/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
@@ -95,6 +95,30 @@ describe('CucumberExpression', () => {
     )
   })
 
+  it('matches single quoted empty string as empty string', () => {
+    assert.deepStrictEqual(match('three {string} mice', "three '' mice"),
+      ['']
+    )
+  })
+
+  it('matches double quoted empty string as empty string ', () => {
+    assert.deepStrictEqual(match('three {string} mice', 'three "" mice'),
+      ['']
+    )
+  })
+
+  it('matches single quoted empty string as empty string, along with other strings', () => {
+    assert.deepStrictEqual(match('three {string} and {string} mice', "three '' and 'handsome' mice"),
+      ['', 'handsome']
+    )
+  })
+
+  it('matches double quoted empty string as empty string, along with other strings', () => {
+    assert.deepStrictEqual(match('three {string} and {string} mice', 'three "" and "handsome" mice'),
+      ['', 'handsome']
+    )
+  })
+
   it('matches escaped parenthesis', () => {
     assert.deepStrictEqual(
       match(

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -55,6 +55,22 @@ module Cucumber
         expect(match('three {string} mice', "three 'bl\\'nd' mice")).to eq(["bl'nd"])
       end
 
+      it('matches single quoted empty string as empty string') do
+        expect(match('three {string} mice', "three '' mice")).to eq([''])
+      end
+
+      it('matches double quoted empty string as empty string') do
+        expect(match('three {string} mice', 'three "" mice')).to eq([''])
+      end
+
+      it('matches single quoted empty string as empty string, along with other strings') do
+        expect(match('three {string} and {string} mice', "three '' and 'handsome' mice")).to eq(['', 'handsome'])
+      end
+
+      it('matches double quoted empty string as empty string, along with other strings') do
+        expect(match('three {string} and {string} mice', 'three "" and "handsome" mice')).to eq(['', 'handsome'])
+      end
+
       it 'matches escaped parentheses' do
         expect(match('three \\(exceptionally) {string} mice', 'three (exceptionally) "blind" mice')).to eq(['blind'])
       end


### PR DESCRIPTION
## Summary

Changes to stop captures of empty string parameters being filtered off when interrogating the group, and to the specific transform function so that falsy values are handled

## Details

Added a small guard to the transform function for the "string" parameter type, so falsy values are switched for an empty string.

This was enough for the tests to pass, but at the root there was still the issue of this value being undefined, due to the logic in the getter for `children` in the `Group` class.

What `children` looks like when the string parameter is empty:

![image](https://user-images.githubusercontent.com/3192745/66713796-27872380-eda7-11e9-9fc3-d4128f701e62.png)

What children looks like when the string parameter is non-empty:

![image](https://user-images.githubusercontent.com/3192745/66713847-48e80f80-eda7-11e9-8740-06bdba571396.png)

Best I can tell, the previous code used `value !== null` as the heuristic to filter off the first item; I've changed it to `start !== undefined`. Although to be fair it didn't seem to be affecting anything else, so technically the guard in the transform is enough.

## Motivation and Context

Fixes #746 

Essentially, empty strings are a valid value for a `{string}` parameter, however these were coming through to the transformer as undefined and then causing an error when the function was expecting a string with a `replace` method. This was called out as a regression, as it used to work.

## How Has This Been Tested?

Added unit tests to `CucumberExpressionTest`, those all other tests passing.

Confirmed it resolves the issue on the reporter's test case project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
~- [ ] The change has been ported to .NET.~
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

~I haven't checked the behaviour of the other language implementations yet - will do that next but wanted to get early review on this change.~