### PR TITLE
Added expected regex for when an optional word may be needed in front…

### DIFF
--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
@@ -39,7 +39,7 @@ public class CucumberExpressionPatternTest {
     @Test
     public void translates_alternation_with_optional_words() {
         assertPattern(
-            "the (test )chat/call/email interactions are visible,
+            "the (test )chat/call/email interactions are visible",
             "^the (?:test )?(?:chat|call|email) interactions are visible$"
         );
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionPatternTest.java
@@ -35,6 +35,14 @@ public class CucumberExpressionPatternTest {
                 "^I said (?:Alpha1|Beta1)$"
         );
     }
+    
+    @Test
+    public void translates_alternation_with_optional_words() {
+        assertPattern(
+            "the (test )chat/call/email interactions are visible,
+            "^the (?:test )?(?:chat|call|email) interactions are visible$"
+        );
+    }
 
     @Test
     public void translates_parameters() {


### PR DESCRIPTION
… of alternative group

cucumber-expression-pattern-test

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Added a test for the expected regex pattern for when an optional word may be needed in front of alternative non-capture group.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

**No changes or new code has been made towards the app**

## Checklist:

- [x] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
