### PR TITLE
tag-expressions-go: Slice rune to string conversion is expensive

### DIFF
--- a/tag-expressions/go/parser.go
+++ b/tag-expressions/go/parser.go
@@ -1,6 +1,7 @@
 package tagexpressions
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -98,12 +99,12 @@ var PREC = map[string]int{
 
 func tokenize(expr string) []string {
 	var tokens []string
-	var token []rune
+	var token bytes.Buffer
 
 	collectToken := func() {
-		if len(token) > 0 {
-			tokens = append(tokens, string(token))
-			token = []rune{}
+		if token.Len() > 0 {
+			tokens = append(tokens, token.String())
+			token.Reset()
 		}
 	}
 
@@ -114,19 +115,21 @@ func tokenize(expr string) []string {
 			continue
 		}
 
-		switch c {
-		case '\\':
+		ch := string(c)
+
+		switch ch {
+		case "\\":
 			escaped = true
-		case '(', ')':
+		case "(", ")":
 			if escaped {
-				token = append(token, c)
+				token.WriteString(ch)
 				escaped = false
 			} else {
 				collectToken()
-				tokens = append(tokens, string(c))
+				tokens = append(tokens, ch)
 			}
 		default:
-			token = append(token, c)
+			token.WriteString(ch)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Currently, we are saving token in a slice of rune and converting it to a string which is expensive. This PR replaces this with `bytes.Buffer` which is much faster.

**Before**
```
goos: darwin
goarch: amd64
expression: not a\\(\\) or b and not c or not d or e and f

BenchmarkTokenize-4   	  740218	      1571 ns/op
```

**After**
```
goos: darwin
goarch: amd64
expression: not a\\(\\) or b and not c or not d or e and f

BenchmarkTokenize-4   	 1227254	       978 ns/op
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Performance enhancement (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
