### PR TITLE
gherkin: Add acceptance test that fails on Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -740,9 +740,6 @@ workflows:
       - gherkin-ruby-26:
           requires:
             - cucumber-messages-ruby
-      - gherkin-ruby-27:
-          requires:
-            - cucumber-messages-ruby
       - gherkin-jruby-92:
           requires:
             - cucumber-messages-ruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,6 @@ executors:
     docker:
       - image: circleci/ruby:2.6
     working_directory: ~/cucumber
-  # JRuby
-  docker-circleci-jruby-92:
-    docker:
-      - image: circleci/jruby:9.2
-    working_directory: ~/cucumber
   # Java
   docker-circleci-openjdk:
     docker:
@@ -415,17 +410,6 @@ jobs:
             cd gherkin/ruby
             make
 
-  gherkin-jruby-92:
-    executor: docker-circleci-jruby-92
-    steps:
-      - attach_workspace:
-          at: "~/cucumber"
-      - run:
-          name: gherkin/ruby
-          command: |
-            cd gherkin/ruby
-            make
-
   tag-expressions-ruby:
     executor: docker-circleci-ruby-26
     steps:
@@ -738,9 +722,6 @@ workflows:
           requires:
             - cucumber-messages-ruby
       - gherkin-ruby-26:
-          requires:
-            - cucumber-messages-ruby
-      - gherkin-jruby-92:
           requires:
             - cucumber-messages-ruby
       - tag-expressions-ruby:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,6 @@ executors:
     docker:
       - image: circleci/ruby:2.6
     working_directory: ~/cucumber
-  docker-circleci-ruby-27:
-    docker:
-      - image: circleci/ruby:2.7.0-preview1
-    working_directory: ~/cucumber
   # JRuby
   docker-circleci-jruby-92:
     docker:
@@ -410,17 +406,6 @@ jobs:
 
   gherkin-ruby-26:
     executor: docker-circleci-ruby-26
-    steps:
-      - attach_workspace:
-          at: "~/cucumber"
-      - run:
-          name: gherkin/ruby
-          command: |
-            cd gherkin/ruby
-            make
-
-  gherkin-ruby-27:
-    executor: docker-circleci-ruby-27
     steps:
       - attach_workspace:
           at: "~/cucumber"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,30 +16,56 @@ executors:
       # Run `source scripts/functions.sh && docker_image Dockerfile` to print it.
       - image: cucumber/cucumber-build:9ce5f6a542de12ceecdd84caaad47365
     working_directory: ~/cucumber
+  # Go
   docker-circleci-golang:
     docker:
       - image: circleci/golang:1.12
     working_directory: ~/cucumber
-  docker-circleci-node8:
+  # Node.js
+  docker-circleci-node-8:
     docker:
       - image: circleci/node:8
     working_directory: ~/cucumber
-  docker-circleci-node10:
+  docker-circleci-node-10:
     docker:
       - image: circleci/node:10
     working_directory: ~/cucumber
-  docker-circleci-node12:
+  docker-circleci-node-12:
     docker:
       - image: circleci/node:12
     working_directory: ~/cucumber
-  docker-circleci-ruby:
+  # Ruby
+  docker-circleci-ruby-23:
+    docker:
+      - image: circleci/ruby:2.3
+    working_directory: ~/cucumber
+  docker-circleci-ruby-24:
+    docker:
+      - image: circleci/ruby:2.4
+    working_directory: ~/cucumber
+  docker-circleci-ruby-25:
+    docker:
+      - image: circleci/ruby:2.5
+    working_directory: ~/cucumber
+  docker-circleci-ruby-26:
     docker:
       - image: circleci/ruby:2.6
     working_directory: ~/cucumber
+  docker-circleci-ruby-27:
+    docker:
+      - image: circleci/ruby:2.7.0-preview1
+    working_directory: ~/cucumber
+  # JRuby
+  docker-circleci-jruby-92:
+    docker:
+      - image: circleci/jruby:9.2
+    working_directory: ~/cucumber
+  # Java
   docker-circleci-openjdk:
     docker:
       - image: circleci/openjdk:11
     working_directory: ~/cucumber
+  # Python
   docker-circleci-python:
     docker:
       - image: circleci/python:3.7.3
@@ -65,7 +91,7 @@ jobs:
             make ci
 
   checkout:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - checkout
       - persist_to_workspace:
@@ -156,7 +182,7 @@ jobs:
 ### JavaScript
 
   c21e-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -171,8 +197,8 @@ jobs:
             - c21e/javascript/dist
             - c21e/javascript/node_modules
 
-  cucumber-expressions-javascript-node8:
-    executor: docker-circleci-node8
+  cucumber-expressions-javascript-node-8:
+    executor: docker-circleci-node-8
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -182,8 +208,8 @@ jobs:
             cd cucumber-expressions/javascript
             make
 
-  cucumber-expressions-javascript-node10:
-    executor: docker-circleci-node10
+  cucumber-expressions-javascript-node-10:
+    executor: docker-circleci-node-10
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -193,8 +219,8 @@ jobs:
             cd cucumber-expressions/javascript
             make
 
-  cucumber-expressions-javascript-node12:
-    executor: docker-circleci-node12
+  cucumber-expressions-javascript-node-12:
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -210,7 +236,7 @@ jobs:
             - cucumber-expressions/javascript/node_modules
 
   cucumber-messages-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -226,7 +252,7 @@ jobs:
             - cucumber-messages/javascript/node_modules
 
   gherkin-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -242,7 +268,7 @@ jobs:
             - gherkin/javascript/node_modules
 
   tag-expressions-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -253,7 +279,7 @@ jobs:
             make
 
   fake-cucumber-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -269,7 +295,7 @@ jobs:
             - fake-cucumber/javascript/node_modules
 
   cucumber-react-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -285,7 +311,7 @@ jobs:
             - cucumber-react/javascript/node_modules
 
   html-formatter-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -296,7 +322,7 @@ jobs:
             make
 
   json-formatter-javascript:
-    executor: docker-circleci-node12
+    executor: docker-circleci-node-12
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -313,7 +339,7 @@ jobs:
 ### Ruby
 
   c21e-ruby:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -324,7 +350,7 @@ jobs:
             make
 
   cucumber-expressions-ruby:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -349,8 +375,63 @@ jobs:
           paths:
             - cucumber-messages/ruby/lib/cucumber/messages_pb.rb
 
-  gherkin-ruby:
-    executor: docker-circleci-ruby
+  gherkin-ruby-23:
+    executor: docker-circleci-ruby-23
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/ruby
+          command: |
+            cd gherkin/ruby
+            make
+
+  gherkin-ruby-24:
+    executor: docker-circleci-ruby-24
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/ruby
+          command: |
+            cd gherkin/ruby
+            make
+
+  gherkin-ruby-25:
+    executor: docker-circleci-ruby-25
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/ruby
+          command: |
+            cd gherkin/ruby
+            make
+
+  gherkin-ruby-26:
+    executor: docker-circleci-ruby-26
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/ruby
+          command: |
+            cd gherkin/ruby
+            make
+
+  gherkin-ruby-27:
+    executor: docker-circleci-ruby-27
+    steps:
+      - attach_workspace:
+          at: "~/cucumber"
+      - run:
+          name: gherkin/ruby
+          command: |
+            cd gherkin/ruby
+            make
+
+  gherkin-jruby-92:
+    executor: docker-circleci-jruby-92
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -361,7 +442,7 @@ jobs:
             make
 
   tag-expressions-ruby:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -372,7 +453,7 @@ jobs:
             make
 
   dots-formatter-ruby:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -383,7 +464,7 @@ jobs:
             make
 
   json-formatter-ruby:
-    executor: docker-circleci-ruby
+    executor: docker-circleci-ruby-26
     steps:
       - attach_workspace:
           at: "~/cucumber"
@@ -615,13 +696,13 @@ workflows:
       - c21e-javascript:
           requires:
             - checkout
-      - cucumber-expressions-javascript-node8:
+      - cucumber-expressions-javascript-node-8:
           requires:
             - checkout
-      - cucumber-expressions-javascript-node10:
+      - cucumber-expressions-javascript-node-10:
           requires:
             - checkout
-      - cucumber-expressions-javascript-node12:
+      - cucumber-expressions-javascript-node-12:
           requires:
             - checkout
       - cucumber-messages-javascript:
@@ -662,7 +743,22 @@ workflows:
       - cucumber-messages-ruby:
           requires:
             - checkout
-      - gherkin-ruby:
+      - gherkin-ruby-23:
+          requires:
+            - cucumber-messages-ruby
+      - gherkin-ruby-24:
+          requires:
+            - cucumber-messages-ruby
+      - gherkin-ruby-25:
+          requires:
+            - cucumber-messages-ruby
+      - gherkin-ruby-26:
+          requires:
+            - cucumber-messages-ruby
+      - gherkin-ruby-27:
+          requires:
+            - cucumber-messages-ruby
+      - gherkin-jruby-92:
           requires:
             - cucumber-messages-ruby
       - tag-expressions-ruby:

--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,6 +19,11 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* [Ruby] Make CI build work on Ruby 2.3, 2.4, 2.5 and 2.6
+  ([#777](https://github.com/cucumber/cucumber/pull/777)
+   [vincent-psarga]
+   [aslakhellesoy])
+
 ## [8.1.1] - 2019-10-17
 
 ### Fixed
@@ -664,5 +669,6 @@ to Gherkin 2.
 [SabotageAndi]:     https://github.com/SabotageAndi
 [tsundberg]:        https://github.com/tsundberg
 [upgundecha]:       https://github.com/upgundecha
+[vincent-psarga]:   https://github.com/vincent-psarga
 [zbmott]:           https://github.com/zbmott
 [Zearin]:           https://github.com/Zearin

--- a/gherkin/c/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/c/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/c/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/c/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/c/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/c/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/c/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/c/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/c/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/dotnet/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/go/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/go/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/go/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/go/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/go/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/go/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/go/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/go/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/go/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/java/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/java/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/java/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/java/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/java/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/java/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/java/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/java/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/java/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/javascript/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/javascript/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/javascript/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/objective-c/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/perl/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/perl/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/perl/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/perl/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/perl/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/perl/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/python/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/python/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/python/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/python/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/python/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/python/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/python/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/python/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/python/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/ruby/Gemfile
+++ b/gherkin/ruby/Gemfile
@@ -3,9 +3,7 @@ source "https://rubygems.org"
 
 gem 'cucumber-messages', :path => File.dirname(__FILE__) + '/../../cucumber-messages/ruby'
 
-# Use an older protobuf on JRuby and MRI < 2.5
-if ((RbConfig::CONFIG['MAJOR'].to_i == 2 && RbConfig::CONFIG['MINOR'].to_i < 5) || RUBY_PLATFORM == "java")
-  gem 'google-protobuf', '~> 3.2.0.2'
-end
+# Use an older protobuf on JRuby
+gem 'google-protobuf', '~> 3.2.0.2' if RUBY_PLATFORM == 'java'
 
 gemspec

--- a/gherkin/ruby/lib/gherkin/ast_builder.rb
+++ b/gherkin/ruby/lib/gherkin/ast_builder.rb
@@ -111,28 +111,25 @@ module Gherkin
         data_table = node.get_single(:DataTable)
         doc_string = node.get_single(:DocString)
 
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature::Step.new(
           location: get_location(step_line, 0),
           keyword: step_line.matched_keyword,
-          text: step_line.matched_text
-        }
-        props[:data_table] = data_table if data_table
-        props[:doc_string] = doc_string if doc_string
-
-        Cucumber::Messages::GherkinDocument::Feature::Step.new(props)
+          text: step_line.matched_text,
+          data_table: data_table,
+          doc_string: doc_string,
+        )
       when :DocString
         separator_token = node.get_tokens(:DocStringSeparator)[0]
         content_type = separator_token.matched_text == '' ? nil : separator_token.matched_text
         line_tokens = node.get_tokens(:Other)
         content = line_tokens.map { |t| t.matched_text }.join("\n")
 
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature::Step::DocString.new(
           location: get_location(separator_token, 0),
           content: content,
-          delimiter: separator_token.matched_keyword
-        }
-        props[:content_type] = content_type if content_type
-        Cucumber::Messages::GherkinDocument::Feature::Step::DocString.new(props)
+          delimiter: separator_token.matched_keyword,
+          content_type: content_type,
+        )
       when :DataTable
         rows = get_table_rows(node)
         Cucumber::Messages::GherkinDocument::Feature::Step::DataTable.new(
@@ -144,14 +141,13 @@ module Gherkin
         description = get_description(node)
         steps = get_steps(node)
 
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature::Background.new(
           location: get_location(background_line, 0),
           keyword: background_line.matched_keyword,
           name: background_line.matched_text,
+          description: description,
           steps: steps
-        }
-        props[:description] = description if description
-        Cucumber::Messages::GherkinDocument::Feature::Background.new(props)
+        )
       when :ScenarioDefinition
         tags = get_tags(node)
         scenario_node = node.get_single(:Scenario)
@@ -159,16 +155,15 @@ module Gherkin
         description = get_description(scenario_node)
         steps = get_steps(scenario_node)
         examples = scenario_node.get_items(:ExamplesDefinition)
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature::Scenario.new(
           tags: tags,
           location: get_location(scenario_line, 0),
           keyword: scenario_line.matched_keyword,
           name: scenario_line.matched_text,
+          description: description,
           steps: steps,
           examples: examples
-        }
-        props[:description] = description if description
-        Cucumber::Messages::GherkinDocument::Feature::Scenario.new(props)
+        )
       when :ExamplesDefinition
         tags = get_tags(node)
         examples_node = node.get_single(:Examples)
@@ -179,16 +174,15 @@ module Gherkin
         table_header = rows.nil? ? nil : rows.first
         table_body = rows.nil? ? nil : rows[1..-1]
 
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature::Scenario::Examples.new(
           tags: tags,
           location: get_location(examples_line, 0),
           keyword: examples_line.matched_keyword,
           name: examples_line.matched_text,
-        }
-        props[:table_header] = table_header if table_header
-        props[:table_body] = table_body if table_body
-        props[:description] = description if description
-        Cucumber::Messages::GherkinDocument::Feature::Scenario::Examples.new(props)
+          description: description,
+          table_header: table_header,
+          table_body: table_body,
+        )
       when :ExamplesTable
         get_table_rows(node)
       when :Description
@@ -215,17 +209,15 @@ module Gherkin
         description = get_description(header)
         language = feature_line.matched_gherkin_dialect
 
-        props = {
+        Cucumber::Messages::GherkinDocument::Feature.new(
           tags: tags,
           location: get_location(feature_line, 0),
           language: language,
           keyword: feature_line.matched_keyword,
           name: feature_line.matched_text,
+          description: description,
           children: children,
-        }
-        props[:description] = description if description
-
-        Cucumber::Messages::GherkinDocument::Feature.new(props)
+        )
       when :Rule
         header = node.get_single(:RuleHeader)
         return unless header

--- a/gherkin/ruby/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/ruby/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/ruby/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF

--- a/gherkin/testdata/good/rule_without_name_and_description.feature
+++ b/gherkin/testdata/good/rule_without_name_and_description.feature
@@ -1,0 +1,5 @@
+Feature:
+
+  Rule:
+  Scenario:
+    Given text

--- a/gherkin/testdata/good/rule_without_name_and_description.feature.ast.ndjson
+++ b/gherkin/testdata/good/rule_without_name_and_description.feature.ast.ndjson
@@ -1,0 +1,45 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "rule": {
+            "children": [
+              {
+                "scenario": {
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 3,
+                    "line": 4
+                  },
+                  "steps": [
+                    {
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 5,
+                        "line": 5
+                      },
+                      "text": "text"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      }
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
+++ b/gherkin/testdata/good/rule_without_name_and_description.feature.pickles.ndjson
@@ -1,0 +1,24 @@
+{
+  "pickle": {
+    "id": "fe69f807f6e2572656fa7fbf72e1fc57ee1f83a2",
+    "language": "en",
+    "locations": [
+      {
+        "column": 3,
+        "line": 4
+      }
+    ],
+    "steps": [
+      {
+        "locations": [
+          {
+            "column": 11,
+            "line": 5
+          }
+        ],
+        "text": "text"
+      }
+    ],
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/testdata/good/rule_without_name_and_description.feature.source.ndjson
+++ b/gherkin/testdata/good/rule_without_name_and_description.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature:\n\n  Rule:\n  Scenario:\n    Given text\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/rule_without_name_and_description.feature"
+  }
+}

--- a/gherkin/testdata/good/rule_without_name_and_description.feature.tokens
+++ b/gherkin/testdata/good/rule_without_name_and_description.feature.tokens
@@ -1,0 +1,6 @@
+(1:1)FeatureLine:Feature//
+(2:1)Empty://
+(3:3)RuleLine:Rule//
+(4:3)ScenarioLine:Scenario//
+(5:5)StepLine:Given /text/
+EOF


### PR DESCRIPTION
This fails on Ruby 2.4 because protobuf on that version does not allow setting `nil` fields.

Two possible fixes:
* Upgrade protobuf
* Only set a rule's `description` if it's not `nil` in `ast_builder.rb` (we do this conditionally already for other elements)

I'd love to make this fail in CI before fixing it though!