### PR TITLE
Release process: do not try to add replace in go.mod when there is no need (see #774)

### DIFF
--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/cucumber-messages/go/default.mk
+++ b/cucumber-messages/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/dots-formatter/go/default.mk
+++ b/dots-formatter/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/pretty-formatter/go/default.mk
+++ b/pretty-formatter/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -107,7 +107,11 @@ remove-replaces:
 .PHONY: remove-replaces
 
 add-replaces:
+ifeq ($(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | wc -l), 0)
+	# No replacements here
+else
 	sed -i '/^go .*/i $(REPLACEMENTS)\n' go.mod
+endif
 .PHONY: add-replaces
 
 update-major:


### PR DESCRIPTION
## Summary

This should fix issue #774 that Aslak saw after releasing `cucumber-messages`. It does not try to update the `go.mod` file after release if the package does not use any other package in the mono-repo.


## Motivation and Context

Don't break the `go.mod` file after releases.

## How Has This Been Tested?

Manually :/
Basically:

```shell
cd cucumber-messages/go # There is no dependencies for this package
make remove-replaces && make add-replaces
cd ../../gherkin/go
make remove-replaces && make add-replaces
```

Running `git status` should say everything is clean.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Build & ops
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
