### PR TITLE
Expose ParameterType#getParameterType()

### DIFF
--- a/cucumber-expressions/go/argument_test.go
+++ b/cucumber-expressions/go/argument_test.go
@@ -1,0 +1,21 @@
+package cucumberexpressions
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgument(t *testing.T) {
+	t.Run("exposes ParameterType", func(t *testing.T) {
+		treeRegexp := NewTreeRegexp(regexp.MustCompile("three (.*) mice"))
+		parameterTypeRegistry := NewParameterTypeRegistry()
+		parameterType := parameterTypeRegistry.LookupByTypeName("string")
+		parameterTypes := []*ParameterType{parameterType}
+		arguments := BuildArguments(treeRegexp, "three blind mice", parameterTypes)
+		argument := arguments[0]
+
+		require.Equal(t, argument.ParameterType().name, "string")
+	})
+}

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Argument.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Argument.java
@@ -11,7 +11,7 @@ public final class Argument<T> {
     private final ParameterType<T> parameterType;
     private final Group group;
 
-    static List<Argument<?>> build(TreeRegexp treeRegexp, List<ParameterType<?>> parameterTypes, String text) {
+    static List<Argument<?>> build(TreeRegexp treeRegexp, String text, List<ParameterType<?>> parameterTypes) {
         Group group = treeRegexp.match(text);
         if (group == null) return null;
 
@@ -69,5 +69,9 @@ public final class Argument<T> {
 
     public Type getType() {
         return parameterType.getType();
+    }
+
+    public ParameterType<T> getParameterType() {
+        return parameterType;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -141,7 +141,7 @@ public final class CucumberExpression implements Expression {
             }
         }
 
-        return Argument.build(treeRegexp, parameterTypes, text);
+        return Argument.build(treeRegexp, text, parameterTypes);
     }
 
     @Override

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -42,7 +42,7 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     }
 
     @SuppressWarnings("unchecked")
-    public static <E extends Enum> ParameterType<E> fromEnum(final Class<E> enumClass) {
+    static <E extends Enum> ParameterType<E> fromEnum(final Class<E> enumClass) {
         Enum[] enumConstants = enumClass.getEnumConstants();
         StringBuilder regexpBuilder = new StringBuilder();
         for (int i = 0; i < enumConstants.length; i++) {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
@@ -65,7 +65,7 @@ public final class RegularExpression implements Expression {
         }
 
 
-        return Argument.build(treeRegexp, parameterTypes, text);
+        return Argument.build(treeRegexp, text, parameterTypes);
     }
 
     @Override

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ArgumentTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ArgumentTest.java
@@ -1,0 +1,20 @@
+package io.cucumber.cucumberexpressions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArgumentTest {
+    @Test
+    public void exposes_parameter_type() {
+        TreeRegexp treeRegexp = new TreeRegexp("three (.*) mice");
+        ParameterTypeRegistry parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
+        List<Argument<?>> arguments = Argument.build(treeRegexp, "three blind mice", Collections.singletonList(parameterTypeRegistry.lookupByTypeName("string")));
+        Argument<?> argument = arguments.get(0);
+        assertEquals("string", argument.getParameterType().getName());
+    }
+}

--- a/cucumber-expressions/javascript/src/Argument.ts
+++ b/cucumber-expressions/javascript/src/Argument.ts
@@ -48,6 +48,10 @@ export default class Argument<T> {
     const groupValues = this.group ? this.group.values : null
     return this.parameterType.transform(thisObj, groupValues)
   }
+
+  public getParameterType() {
+    return this.parameterType
+  }
 }
 
 module.exports = Argument

--- a/cucumber-expressions/javascript/test/ArgumentTest.ts
+++ b/cucumber-expressions/javascript/test/ArgumentTest.ts
@@ -1,0 +1,16 @@
+import TreeRegexp from '../src/TreeRegexp'
+import ParameterTypeRegistry from '../src/ParameterTypeRegistry'
+import Argument from '../src/Argument'
+import * as assert from 'assert'
+
+describe('Argument', () => {
+  it('exposes getParameterTypeName()', () => {
+    const treeRegexp = new TreeRegexp('three (.*) mice')
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const args = Argument.build(treeRegexp, 'three blind mice', [
+      parameterTypeRegistry.lookupByTypeName('string'),
+    ])
+    const argument = args[0]
+    assert.strictEqual(argument.getParameterType().name, 'string')
+  })
+})

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
@@ -4,7 +4,7 @@ require 'cucumber/cucumber_expressions/errors'
 module Cucumber
   module CucumberExpressions
     class Argument
-      attr_reader :group
+      attr_reader :group, :parameter_type
 
       def self.build(tree_regexp, text, parameter_types)
         group = tree_regexp.match(text)

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/tree_regexp.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/tree_regexp.rb
@@ -23,7 +23,7 @@ module Cucumber
             char_class = false
           elsif c == '(' && !escaping && !char_class
             @stack.push(GroupBuilder.new)
-            group_start_stack.push(n+1)
+            group_start_stack.push(n + 1)
             @non_capturing_maybe = false
           elsif c == ')' && !escaping && !char_class
             gb = @stack.pop
@@ -40,9 +40,9 @@ module Cucumber
           elsif (c == '<') && @non_capturing_maybe
             @name_capturing_maybe = true
           elsif (c == ':' || c == '!' || c == '=') && last == '?' && @non_capturing_maybe
-            end_non_capturing_group()
+            end_non_capturing_group
           elsif (c == '=' || c == '!') && last == '<' && @name_capturing_maybe
-            end_non_capturing_group()
+            end_non_capturing_group
           elsif @name_capturing_maybe
             raise CucumberExpressionError.new("Named capture groups are not supported. See https://github.com/cucumber/cucumber/issues/329")
           end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/argument_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/argument_spec.rb
@@ -1,0 +1,17 @@
+require 'cucumber/cucumber_expressions/argument'
+require 'cucumber/cucumber_expressions/tree_regexp'
+require 'cucumber/cucumber_expressions/parameter_type_registry'
+
+module Cucumber
+  module CucumberExpressions
+    describe Argument do
+      it 'exposes parameter_type' do
+        tree_regexp = TreeRegexp.new(/three (.*) mice/)
+        parameter_type_registry = ParameterTypeRegistry.new
+        arguments = Argument.build(tree_regexp, "three blind mice", [parameter_type_registry.lookup_by_type_name("string")])
+        argument = arguments[0]
+        expect(argument.parameter_type.name).to eq("string")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This exposes `Argument#getParameterType()`. Cucumber-JVM's upcoming `protobuf` formatter needs this to build `TestStepMatched` messages, and I imagine other platforms will need it too when they do the same.