### PR TITLE
Package cucumber-expressions with Webpack

### DIFF
--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint src/**/*.ts test/**/*.ts",
     "lint-fix": "tslint --fix src/**/*.ts test/**/*.ts",
     "coverage": "nyc --reporter=html --reporter=text mocha",
-    "build": "tsc",
+    "build": "tsc && webpack",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -30,15 +30,18 @@
   "homepage": "https://github.com/cucumber/cucumber-expressions-javascript#readme",
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.3",
+    "@types/node": "^12.12.7",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
+    "ts-loader": "^6.2.1",
     "ts-node": "^8.4.1",
-    "tslint": "^5.20.0",
+    "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10"
   },
   "files": [
     "*"

--- a/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
@@ -1,6 +1,6 @@
 import ParameterType from './ParameterType'
 // @ts-ignore
-import XRegExp from 'xregexp';
+import XRegExp from 'xregexp'
 
 // Needed for Node8 support, should be able to remove once Node 8 reaches end of life
 // (eta 2019-12-31) https://nodejs.org/en/about/releases/
@@ -54,16 +54,22 @@ export default class ParameterTypeMatcher {
   }
 
   get full_word() {
-    return this.match_start_word && this.match_end_word
+    return this.matchStartWord && this.matchEndWord
   }
 
-  get match_start_word() {
-    return this.start == 0 || this.text[this.start - 1].match(whitespacePunctuationPattern)
+  get matchStartWord() {
+    return (
+      this.start === 0 ||
+      this.text[this.start - 1].match(whitespacePunctuationPattern)
+    )
   }
 
-  get match_end_word() {
-    const next_character_index = this.start + this.group.length
-    return  next_character_index === this.text.length || this.text[next_character_index].match(whitespacePunctuationPattern)
+  get matchEndWord() {
+    const nextCharacterIndex = this.start + this.group.length
+    return (
+      nextCharacterIndex === this.text.length ||
+      this.text[nextCharacterIndex].match(whitespacePunctuationPattern)
+    )
   }
 
   get group() {

--- a/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
@@ -1,7 +1,7 @@
 import ParameterType from './ParameterType'
 
 import CucumberExpressionGenerator from './CucumberExpressionGenerator'
-import {AmbiguousParameterTypeError, CucumberExpressionError} from './Errors'
+import { AmbiguousParameterTypeError, CucumberExpressionError } from './Errors'
 
 export default class ParameterTypeRegistry {
   public static readonly INTEGER_REGEXPS = [/-?\d+/, /\d+/]
@@ -11,7 +11,10 @@ export default class ParameterTypeRegistry {
   public static readonly ANONYMOUS_REGEXP = /.*/
 
   private readonly parameterTypeByName = new Map<string, ParameterType<any>>()
-  private readonly parameterTypesByRegexp = new Map<string, Array<ParameterType<any>>>()
+  private readonly parameterTypesByRegexp = new Map<
+    string,
+    Array<ParameterType<any>>
+  >()
 
   constructor() {
     this.defineParameterType(

--- a/cucumber-expressions/javascript/src/web.ts
+++ b/cucumber-expressions/javascript/src/web.ts
@@ -1,0 +1,16 @@
+import CucumberExpressions from './index'
+
+declare var define: { (fn: () => void): () => void; amd: boolean }
+;(function(GLOBAL: any) {
+  if (typeof define === 'function' && define.amd) {
+    define(() => CucumberExpressions)
+
+    // Node and other CommonJS-like environments that support module.exports.
+  } else if (typeof module !== 'undefined' && module.exports) {
+    module.exports = CucumberExpressions
+
+    // Browser.
+  } else {
+    GLOBAL.CucumberExpressions = CucumberExpressions
+  }
+})(this)

--- a/cucumber-expressions/javascript/test/CucumberExpressionGeneratorTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionGeneratorTest.ts
@@ -223,7 +223,14 @@ describe('CucumberExpressionGenerator', () => {
   it('generates at most 256 expressions', () => {
     for (let i = 0; i < 4; i++) {
       parameterTypeRegistry.defineParameterType(
-        new ParameterType('my-type-' + i, /([a-z] )*?[a-z]/, null, s => s, true, false)
+        new ParameterType(
+          'my-type-' + i,
+          /([a-z] )*?[a-z]/,
+          null,
+          s => s,
+          true,
+          false
+        )
       )
     }
     // This would otherwise generate 4^11=419430 expressions and consume just shy of 1.5GB.
@@ -258,14 +265,8 @@ describe('CucumberExpressionGenerator', () => {
 
     const expressions = generator.generateExpressions('I download a picture')
     assert.strictEqual(expressions.length, 1)
-    assert.notEqual(
-      expressions[0].source,
-      'I {direction}load a picture'
-    )
-    assert.strictEqual(
-      expressions[0].source,
-      'I download a picture'
-    )
+    assert.notEqual(expressions[0].source, 'I {direction}load a picture')
+    assert.strictEqual(expressions[0].source, 'I download a picture')
   })
 
   it('does not suggest parameter included inside a word', () => {
@@ -275,14 +276,8 @@ describe('CucumberExpressionGenerator', () => {
 
     const expressions = generator.generateExpressions('I watch the muppet show')
     assert.strictEqual(expressions.length, 1)
-    assert.notEqual(
-      expressions[0].source,
-      'I watch the m{direction}pet show'
-    )
-    assert.strictEqual(
-      expressions[0].source,
-      'I watch the muppet show'
-    )
+    assert.notEqual(expressions[0].source, 'I watch the m{direction}pet show')
+    assert.strictEqual(expressions[0].source, 'I watch the muppet show')
   })
 
   it('does not suggest parameter at the end of a word', () => {
@@ -292,14 +287,8 @@ describe('CucumberExpressionGenerator', () => {
 
     const expressions = generator.generateExpressions('I create a group')
     assert.strictEqual(expressions.length, 1)
-    assert.notEqual(
-      expressions[0].source,
-      'I create a gro{direction}'
-    )
-    assert.strictEqual(
-      expressions[0].source,
-      'I create a group'
-    )
+    assert.notEqual(expressions[0].source, 'I create a gro{direction}')
+    assert.strictEqual(expressions[0].source, 'I create a group')
   })
 
   it('does suggest parameter that are a full word', () => {
@@ -308,18 +297,19 @@ describe('CucumberExpressionGenerator', () => {
     )
 
     assert.strictEqual(
-      generator.generateExpressions("When I go down the road")[0].source,
-      "When I go {direction} the road"
+      generator.generateExpressions('When I go down the road')[0].source,
+      'When I go {direction} the road'
     )
 
     assert.strictEqual(
-      generator.generateExpressions("When I walk up the hill")[0].source,
-      "When I walk {direction} the hill"
+      generator.generateExpressions('When I walk up the hill')[0].source,
+      'When I walk {direction} the hill'
     )
 
     assert.strictEqual(
-      generator.generateExpressions("up the hill, the road goes down")[0].source,
-      "{direction} the hill, the road goes {direction}"
+      generator.generateExpressions('up the hill, the road goes down')[0]
+        .source,
+      '{direction} the hill, the road goes {direction}'
     )
   })
 
@@ -329,13 +319,13 @@ describe('CucumberExpressionGenerator', () => {
     )
 
     assert.strictEqual(
-      generator.generateExpressions("direction is:down")[0].source,
-      "direction is:{direction}"
+      generator.generateExpressions('direction is:down')[0].source,
+      'direction is:{direction}'
     )
 
     assert.strictEqual(
-      generator.generateExpressions("direction is down.")[0].source,
-      "direction is {direction}."
+      generator.generateExpressions('direction is down.')[0].source,
+      'direction is {direction}.'
     )
   })
 })

--- a/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
@@ -96,25 +96,23 @@ describe('CucumberExpression', () => {
   })
 
   it('matches single quoted empty string as empty string', () => {
-    assert.deepStrictEqual(match('three {string} mice', "three '' mice"),
-      ['']
-    )
+    assert.deepStrictEqual(match('three {string} mice', "three '' mice"), [''])
   })
 
   it('matches double quoted empty string as empty string ', () => {
-    assert.deepStrictEqual(match('three {string} mice', 'three "" mice'),
-      ['']
-    )
+    assert.deepStrictEqual(match('three {string} mice', 'three "" mice'), [''])
   })
 
   it('matches single quoted empty string as empty string, along with other strings', () => {
-    assert.deepStrictEqual(match('three {string} and {string} mice', "three '' and 'handsome' mice"),
+    assert.deepStrictEqual(
+      match('three {string} and {string} mice', "three '' and 'handsome' mice"),
       ['', 'handsome']
     )
   })
 
   it('matches double quoted empty string as empty string, along with other strings', () => {
-    assert.deepStrictEqual(match('three {string} and {string} mice', 'three "" and "handsome" mice'),
+    assert.deepStrictEqual(
+      match('three {string} and {string} mice', 'three "" and "handsome" mice'),
       ['', 'handsome']
     )
   })
@@ -142,38 +140,38 @@ describe('CucumberExpression', () => {
   })
 
   it('matches float', () => {
-    assert.deepStrictEqual(match('{float}', ""), null);
-    assert.deepStrictEqual(match('{float}', "."), null);
-    assert.deepStrictEqual(match('{float}', ","), null);
-    assert.deepStrictEqual(match('{float}', "-"), null);
-    assert.deepStrictEqual(match('{float}', "E"), null);
-    assert.deepStrictEqual(match('{float}', "1,"), null);
-    assert.deepStrictEqual(match('{float}', ",1"), null);
-    assert.deepStrictEqual(match('{float}', "1."), null);
+    assert.deepStrictEqual(match('{float}', ''), null)
+    assert.deepStrictEqual(match('{float}', '.'), null)
+    assert.deepStrictEqual(match('{float}', ','), null)
+    assert.deepStrictEqual(match('{float}', '-'), null)
+    assert.deepStrictEqual(match('{float}', 'E'), null)
+    assert.deepStrictEqual(match('{float}', '1,'), null)
+    assert.deepStrictEqual(match('{float}', ',1'), null)
+    assert.deepStrictEqual(match('{float}', '1.'), null)
 
-    assert.deepStrictEqual(match('{float}', "1"), [1]);
-    assert.deepStrictEqual(match('{float}', "-1"), [-1]);
-    assert.deepStrictEqual(match('{float}', "1.1"), [1.1]);
-    assert.deepStrictEqual(match('{float}', "1,000"), null);
-    assert.deepStrictEqual(match('{float}', "1,000,0"), null);
-    assert.deepStrictEqual(match('{float}', "1,000.1"), null);
-    assert.deepStrictEqual(match('{float}', "1,000,10"), null);
-    assert.deepStrictEqual(match('{float}', "1,0.1"), null);
-    assert.deepStrictEqual(match('{float}', "1,000,000.1"), null);
-    assert.deepStrictEqual(match('{float}', "-1.1"), [-1.1]);
+    assert.deepStrictEqual(match('{float}', '1'), [1])
+    assert.deepStrictEqual(match('{float}', '-1'), [-1])
+    assert.deepStrictEqual(match('{float}', '1.1'), [1.1])
+    assert.deepStrictEqual(match('{float}', '1,000'), null)
+    assert.deepStrictEqual(match('{float}', '1,000,0'), null)
+    assert.deepStrictEqual(match('{float}', '1,000.1'), null)
+    assert.deepStrictEqual(match('{float}', '1,000,10'), null)
+    assert.deepStrictEqual(match('{float}', '1,0.1'), null)
+    assert.deepStrictEqual(match('{float}', '1,000,000.1'), null)
+    assert.deepStrictEqual(match('{float}', '-1.1'), [-1.1])
 
-    assert.deepStrictEqual(match('{float}', ".1"), [0.1]);
-    assert.deepStrictEqual(match('{float}', "-.1"), [-0.1]);
-    assert.deepStrictEqual(match('{float}', "-.10000001"), [-0.10000001]);
-    assert.deepStrictEqual(match('{float}', "1E1"), [1E1]); // precision 1 with scale -1, can not be expressed as a decimal
-    assert.deepStrictEqual(match('{float}', ".1E1"), [1]);
-    assert.deepStrictEqual(match('{float}', "E1"), null);
-    assert.deepStrictEqual(match('{float}', "-.1E-1"), [-0.01]);
-    assert.deepStrictEqual(match('{float}', "-.1E-2"), [-0.001]);
-    assert.deepStrictEqual(match('{float}', "-.1E+1"), [-1]);
-    assert.deepStrictEqual(match('{float}', "-.1E+2"), [-10]);
-    assert.deepStrictEqual(match('{float}', "-.1E1"), [-1]);
-    assert.deepStrictEqual(match('{float}', "-.10E2"), [-10]);
+    assert.deepStrictEqual(match('{float}', '.1'), [0.1])
+    assert.deepStrictEqual(match('{float}', '-.1'), [-0.1])
+    assert.deepStrictEqual(match('{float}', '-.10000001'), [-0.10000001])
+    assert.deepStrictEqual(match('{float}', '1E1'), [1e1]) // precision 1 with scale -1, can not be expressed as a decimal
+    assert.deepStrictEqual(match('{float}', '.1E1'), [1])
+    assert.deepStrictEqual(match('{float}', 'E1'), null)
+    assert.deepStrictEqual(match('{float}', '-.1E-1'), [-0.01])
+    assert.deepStrictEqual(match('{float}', '-.1E-2'), [-0.001])
+    assert.deepStrictEqual(match('{float}', '-.1E+1'), [-1])
+    assert.deepStrictEqual(match('{float}', '-.1E+2'), [-10])
+    assert.deepStrictEqual(match('{float}', '-.1E1'), [-1])
+    assert.deepStrictEqual(match('{float}', '-.10E2'), [-10])
   })
 
   it('matches float with zero', () => {
@@ -264,7 +262,7 @@ describe('CucumberExpression', () => {
         'widget',
         /\w+/,
         null,
-        function (s: string) {
+        function(s: string) {
           return this.createWidget(s)
         },
         false,

--- a/cucumber-expressions/javascript/test/TreeRegexpTest.ts
+++ b/cucumber-expressions/javascript/test/TreeRegexpTest.ts
@@ -4,10 +4,10 @@ import TreeRegexp from '../src/TreeRegexp'
 describe('TreeRegexp', () => {
   it('exposes group source', () => {
     const tr = new TreeRegexp(/(a(?:b)?)(c)/)
-    assert.deepStrictEqual(tr.groupBuilder.children.map(gb => gb.source), [
-      'a(?:b)?',
-      'c',
-    ])
+    assert.deepStrictEqual(
+      tr.groupBuilder.children.map(gb => gb.source),
+      ['a(?:b)?', 'c']
+    )
   })
 
   it('builds tree', () => {

--- a/cucumber-expressions/javascript/webpack.config.js
+++ b/cucumber-expressions/javascript/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path')
+
+module.exports = {
+  entry: './src/web.ts',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    filename: 'web.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+}


### PR DESCRIPTION
I want to be able to pull in `cucumber-expressions` as a [jsDelivr](https://www.jsdelivr.com/) dependency (e.g. in a [Codepen](https://codepen.io/) pen).

What I want to create is a simple playground for Cucumber Expressions, similar to [rubular](https://rubular.com/) or [scriptular](https://scriptular.com/), but in a codepen we can embed in our docs.

This PR also ran code reformatting