### PR TITLE
Gherkin unique picklestep ids

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,6 +19,10 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* PickleStep have unique IDs when generated from a `Background` section
+  ([#800](https://github.com/cucumber/cucumber/pull/800)
+   [vincent-psarga])
+
 ## [8.2.0] - 2019-11-14
 
 ### Fixed

--- a/gherkin/c/testdata/good/background.feature
+++ b/gherkin/c/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/c/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/c/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/c/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/c/testdata/good/background.feature.source.ndjson
+++ b/gherkin/c/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/c/testdata/good/background.feature.tokens
+++ b/gherkin/c/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/c/testdata/good/complex_background.feature
+++ b/gherkin/c/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/c/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/c/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/c/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/c/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/c/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/c/testdata/good/complex_background.feature.tokens
+++ b/gherkin/c/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/c/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/c/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/c/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/dotnet/testdata/good/background.feature
+++ b/gherkin/dotnet/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/dotnet/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/dotnet/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/dotnet/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/dotnet/testdata/good/background.feature.source.ndjson
+++ b/gherkin/dotnet/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/dotnet/testdata/good/background.feature.tokens
+++ b/gherkin/dotnet/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/dotnet/testdata/good/complex_background.feature
+++ b/gherkin/dotnet/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/dotnet/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/dotnet/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/dotnet/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/dotnet/testdata/good/complex_background.feature.tokens
+++ b/gherkin/dotnet/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/dotnet/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/dotnet/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/dotnet/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/go/pickles.go
+++ b/gherkin/go/pickles.go
@@ -18,20 +18,20 @@ func Pickles(gherkinDocument messages.GherkinDocument, uri string, newId func() 
 }
 
 func compileFeature(pickles []*messages.Pickle, feature messages.GherkinDocument_Feature, uri string, language string, newId func() string) []*messages.Pickle {
-	backgroundSteps := make([]*messages.GherkinDocument_Feature_Step, 0)
+	featureBackgroundSteps := make([]*messages.GherkinDocument_Feature_Step, 0)
 	featureTags := feature.Tags
 	for _, child := range feature.Children {
 		switch t := child.Value.(type) {
 		case *messages.GherkinDocument_Feature_FeatureChild_Background:
-			backgroundSteps = append(backgroundSteps, t.Background.Steps...)
+			featureBackgroundSteps = append(featureBackgroundSteps, t.Background.Steps...)
 		case *messages.GherkinDocument_Feature_FeatureChild_Rule_:
-			pickles = compileRule(pickles, child.GetRule(), featureTags, backgroundSteps, uri, language, newId)
+			pickles = compileRule(pickles, child.GetRule(), featureTags, featureBackgroundSteps, uri, language, newId)
 		case *messages.GherkinDocument_Feature_FeatureChild_Scenario:
 			scenario := t.Scenario
 			if len(scenario.GetExamples()) == 0 {
-				pickles = compileScenario(pickles, backgroundSteps, scenario, featureTags, uri, language, newId)
+				pickles = compileScenario(pickles, featureBackgroundSteps, scenario, featureTags, uri, language, newId)
 			} else {
-				pickles = compileScenarioOutline(pickles, scenario, featureTags, backgroundSteps, uri, language, newId)
+				pickles = compileScenarioOutline(pickles, scenario, featureTags, featureBackgroundSteps, uri, language, newId)
 			}
 		default:
 			panic(fmt.Sprintf("unexpected %T feature child", child))

--- a/gherkin/go/pickles.go
+++ b/gherkin/go/pickles.go
@@ -18,12 +18,12 @@ func Pickles(gherkinDocument messages.GherkinDocument, uri string, newId func() 
 }
 
 func compileFeature(pickles []*messages.Pickle, feature messages.GherkinDocument_Feature, uri string, language string, newId func() string) []*messages.Pickle {
-	backgroundSteps := make([]*messages.Pickle_PickleStep, 0)
+	backgroundSteps := make([]*messages.GherkinDocument_Feature_Step, 0)
 	featureTags := feature.Tags
 	for _, child := range feature.Children {
 		switch t := child.Value.(type) {
 		case *messages.GherkinDocument_Feature_FeatureChild_Background:
-			backgroundSteps = append(backgroundSteps, pickleSteps(t.Background.Steps, newId)...)
+			backgroundSteps = append(backgroundSteps, t.Background.Steps...)
 		case *messages.GherkinDocument_Feature_FeatureChild_Rule_:
 			pickles = compileRule(pickles, child.GetRule(), featureTags, backgroundSteps, uri, language, newId)
 		case *messages.GherkinDocument_Feature_FeatureChild_Scenario:
@@ -40,20 +40,28 @@ func compileFeature(pickles []*messages.Pickle, feature messages.GherkinDocument
 	return pickles
 }
 
-func compileRule(pickles []*messages.Pickle, rule *messages.GherkinDocument_Feature_FeatureChild_Rule, tags []*messages.GherkinDocument_Feature_Tag, steps []*messages.Pickle_PickleStep, uri string, language string, newId func() string) []*messages.Pickle {
-	backgroundSteps := make([]*messages.Pickle_PickleStep, 0)
-	backgroundSteps = append(backgroundSteps, steps...)
+func compileRule(
+	pickles []*messages.Pickle,
+	rule *messages.GherkinDocument_Feature_FeatureChild_Rule,
+	tags []*messages.GherkinDocument_Feature_Tag,
+	featureBackgroundSteps []*messages.GherkinDocument_Feature_Step,
+	uri string,
+	language string,
+	newId func() string,
+) []*messages.Pickle {
+	ruleBackgroundSteps := make([]*messages.GherkinDocument_Feature_Step, 0)
+	ruleBackgroundSteps = append(ruleBackgroundSteps, featureBackgroundSteps...)
 
 	for _, child := range rule.Children {
 		switch t := child.Value.(type) {
 		case *messages.GherkinDocument_Feature_FeatureChild_RuleChild_Background:
-			backgroundSteps = append(backgroundSteps, pickleSteps(t.Background.Steps, newId)...)
+			ruleBackgroundSteps = append(ruleBackgroundSteps, t.Background.Steps...)
 		case *messages.GherkinDocument_Feature_FeatureChild_RuleChild_Scenario:
 			scenario := t.Scenario
 			if len(scenario.GetExamples()) == 0 {
-				pickles = compileScenario(pickles, backgroundSteps, scenario, tags, uri, language, newId)
+				pickles = compileScenario(pickles, ruleBackgroundSteps, scenario, tags, uri, language, newId)
 			} else {
-				pickles = compileScenarioOutline(pickles, scenario, tags, backgroundSteps, uri, language, newId)
+				pickles = compileScenarioOutline(pickles, scenario, tags, ruleBackgroundSteps, uri, language, newId)
 			}
 		default:
 			panic(fmt.Sprintf("unexpected %T feature child", child))
@@ -67,7 +75,7 @@ func compileScenarioOutline(
 	pickles []*messages.Pickle,
 	scenario *messages.GherkinDocument_Feature_Scenario,
 	featureTags []*messages.GherkinDocument_Feature_Tag,
-	backgroundSteps []*messages.Pickle_PickleStep,
+	backgroundSteps []*messages.GherkinDocument_Feature_Step,
 	uri string,
 	language string,
 	newId func() string,
@@ -81,9 +89,14 @@ func compileScenarioOutline(
 			valueCells := valuesRow.Cells
 			tags := pickleTags(append(featureTags, append(scenario.Tags, examples.Tags...)...))
 
-			pickleSteps := make([]*messages.Pickle_PickleStep, 0)
+			computedPickleSteps := make([]*messages.Pickle_PickleStep, 0)
+			pickleBackgroundSteps := make([]*messages.Pickle_PickleStep, 0)
 
-			// translate pickleSteps based on valuesRow
+			if len(scenario.Steps) > 0 {
+				pickleBackgroundSteps = pickleSteps(backgroundSteps, newId)
+			}
+
+			// translate computedPickleSteps based on valuesRow
 			for _, step := range scenario.Steps {
 				text := step.Text
 				for i, variableCell := range variableCells {
@@ -91,7 +104,7 @@ func compileScenarioOutline(
 				}
 
 				pickleStep := pickleStep(step, variableCells, valuesRow, newId)
-				pickleSteps = append(pickleSteps, pickleStep)
+				computedPickleSteps = append(computedPickleSteps, pickleStep)
 			}
 
 			// translate pickle name
@@ -100,14 +113,14 @@ func compileScenarioOutline(
 				name = strings.Replace(name, "<"+key.Value+">", valueCells[i].Value, -1)
 			}
 
-			if len(pickleSteps) > 0 {
-				pickleSteps = append(backgroundSteps, pickleSteps...)
+			if len(computedPickleSteps) > 0 {
+				computedPickleSteps = append(pickleBackgroundSteps, computedPickleSteps...)
 			}
 
 			pickles = append(pickles, &messages.Pickle{
 				Id:        newId(),
 				Uri:       uri,
-				Steps:     pickleSteps,
+				Steps:     computedPickleSteps,
 				Tags:      tags,
 				Name:      name,
 				Language:  language,
@@ -118,10 +131,19 @@ func compileScenarioOutline(
 	return pickles
 }
 
-func compileScenario(pickles []*messages.Pickle, backgroundSteps []*messages.Pickle_PickleStep, scenario *messages.GherkinDocument_Feature_Scenario, featureTags []*messages.GherkinDocument_Feature_Tag, uri string, language string, newId func() string) []*messages.Pickle {
+func compileScenario(
+	pickles []*messages.Pickle,
+	backgroundSteps []*messages.GherkinDocument_Feature_Step,
+	scenario *messages.GherkinDocument_Feature_Scenario,
+	featureTags []*messages.GherkinDocument_Feature_Tag,
+	uri string,
+	language string,
+	newId func() string,
+) []*messages.Pickle {
 	steps := make([]*messages.Pickle_PickleStep, 0)
 	if len(scenario.Steps) > 0 {
-		steps = append(backgroundSteps, pickleSteps(scenario.Steps, newId)...)
+		pickleBackgroundSteps := pickleSteps(backgroundSteps, newId)
+		steps = append(pickleBackgroundSteps, pickleSteps(scenario.Steps, newId)...)
 	}
 	tags := pickleTags(append(featureTags, scenario.Tags...))
 	pickles = append(pickles, &messages.Pickle{

--- a/gherkin/go/testdata/good/background.feature
+++ b/gherkin/go/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/go/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/go/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/go/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/go/testdata/good/background.feature.source.ndjson
+++ b/gherkin/go/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/go/testdata/good/background.feature.tokens
+++ b/gherkin/go/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/go/testdata/good/complex_background.feature
+++ b/gherkin/go/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/go/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/go/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/go/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/go/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/go/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/go/testdata/good/complex_background.feature.tokens
+++ b/gherkin/go/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/go/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/go/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/go/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/java/src/main/java/io/cucumber/gherkin/pickles/PickleCompiler.java
+++ b/gherkin/java/src/main/java/io/cucumber/gherkin/pickles/PickleCompiler.java
@@ -51,18 +51,18 @@ public class PickleCompiler {
 
     private void compileFeature(List<Pickle> pickles, Feature feature, String language, String uri) {
         List<Tag> tags = feature.getTagsList();
-        List<Step> backgroundSteps = new ArrayList<>();
+        List<Step> featureBackgroundSteps = new ArrayList<>();
         for (FeatureChild child : feature.getChildrenList()) {
             if (child.hasBackground()) {
-                backgroundSteps.addAll(child.getBackground().getStepsList());
+                featureBackgroundSteps.addAll(child.getBackground().getStepsList());
             } else if (child.hasRule()) {
-                compileRule(pickles, child.getRule(), tags, backgroundSteps, language, uri);
+                compileRule(pickles, child.getRule(), tags, featureBackgroundSteps, language, uri);
             } else {
                 Feature.Scenario scenario = child.getScenario();
                 if (scenario.getExamplesList().isEmpty()) {
-                    compileScenario(pickles, scenario, tags, backgroundSteps, language, uri);
+                    compileScenario(pickles, scenario, tags, featureBackgroundSteps, language, uri);
                 } else {
-                    compileScenarioOutline(pickles, scenario, tags, backgroundSteps, language, uri);
+                    compileScenarioOutline(pickles, scenario, tags, featureBackgroundSteps, language, uri);
                 }
             }
         }

--- a/gherkin/java/src/main/java/io/cucumber/gherkin/pickles/PickleCompiler.java
+++ b/gherkin/java/src/main/java/io/cucumber/gherkin/pickles/PickleCompiler.java
@@ -51,10 +51,10 @@ public class PickleCompiler {
 
     private void compileFeature(List<Pickle> pickles, Feature feature, String language, String uri) {
         List<Tag> tags = feature.getTagsList();
-        List<PickleStep> backgroundSteps = new ArrayList<>();
+        List<Step> backgroundSteps = new ArrayList<>();
         for (FeatureChild child : feature.getChildrenList()) {
             if (child.hasBackground()) {
-                backgroundSteps.addAll(pickleSteps(child.getBackground().getStepsList()));
+                backgroundSteps.addAll(child.getBackground().getStepsList());
             } else if (child.hasRule()) {
                 compileRule(pickles, child.getRule(), tags, backgroundSteps, language, uri);
             } else {
@@ -68,26 +68,26 @@ public class PickleCompiler {
         }
     }
 
-    private void compileRule(List<Pickle> pickles, Rule rule, List<Tag> tags, List<PickleStep> featureBackgroundSteps, String language, String uri) {
-        List<PickleStep> backgroundSteps = new ArrayList<>(featureBackgroundSteps);
+    private void compileRule(List<Pickle> pickles, Rule rule, List<Tag> tags, List<Step> featureBackgroundSteps, String language, String uri) {
+        List<Step> ruleBackgroundSteps = new ArrayList<>(featureBackgroundSteps);
         for (FeatureChild.RuleChild child : rule.getChildrenList()) {
             if (child.hasBackground()) {
-                backgroundSteps.addAll(pickleSteps(child.getBackground().getStepsList()));
+                ruleBackgroundSteps.addAll(child.getBackground().getStepsList());
             } else {
                 Feature.Scenario scenario = child.getScenario();
                 if (scenario.getExamplesList().isEmpty()) {
-                    compileScenario(pickles, scenario, tags, backgroundSteps, language, uri);
+                    compileScenario(pickles, scenario, tags, ruleBackgroundSteps, language, uri);
                 } else {
-                    compileScenarioOutline(pickles, scenario, tags, backgroundSteps, language, uri);
+                    compileScenarioOutline(pickles, scenario, tags, ruleBackgroundSteps, language, uri);
                 }
             }
         }
     }
 
-    private void compileScenario(List<Pickle> pickles, Feature.Scenario scenario, List<Tag> parentTags, List<PickleStep> backgroundSteps, String language, String uri) {
+    private void compileScenario(List<Pickle> pickles, Feature.Scenario scenario, List<Tag> parentTags, List<Step> backgroundSteps, String language, String uri) {
         List<PickleStep> steps = new ArrayList<>();
         if (!scenario.getStepsList().isEmpty())
-            steps.addAll(backgroundSteps);
+            steps.addAll(pickleSteps(backgroundSteps));
 
         steps.addAll(pickleSteps(scenario.getStepsList()));
 
@@ -110,7 +110,7 @@ public class PickleCompiler {
         pickles.add(pickle);
     }
 
-    private void compileScenarioOutline(List<Pickle> pickles, Feature.Scenario scenario, List<Tag> featureTags, List<PickleStep> backgroundSteps, String language, String uri) {
+    private void compileScenarioOutline(List<Pickle> pickles, Feature.Scenario scenario, List<Tag> featureTags, List<Step> backgroundSteps, String language, String uri) {
         for (final Examples examples : scenario.getExamplesList()) {
             if (examples.getTableHeader() == null) continue;
             List<TableCell> variableCells = examples.getTableHeader().getCellsList();
@@ -120,7 +120,8 @@ public class PickleCompiler {
                 List<PickleStep> steps = new ArrayList<>();
 
                 if (!scenario.getStepsList().isEmpty())
-                    steps.addAll(backgroundSteps);
+                    steps.addAll(pickleSteps(backgroundSteps));
+
 
                 List<Tag> tags = new ArrayList<>();
                 tags.addAll(featureTags);

--- a/gherkin/java/testdata/good/background.feature
+++ b/gherkin/java/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/java/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/java/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/java/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/java/testdata/good/background.feature.source.ndjson
+++ b/gherkin/java/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/java/testdata/good/background.feature.tokens
+++ b/gherkin/java/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/java/testdata/good/complex_background.feature
+++ b/gherkin/java/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/java/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/java/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/java/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/java/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/java/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/java/testdata/good/complex_background.feature.tokens
+++ b/gherkin/java/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/java/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/java/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/java/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/javascript/src/pickles/compile.ts
+++ b/gherkin/javascript/src/pickles/compile.ts
@@ -20,7 +20,7 @@ export default function compile(
 
   feature.children.forEach(stepsContainer => {
     if (stepsContainer.background) {
-      backgroundSteps = pickleSteps(stepsContainer.background, [], null, newId)
+      backgroundSteps = [].concat(stepsContainer.background.steps)
     } else if (stepsContainer.rule) {
       compileRule(
         featureTags,
@@ -69,9 +69,7 @@ function compileRule(
 
   rule.children.forEach(stepsContainer => {
     if (stepsContainer.background) {
-      backgroundSteps = backgroundSteps.concat(
-        pickleSteps(stepsContainer.background, [], null, newId)
-      )
+      backgroundSteps = backgroundSteps.concat(stepsContainer.background.steps)
     } else if (stepsContainer.scenario.examples.length === 0) {
       compileScenario(
         featureTags,
@@ -105,7 +103,7 @@ function compileScenario(
   uri: string,
   newId: NewId
 ) {
-  const steps = scenario.steps.length === 0 ? [] : [].concat(backgroundSteps)
+  const steps = scenario.steps.length === 0 ? [] : backgroundSteps.map(step => pickleStep(step, [], null, newId))
 
   const tags = [].concat(featureTags).concat(scenario.tags)
 
@@ -137,8 +135,8 @@ function compileScenarioOutline(
     .forEach(examples => {
       const variableCells = examples.tableHeader.cells
       examples.tableBody.forEach(valuesRow => {
-        const steps =
-          scenario.steps.length === 0 ? [] : [].concat(backgroundSteps)
+        const steps = scenario.steps.length === 0 ?
+          [] : backgroundSteps.map(step => pickleStep(step, [], null, newId))
         const tags = []
           .concat(featureTags)
           .concat(scenario.tags)

--- a/gherkin/javascript/src/pickles/compile.ts
+++ b/gherkin/javascript/src/pickles/compile.ts
@@ -16,15 +16,15 @@ export default function compile(
   const feature = gherkinDocument.feature
   const language = feature.language
   const featureTags = feature.tags
-  let backgroundSteps: messages.GherkinDocument.Feature.IStep[] = []
+  let featureBackgroundSteps: messages.GherkinDocument.Feature.IStep[] = []
 
   feature.children.forEach(stepsContainer => {
     if (stepsContainer.background) {
-      backgroundSteps = [].concat(stepsContainer.background.steps)
+      featureBackgroundSteps = [].concat(stepsContainer.background.steps)
     } else if (stepsContainer.rule) {
       compileRule(
         featureTags,
-        backgroundSteps,
+        featureBackgroundSteps,
         stepsContainer.rule,
         language,
         pickles,
@@ -34,7 +34,7 @@ export default function compile(
     } else if (stepsContainer.scenario.examples.length === 0) {
       compileScenario(
         featureTags,
-        backgroundSteps,
+        featureBackgroundSteps,
         stepsContainer.scenario,
         language,
         pickles,
@@ -44,7 +44,7 @@ export default function compile(
     } else {
       compileScenarioOutline(
         featureTags,
-        backgroundSteps,
+        featureBackgroundSteps,
         stepsContainer.scenario,
         language,
         pickles,
@@ -58,22 +58,22 @@ export default function compile(
 
 function compileRule(
   featureTags: messages.GherkinDocument.Feature.ITag[],
-  inheritedBackgroundSteps: messages.GherkinDocument.Feature.IStep[],
+  featureBackgroundSteps: messages.GherkinDocument.Feature.IStep[],
   rule: messages.GherkinDocument.Feature.FeatureChild.IRule,
   language: string,
   pickles: messages.IPickle[],
   uri: string,
   newId: NewId
 ) {
-  let backgroundSteps = [].concat(inheritedBackgroundSteps)
+  let ruleBackgroundSteps = [].concat(featureBackgroundSteps)
 
   rule.children.forEach(stepsContainer => {
     if (stepsContainer.background) {
-      backgroundSteps = backgroundSteps.concat(stepsContainer.background.steps)
+      ruleBackgroundSteps = ruleBackgroundSteps.concat(stepsContainer.background.steps)
     } else if (stepsContainer.scenario.examples.length === 0) {
       compileScenario(
         featureTags,
-        backgroundSteps,
+        ruleBackgroundSteps,
         stepsContainer.scenario,
         language,
         pickles,
@@ -83,7 +83,7 @@ function compileRule(
     } else {
       compileScenarioOutline(
         featureTags,
-        backgroundSteps,
+        ruleBackgroundSteps,
         stepsContainer.scenario,
         language,
         pickles,

--- a/gherkin/javascript/testdata/good/background.feature
+++ b/gherkin/javascript/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/javascript/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/javascript/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/javascript/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/javascript/testdata/good/background.feature.source.ndjson
+++ b/gherkin/javascript/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/javascript/testdata/good/background.feature.tokens
+++ b/gherkin/javascript/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/javascript/testdata/good/complex_background.feature
+++ b/gherkin/javascript/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/javascript/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/javascript/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/javascript/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/javascript/testdata/good/complex_background.feature.tokens
+++ b/gherkin/javascript/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/javascript/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/javascript/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/javascript/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/objective-c/testdata/good/background.feature
+++ b/gherkin/objective-c/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/objective-c/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/objective-c/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/objective-c/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/objective-c/testdata/good/background.feature.source.ndjson
+++ b/gherkin/objective-c/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/objective-c/testdata/good/background.feature.tokens
+++ b/gherkin/objective-c/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/objective-c/testdata/good/complex_background.feature
+++ b/gherkin/objective-c/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/objective-c/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/objective-c/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/objective-c/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/objective-c/testdata/good/complex_background.feature.tokens
+++ b/gherkin/objective-c/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/objective-c/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/objective-c/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/objective-c/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/perl/testdata/good/background.feature
+++ b/gherkin/perl/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/perl/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/perl/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/perl/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/perl/testdata/good/background.feature.source.ndjson
+++ b/gherkin/perl/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/perl/testdata/good/background.feature.tokens
+++ b/gherkin/perl/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/perl/testdata/good/complex_background.feature
+++ b/gherkin/perl/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/perl/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/perl/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/perl/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/perl/testdata/good/complex_background.feature.tokens
+++ b/gherkin/perl/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/perl/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/perl/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/perl/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/python/testdata/good/background.feature
+++ b/gherkin/python/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/python/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/python/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/python/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/python/testdata/good/background.feature.source.ndjson
+++ b/gherkin/python/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/python/testdata/good/background.feature.tokens
+++ b/gherkin/python/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/python/testdata/good/complex_background.feature
+++ b/gherkin/python/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/python/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/python/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/python/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/python/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/python/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/python/testdata/good/complex_background.feature.tokens
+++ b/gherkin/python/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/python/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/python/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/python/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/ruby/lib/gherkin/pickles/compiler.rb
+++ b/gherkin/ruby/lib/gherkin/pickles/compiler.rb
@@ -26,7 +26,7 @@ module Gherkin
         background_steps = []
         feature.children.each do |child|
           if child.background
-            background_steps.concat(pickle_steps(child.background.steps))
+            background_steps.concat(child.background.steps)
           elsif child.rule
             compile_rule(pickles, language, tags, background_steps, child.rule, source)
           else
@@ -44,7 +44,7 @@ module Gherkin
         background_steps = feature_background_steps.dup
         rule.children.each do |child|
           if child.background
-            background_steps.concat(pickle_steps(child.background.steps))
+            background_steps.concat(child.background.steps)
           else
             scenario = child.scenario
             if scenario.examples.empty?
@@ -57,7 +57,7 @@ module Gherkin
       end
 
       def compile_scenario(feature_tags, background_steps, scenario, language, pickles, source)
-        steps = scenario.steps.empty? ? [] : [].concat(background_steps)
+        steps = scenario.steps.empty? ? [] : [].concat(pickle_steps(background_steps))
 
         tags = [].concat(feature_tags).concat(scenario.tags)
 
@@ -82,7 +82,7 @@ module Gherkin
           variable_cells = examples.table_header.cells
           examples.table_body.each do |values_row|
             value_cells = values_row.cells
-            steps = scenario.steps.empty? ? [] : [].concat(background_steps)
+            steps = scenario.steps.empty? ? [] : [].concat(pickle_steps(background_steps))
             tags = [].concat(feature_tags).concat(scenario.tags).concat(examples.tags)
 
             scenario.steps.each do |scenario_outline_step|

--- a/gherkin/ruby/lib/gherkin/pickles/compiler.rb
+++ b/gherkin/ruby/lib/gherkin/pickles/compiler.rb
@@ -23,34 +23,34 @@ module Gherkin
       private
 
       def compile_feature(pickles, language, tags, feature, source)
-        background_steps = []
+        feature_background_steps = []
         feature.children.each do |child|
           if child.background
-            background_steps.concat(child.background.steps)
+            feature_background_steps.concat(child.background.steps)
           elsif child.rule
-            compile_rule(pickles, language, tags, background_steps, child.rule, source)
+            compile_rule(pickles, language, tags, feature_background_steps, child.rule, source)
           else
             scenario = child.scenario
             if scenario.examples.empty?
-              compile_scenario(tags, background_steps, scenario, language, pickles, source)
+              compile_scenario(tags, feature_background_steps, scenario, language, pickles, source)
             else
-              compile_scenario_outline(tags, background_steps, scenario, language, pickles, source)
+              compile_scenario_outline(tags, feature_background_steps, scenario, language, pickles, source)
             end
           end
         end
       end
 
       def compile_rule(pickles, language, tags, feature_background_steps, rule, source)
-        background_steps = feature_background_steps.dup
+        rule_background_steps = feature_background_steps.dup
         rule.children.each do |child|
           if child.background
-            background_steps.concat(child.background.steps)
+            rule_background_steps.concat(child.background.steps)
           else
             scenario = child.scenario
             if scenario.examples.empty?
-              compile_scenario(tags, background_steps, scenario, language, pickles, source)
+              compile_scenario(tags, rule_background_steps, scenario, language, pickles, source)
             else
-              compile_scenario_outline(tags, background_steps, scenario, language, pickles, source)
+              compile_scenario_outline(tags, rule_background_steps, scenario, language, pickles, source)
             end
           end
         end

--- a/gherkin/ruby/testdata/good/background.feature
+++ b/gherkin/ruby/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/ruby/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/ruby/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/ruby/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/ruby/testdata/good/background.feature.source.ndjson
+++ b/gherkin/ruby/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/ruby/testdata/good/background.feature.tokens
+++ b/gherkin/ruby/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/ruby/testdata/good/complex_background.feature
+++ b/gherkin/ruby/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/ruby/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/ruby/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/ruby/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/ruby/testdata/good/complex_background.feature.tokens
+++ b/gherkin/ruby/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/ruby/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/ruby/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/ruby/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],

--- a/gherkin/testdata/good/background.feature
+++ b/gherkin/testdata/good/background.feature
@@ -6,3 +6,6 @@ Feature: Background
 
   Scenario: minimalistic
     Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism

--- a/gherkin/testdata/good/background.feature.ast.ndjson
+++ b/gherkin/testdata/good/background.feature.ast.ndjson
@@ -44,6 +44,28 @@
               }
             ]
           }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
         }
       ],
       "keyword": "Feature",

--- a/gherkin/testdata/good/background.feature.pickles.ndjson
+++ b/gherkin/testdata/good/background.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "5",
+    "id": "7",
     "language": "en",
     "name": "minimalistic",
     "sourceIds": [
@@ -8,16 +8,43 @@
     ],
     "steps": [
       {
-        "id": "3",
+        "id": "5",
         "sourceIds": [
           "0"
         ],
         "text": "the minimalism inside a background"
       },
       {
-        "id": "4",
+        "id": "6",
         "sourceIds": [
           "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "10",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "8",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "9",
+        "sourceIds": [
+          "3"
         ],
         "text": "the minimalism"
       }

--- a/gherkin/testdata/good/background.feature.source.ndjson
+++ b/gherkin/testdata/good/background.feature.source.ndjson
@@ -1,6 +1,6 @@
 {
   "source": {
-    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n",
+    "data": "Feature: Background\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism",
     "media": {
       "contentType": "text/x.cucumber.gherkin+plain",
       "encoding": "UTF8"

--- a/gherkin/testdata/good/background.feature.tokens
+++ b/gherkin/testdata/good/background.feature.tokens
@@ -6,4 +6,7 @@
 (6:1)Empty://
 (7:3)ScenarioLine:Scenario/minimalistic/
 (8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
 EOF

--- a/gherkin/testdata/good/complex_background.feature
+++ b/gherkin/testdata/good/complex_background.feature
@@ -1,0 +1,24 @@
+Feature: Complex background
+  We want to ensure PickleStep all have different IDs
+
+  Background: a simple background
+    Given the minimalism inside a background
+
+  Scenario: minimalistic
+    Given the minimalism
+
+  Scenario: also minimalistic
+    Given the minimalism
+
+  Rule: My Rule
+
+    Background:
+      Given a rule background step
+
+    Scenario: with examples
+      Given the <value> minimalism
+
+      Examples:
+      | value |
+      | 1     |
+      | 2     |

--- a/gherkin/testdata/good/complex_background.feature.ast.ndjson
+++ b/gherkin/testdata/good/complex_background.feature.ast.ndjson
@@ -1,0 +1,195 @@
+{
+  "gherkinDocument": {
+    "feature": {
+      "children": [
+        {
+          "background": {
+            "keyword": "Background",
+            "location": {
+              "column": 3,
+              "line": 4
+            },
+            "name": "a simple background",
+            "steps": [
+              {
+                "id": "0",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 5
+                },
+                "text": "the minimalism inside a background"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "2",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "name": "minimalistic",
+            "steps": [
+              {
+                "id": "1",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 8
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "scenario": {
+            "id": "4",
+            "keyword": "Scenario",
+            "location": {
+              "column": 3,
+              "line": 10
+            },
+            "name": "also minimalistic",
+            "steps": [
+              {
+                "id": "3",
+                "keyword": "Given ",
+                "location": {
+                  "column": 5,
+                  "line": 11
+                },
+                "text": "the minimalism"
+              }
+            ]
+          }
+        },
+        {
+          "rule": {
+            "children": [
+              {
+                "background": {
+                  "keyword": "Background",
+                  "location": {
+                    "column": 5,
+                    "line": 15
+                  },
+                  "steps": [
+                    {
+                      "id": "5",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 16
+                      },
+                      "text": "a rule background step"
+                    }
+                  ]
+                }
+              },
+              {
+                "scenario": {
+                  "examples": [
+                    {
+                      "keyword": "Examples",
+                      "location": {
+                        "column": 7,
+                        "line": 21
+                      },
+                      "tableBody": [
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 23
+                              },
+                              "value": "1"
+                            }
+                          ],
+                          "id": "8",
+                          "location": {
+                            "column": 7,
+                            "line": 23
+                          }
+                        },
+                        {
+                          "cells": [
+                            {
+                              "location": {
+                                "column": 9,
+                                "line": 24
+                              },
+                              "value": "2"
+                            }
+                          ],
+                          "id": "9",
+                          "location": {
+                            "column": 7,
+                            "line": 24
+                          }
+                        }
+                      ],
+                      "tableHeader": {
+                        "cells": [
+                          {
+                            "location": {
+                              "column": 9,
+                              "line": 22
+                            },
+                            "value": "value"
+                          }
+                        ],
+                        "id": "7",
+                        "location": {
+                          "column": 7,
+                          "line": 22
+                        }
+                      }
+                    }
+                  ],
+                  "id": "10",
+                  "keyword": "Scenario",
+                  "location": {
+                    "column": 5,
+                    "line": 18
+                  },
+                  "name": "with examples",
+                  "steps": [
+                    {
+                      "id": "6",
+                      "keyword": "Given ",
+                      "location": {
+                        "column": 7,
+                        "line": 19
+                      },
+                      "text": "the <value> minimalism"
+                    }
+                  ]
+                }
+              }
+            ],
+            "keyword": "Rule",
+            "location": {
+              "column": 3,
+              "line": 13
+            },
+            "name": "My Rule"
+          }
+        }
+      ],
+      "description": "  We want to ensure PickleStep all have different IDs",
+      "keyword": "Feature",
+      "language": "en",
+      "location": {
+        "column": 1,
+        "line": 1
+      },
+      "name": "Complex background"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/testdata/good/complex_background.feature.pickles.ndjson
+++ b/gherkin/testdata/good/complex_background.feature.pickles.ndjson
@@ -1,0 +1,126 @@
+{
+  "pickle": {
+    "id": "13",
+    "language": "en",
+    "name": "minimalistic",
+    "sourceIds": [
+      "2"
+    ],
+    "steps": [
+      {
+        "id": "11",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "12",
+        "sourceIds": [
+          "1"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "16",
+    "language": "en",
+    "name": "also minimalistic",
+    "sourceIds": [
+      "4"
+    ],
+    "steps": [
+      {
+        "id": "14",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "15",
+        "sourceIds": [
+          "3"
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "20",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "8"
+    ],
+    "steps": [
+      {
+        "id": "17",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "18",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "19",
+        "sourceIds": [
+          "6",
+          "8"
+        ],
+        "text": "the 1 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}
+{
+  "pickle": {
+    "id": "24",
+    "language": "en",
+    "name": "with examples",
+    "sourceIds": [
+      "10",
+      "9"
+    ],
+    "steps": [
+      {
+        "id": "21",
+        "sourceIds": [
+          "0"
+        ],
+        "text": "the minimalism inside a background"
+      },
+      {
+        "id": "22",
+        "sourceIds": [
+          "5"
+        ],
+        "text": "a rule background step"
+      },
+      {
+        "id": "23",
+        "sourceIds": [
+          "6",
+          "9"
+        ],
+        "text": "the 2 minimalism"
+      }
+    ],
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/testdata/good/complex_background.feature.source.ndjson
+++ b/gherkin/testdata/good/complex_background.feature.source.ndjson
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "data": "Feature: Complex background\n  We want to ensure PickleStep all have different IDs\n\n  Background: a simple background\n    Given the minimalism inside a background\n\n  Scenario: minimalistic\n    Given the minimalism\n\n  Scenario: also minimalistic\n    Given the minimalism\n\n  Rule: My Rule\n\n    Background:\n      Given a rule background step\n\n    Scenario: with examples\n      Given the <value> minimalism\n\n      Examples:\n      | value |\n      | 1     |\n      | 2     |\n",
+    "media": {
+      "contentType": "text/x.cucumber.gherkin+plain",
+      "encoding": "UTF8"
+    },
+    "uri": "testdata/good/complex_background.feature"
+  }
+}

--- a/gherkin/testdata/good/complex_background.feature.tokens
+++ b/gherkin/testdata/good/complex_background.feature.tokens
@@ -1,0 +1,25 @@
+(1:1)FeatureLine:Feature/Complex background/
+(2:1)Other:/  We want to ensure PickleStep all have different IDs/
+(3:1)Other://
+(4:3)BackgroundLine:Background/a simple background/
+(5:5)StepLine:Given /the minimalism inside a background/
+(6:1)Empty://
+(7:3)ScenarioLine:Scenario/minimalistic/
+(8:5)StepLine:Given /the minimalism/
+(9:1)Empty://
+(10:3)ScenarioLine:Scenario/also minimalistic/
+(11:5)StepLine:Given /the minimalism/
+(12:1)Empty://
+(13:3)RuleLine:Rule/My Rule/
+(14:1)Empty://
+(15:5)BackgroundLine:Background//
+(16:7)StepLine:Given /a rule background step/
+(17:1)Empty://
+(18:5)ScenarioLine:Scenario/with examples/
+(19:7)StepLine:Given /the <value> minimalism/
+(20:1)Empty://
+(21:7)ExamplesLine:Examples//
+(22:7)TableRow://9:value
+(23:7)TableRow://9:1
+(24:7)TableRow://9:2
+EOF

--- a/gherkin/testdata/good/incomplete_scenario.feature.pickles.ndjson
+++ b/gherkin/testdata/good/incomplete_scenario.feature.pickles.ndjson
@@ -1,6 +1,6 @@
 {
   "pickle": {
-    "id": "3",
+    "id": "2",
     "language": "en",
     "name": "no steps",
     "sourceIds": [

--- a/gherkin/testdata/good/rule.feature.pickles.ndjson
+++ b/gherkin/testdata/good/rule.feature.pickles.ndjson
@@ -34,7 +34,7 @@
 }
 {
   "pickle": {
-    "id": "11",
+    "id": "12",
     "language": "en",
     "name": "Example B",
     "sourceIds": [
@@ -42,14 +42,14 @@
     ],
     "steps": [
       {
-        "id": "6",
+        "id": "10",
         "sourceIds": [
           "0"
         ],
         "text": "fb"
       },
       {
-        "id": "10",
+        "id": "11",
         "sourceIds": [
           "4"
         ],


### PR DESCRIPTION
## Summary

When `gherkin` computes the pickles in a feature file containing a `Background`, the `PickleStep` originating from the background all share the same `id` (which is obviously bad).

This fixes it.

## How Has This Been Tested?

The feature testing the background has now 2 scenarios (and the GOLDEN Json generated from it shows 2 different ids for the steps).
Also, a new `complex_background.feature` file has been added, with a `Background`, another `Background` inside a `Rule`and also a scenario with examples.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
