### PR TITLE
Support doc strings and data tables

### DIFF
--- a/fake-cucumber/javascript/src/ExpressionStepDefinition.ts
+++ b/fake-cucumber/javascript/src/ExpressionStepDefinition.ts
@@ -20,10 +20,16 @@ export default class ExpressionStepDefinition implements IStepDefinition {
   public match(
     pickleStep: messages.Pickle.IPickleStep
   ): SupportCodeExecutor | null {
-    const args = this.getArguments(pickleStep.text)
-    return args === null
+    const expressionArgs = this.getArguments(pickleStep.text)
+    return expressionArgs === null
       ? null
-      : new SupportCodeExecutor(this.id, this.body, args)
+      : new SupportCodeExecutor(
+          this.id,
+          this.body,
+          expressionArgs,
+          pickleStep.argument && pickleStep.argument.docString,
+          pickleStep.argument && pickleStep.argument.dataTable
+        )
   }
 
   public getArguments(text: string): Array<Argument<any>> {

--- a/fake-cucumber/javascript/src/SupportCodeExecutor.ts
+++ b/fake-cucumber/javascript/src/SupportCodeExecutor.ts
@@ -1,28 +1,43 @@
-import { Argument } from 'cucumber-expressions'
+import { Argument, Group } from 'cucumber-expressions'
 import { messages } from 'cucumber-messages'
 
 export default class SupportCodeExecutor {
   constructor(
     public readonly stepDefinitionId: string,
     private readonly body: (...args: any) => any,
-    private readonly args: Array<Argument<any>>
+    private readonly args: Array<Argument<any>>,
+    private readonly docString: messages.PickleStepArgument.IPickleDocString,
+    private readonly dataTable: messages.PickleStepArgument.IPickleTable
   ) {}
 
   public execute(): any {
     const thisObj: any = null
-    return this.body.apply(
-      thisObj,
-      this.args.map(arg => arg.getValue(thisObj))
-    )
+    const argArray = this.args.map(arg => arg.getValue(thisObj))
+    if (this.docString) {
+      // TODO: Hand off to DocStringTransformer
+      argArray.push(this.docString.content)
+    }
+    if (this.dataTable) {
+      // TODO: Hand off to DataTableTransformer
+      argArray.push(this.dataTable.rows.map(r => r.cells.map(c => c.value)))
+    }
+    return this.body.apply(thisObj, argArray)
   }
 
   public argsToMessages(): messages.IStepMatchArgument[] {
     return this.args.map(arg => {
       return new messages.StepMatchArgument({
-        // TODO: add recursive transformation.
-        group: arg.group,
+        group: toMessageGroup(arg.group),
         parameterTypeName: arg.parameterType.name,
       })
     })
   }
+}
+
+function toMessageGroup(group: Group): messages.StepMatchArgument.IGroup {
+  return new messages.StepMatchArgument.Group({
+    value: group.value,
+    start: group.start,
+    children: group.children.map(g => toMessageGroup(g)),
+  })
 }

--- a/fake-cucumber/javascript/src/TestStep.ts
+++ b/fake-cucumber/javascript/src/TestStep.ts
@@ -35,6 +35,7 @@ export default class TestStep {
       return this.emitTestStepFinished(
         testCaseStartedId,
         messages.TestResult.Status.UNDEFINED,
+        null,
         notifier
       )
     }
@@ -43,6 +44,7 @@ export default class TestStep {
       return this.emitTestStepFinished(
         testCaseStartedId,
         messages.TestResult.Status.AMBIGUOUS,
+        null,
         notifier
       )
     }
@@ -54,12 +56,14 @@ export default class TestStep {
         result === 'pending'
           ? messages.TestResult.Status.PENDING
           : messages.TestResult.Status.PASSED,
+        null,
         notifier
       )
     } catch (error) {
       return this.emitTestStepFinished(
         testCaseStartedId,
         messages.TestResult.Status.FAILED,
+        error.message,
         notifier
       )
     }
@@ -72,6 +76,7 @@ export default class TestStep {
     return this.emitTestStepFinished(
       testCaseStartedId,
       messages.TestResult.Status.SKIPPED,
+      null,
       notifier
     )
   }
@@ -93,6 +98,7 @@ export default class TestStep {
   protected emitTestStepFinished(
     testCaseStartedId: string,
     status: messages.TestResult.Status,
+    message: string,
     notifier: MessageNotifier
   ): messages.TestResult.Status {
     notifier(
@@ -102,6 +108,7 @@ export default class TestStep {
           testStepId: this.id,
           testResult: new messages.TestResult({
             status,
+            message,
             duration: new messages.Duration({
               seconds: 123,
               nanos: 456,

--- a/fake-cucumber/javascript/test/TestCaseTest.ts
+++ b/fake-cucumber/javascript/test/TestCaseTest.ts
@@ -13,7 +13,12 @@ class StubTestStep extends TestStep {
     notifier: MessageNotifier,
     testCaseStartedId: string
   ): messages.TestResult.Status {
-    return this.emitTestStepFinished(testCaseStartedId, this.status, notifier)
+    return this.emitTestStepFinished(
+      testCaseStartedId,
+      this.status,
+      null,
+      notifier
+    )
   }
 }
 

--- a/fake-cucumber/javascript/test/TestHelpers.ts
+++ b/fake-cucumber/javascript/test/TestHelpers.ts
@@ -32,7 +32,9 @@ export function stubMatchingStepDefinition(
   executor: SupportCodeExecutor = new SupportCodeExecutor(
     'some-id',
     () => null,
-    []
+    [],
+    null,
+    null
   )
 ): ExpressionStepDefinition {
   const stepDefinitionStub = stubConstructor(ExpressionStepDefinition)


### PR DESCRIPTION
## Summary

Support `DocString` and `DataTable` in `fake-cucumber`

## Details

For now, we just grab the `DocString#value` and the `DataTable`is transformed into a `string[][]`. This can be made pluggable later so users can provide their own converters (as Cucumber-JVM has)

