### PR TITLE
Json formatter attachments

### DIFF
--- a/fake-cucumber/javascript/src/ITestStep.ts
+++ b/fake-cucumber/javascript/src/ITestStep.ts
@@ -1,5 +1,6 @@
 import { messages } from 'cucumber-messages'
 import { MessageNotifier } from './types'
+import IWorld from './IWorld'
 
 export default interface ITestStep {
   sourceId: string
@@ -8,6 +9,7 @@ export default interface ITestStep {
   toMessage(): messages.TestCase.ITestStep
 
   execute(
+    world: IWorld,
     notifier: MessageNotifier,
     testCaseStartedId: string
   ): messages.ITestResult

--- a/fake-cucumber/javascript/src/IWorld.ts
+++ b/fake-cucumber/javascript/src/IWorld.ts
@@ -1,0 +1,3 @@
+export default interface IWorld {
+  attach(data: string, contentType: string): void
+}

--- a/fake-cucumber/javascript/src/IWorld.ts
+++ b/fake-cucumber/javascript/src/IWorld.ts
@@ -1,3 +1,4 @@
 export default interface IWorld {
+  testStepId: string
   attach(data: string, contentType: string): void
 }

--- a/fake-cucumber/javascript/src/SupportCodeExecutor.ts
+++ b/fake-cucumber/javascript/src/SupportCodeExecutor.ts
@@ -1,5 +1,6 @@
 import { Argument, Group } from 'cucumber-expressions'
 import { messages } from 'cucumber-messages'
+import IWorld from './IWorld'
 
 export default class SupportCodeExecutor {
   constructor(
@@ -10,8 +11,7 @@ export default class SupportCodeExecutor {
     private readonly dataTable: messages.PickleStepArgument.IPickleTable
   ) {}
 
-  public execute(): any {
-    const thisObj: any = null
+  public execute(thisObj: IWorld): any {
     const argArray = this.args.map(arg => arg.getValue(thisObj))
     if (this.docString) {
       // TODO: Hand off to DocStringTransformer

--- a/fake-cucumber/javascript/src/TestCase.ts
+++ b/fake-cucumber/javascript/src/TestCase.ts
@@ -8,6 +8,8 @@ import IWorld from './IWorld'
 const { millisecondsToDuration } = TimeConversion
 
 class DefaultWorld implements IWorld {
+  public testStepId: string
+
   constructor(
     public readonly attach: (data: any, contentType: string) => void
   ) {}
@@ -47,14 +49,17 @@ export default class TestCase {
 
     const start = performance.now()
 
-    const attach = (data: string, contentType: string) => {
+    function attach(data: string, contentType: string) {
+      if (!this.testStepId) {
+        throw new Error(`this.testStepId is not set`)
+      }
       const encoding = messages.Media.Encoding.UTF8 // TODO: Use Base64 is the data is a Buffer (objects will be JSONified)
       notifier(
         new messages.Envelope({
           attachment: new messages.Attachment({
             data,
             testCaseStartedId,
-            testStepId: 'TODO FIX ME!!!',
+            testStepId: this.testStepId,
             media: new messages.Media({
               contentType,
               encoding,

--- a/fake-cucumber/javascript/src/TestStep.ts
+++ b/fake-cucumber/javascript/src/TestStep.ts
@@ -46,6 +46,7 @@ export default abstract class TestStep implements ITestStep {
 
     const start = performance.now()
     try {
+      world.testStepId = this.id
       const result = this.supportCodeExecutors[0].execute(world)
       const finish = performance.now()
       const duration = millisecondsToDuration(finish - start)

--- a/fake-cucumber/javascript/src/TestStep.ts
+++ b/fake-cucumber/javascript/src/TestStep.ts
@@ -4,6 +4,7 @@ import uuidv4 from 'uuid/v4'
 import SupportCodeExecutor from './SupportCodeExecutor'
 import { MessageNotifier } from './types'
 import ITestStep from './ITestStep'
+import IWorld from './IWorld'
 const { millisecondsToDuration } = TimeConversion
 
 export default abstract class TestStep implements ITestStep {
@@ -17,6 +18,7 @@ export default abstract class TestStep implements ITestStep {
   public abstract toMessage(): messages.TestCase.ITestStep
 
   public execute(
+    world: IWorld,
     notifier: MessageNotifier,
     testCaseStartedId: string
   ): messages.ITestResult {
@@ -44,7 +46,7 @@ export default abstract class TestStep implements ITestStep {
 
     const start = performance.now()
     try {
-      const result = this.supportCodeExecutors[0].execute()
+      const result = this.supportCodeExecutors[0].execute(world)
       const finish = performance.now()
       const duration = millisecondsToDuration(finish - start)
       return this.emitTestStepFinished(

--- a/fake-cucumber/javascript/src/makeDummyStepDefinitions.ts
+++ b/fake-cucumber/javascript/src/makeDummyStepDefinitions.ts
@@ -1,9 +1,5 @@
 import ExpressionStepDefinition from './ExpressionStepDefinition'
-import {
-  CucumberExpression,
-  RegularExpression,
-  ParameterTypeRegistry,
-} from 'cucumber-expressions'
+import { CucumberExpression, ParameterTypeRegistry } from 'cucumber-expressions'
 import IStepDefinition from './IStepDefinition'
 
 export default function makeDummyStepDefinitions(): IStepDefinition[] {
@@ -14,8 +10,17 @@ export default function makeDummyStepDefinitions(): IStepDefinition[] {
       (thing: string) => undefined
     ),
     new ExpressionStepDefinition(
-      new RegularExpression(/a passed step .*/, parameterTypeRegistry),
-      (thing: string) => undefined
+      new CucumberExpression('a passed {word} with', parameterTypeRegistry),
+      (thing: string, dataTableOrDocString) => undefined
+    ),
+    new ExpressionStepDefinition(
+      new CucumberExpression(
+        'a passed {word} with text attachment {string}',
+        parameterTypeRegistry
+      ),
+      function(thing: string, textAttachment) {
+        this.attach(textAttachment, 'text/plain')
+      }
     ),
     new ExpressionStepDefinition(
       new CucumberExpression(
@@ -31,9 +36,13 @@ export default function makeDummyStepDefinitions(): IStepDefinition[] {
       }
     ),
     new ExpressionStepDefinition(
-      new RegularExpression(/a failed step .*/, parameterTypeRegistry),
-      (thing: string) => {
-        throw new Error(`This step failed. The thing was "${thing}"`)
+      new CucumberExpression('a failed {word} with', parameterTypeRegistry),
+      (thing: string, dataTableOrDocString) => {
+        throw new Error(
+          `This step failed. The thing was "${thing}" and the dataTable/docString was ${JSON.stringify(
+            dataTableOrDocString
+          )}`
+        )
       }
     ),
     new ExpressionStepDefinition(

--- a/fake-cucumber/javascript/test/HookTest.ts
+++ b/fake-cucumber/javascript/test/HookTest.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 import { HookType } from '../src/IHook'
 import Hook from '../src/Hook'
 import { messages } from 'cucumber-messages'
+import TestWorld from './TestWorld'
 
 describe('Hook', () => {
   describe('#match', () => {
@@ -26,7 +27,7 @@ describe('Hook', () => {
       })
       const executor = hook.match(pickle, HookType.Before)
 
-      assert.strictEqual(executor.execute(), 'something')
+      assert.strictEqual(executor.execute(new TestWorld()), 'something')
     })
 
     it('returns a SupportCodeExecutor if the hook has no tag expression', () => {
@@ -38,7 +39,7 @@ describe('Hook', () => {
       })
       const executor = hook.match(pickle, HookType.Before)
 
-      assert.strictEqual(executor.execute(), 'something')
+      assert.strictEqual(executor.execute(new TestWorld()), 'something')
     })
 
     it('does not return a SupportCodeExecutor if the hook type does not match', () => {

--- a/fake-cucumber/javascript/test/StepDefinitionTest.ts
+++ b/fake-cucumber/javascript/test/StepDefinitionTest.ts
@@ -3,6 +3,7 @@ import { messages } from 'cucumber-messages'
 import ExpressionStepDefinition from '../src/ExpressionStepDefinition'
 import { CucumberExpression, ParameterTypeRegistry } from 'cucumber-expressions'
 import RegularExpression from 'cucumber-expressions/dist/src/RegularExpression'
+import TestWorld from './TestWorld'
 
 describe('StepDefinition', () => {
   describe('#match', () => {
@@ -32,12 +33,12 @@ describe('StepDefinition', () => {
         text: 'I have 7 cukes',
       })
       const executor = stepdef.match(pickleStep)
-      assert.strictEqual(executor.execute(), 7)
+      assert.strictEqual(executor.execute(new TestWorld()), 7)
     })
   })
 
   describe('#toMessage', () => {
-    it('generates a StepDefinitionConfig object for RegularExpression', () => {
+    it('generates a StepDefinition object for RegularExpression', () => {
       const expression = new RegularExpression(
         /banana/,
         new ParameterTypeRegistry()
@@ -51,7 +52,7 @@ describe('StepDefinition', () => {
       )
     })
 
-    it('generates a StepDefinitionConfig object for CucumberExpression', () => {
+    it('generates a StepDefinition object for CucumberExpression', () => {
       const expression = new CucumberExpression(
         'banana',
         new ParameterTypeRegistry()

--- a/fake-cucumber/javascript/test/SupportCodeExecutorTest.ts
+++ b/fake-cucumber/javascript/test/SupportCodeExecutorTest.ts
@@ -16,6 +16,7 @@ describe('SupportCodeExecutor', () => {
 
     let attachedData: string
     const world = {
+      testStepId: 'some-test-step-id',
       attach(data: string, contentType: string) {
         attachedData = data
       },

--- a/fake-cucumber/javascript/test/SupportCodeExecutorTest.ts
+++ b/fake-cucumber/javascript/test/SupportCodeExecutorTest.ts
@@ -1,0 +1,27 @@
+import SupportCodeExecutor from '../src/SupportCodeExecutor'
+import assert from 'assert'
+
+describe('SupportCodeExecutor', () => {
+  it('can attach attachments', () => {
+    function body() {
+      this.attach('hello', 'text/plain')
+    }
+    const executor = new SupportCodeExecutor(
+      'step-definition-id',
+      body,
+      [],
+      null,
+      null
+    )
+
+    let attachedData: string
+    const world = {
+      attach(data: string, contentType: string) {
+        attachedData = data
+      },
+    }
+
+    executor.execute(world)
+    assert.strictEqual(attachedData, 'hello')
+  })
+})

--- a/fake-cucumber/javascript/test/TestCaseTest.ts
+++ b/fake-cucumber/javascript/test/TestCaseTest.ts
@@ -3,6 +3,7 @@ import assert from 'assert'
 import TestStep from '../src/TestStep'
 import TestCase from '../src/TestCase'
 import { MessageNotifier } from '../src/types'
+import IWorld from '../src/IWorld'
 const { millisecondsToDuration } = TimeConversion
 
 class StubTestStep extends TestStep {
@@ -18,6 +19,7 @@ class StubTestStep extends TestStep {
   }
 
   public execute(
+    world: IWorld,
     notifier: MessageNotifier,
     testCaseStartedId: string
   ): messages.ITestResult {

--- a/fake-cucumber/javascript/test/TestPlanTest.ts
+++ b/fake-cucumber/javascript/test/TestPlanTest.ts
@@ -7,12 +7,15 @@ import { messages } from 'cucumber-messages'
 import { MessageNotifier } from '../src/types'
 import assert from 'assert'
 import TestPlan from '../src/TestPlan'
+import IStepDefinition from '../src/IStepDefinition'
+import { CucumberExpression, ParameterTypeRegistry } from 'cucumber-expressions'
+import ExpressionStepDefinition from '../src/ExpressionStepDefinition'
 
 describe('TestPlan', () => {
   it('executes test cases', async () => {
     const stepDefinition = stubMatchingStepDefinition()
 
-    const gherkinMessageList = await streamToArray(
+    const gherkinEnvelopes = await streamToArray(
       gherkinMessages(
         `Feature: test
   Scenario: test
@@ -22,11 +25,42 @@ describe('TestPlan', () => {
       )
     )
 
-    const pickles = gherkinMessageList.filter(m => m.pickle).map(m => m.pickle)
+    const pickles = gherkinEnvelopes.filter(m => m.pickle).map(m => m.pickle)
     const testPlan = new TestPlan(pickles, [stepDefinition], [])
-    const messageList: messages.IEnvelope[] = []
-    const notifier: MessageNotifier = message => messageList.push(message)
+    const envelopes: messages.IEnvelope[] = []
+    const notifier: MessageNotifier = message => envelopes.push(message)
     testPlan.execute(notifier)
-    assert.deepStrictEqual(messageList.length, 5)
+    assert.deepStrictEqual(envelopes.length, 5)
+  })
+
+  it('attaches attachments from support code', async () => {
+    const stepDefinition: IStepDefinition = new ExpressionStepDefinition(
+      new CucumberExpression('a passed step', new ParameterTypeRegistry()),
+      function() {
+        this.attach('hello world', 'text/plain')
+      }
+    )
+
+    const gherkinEnvelopes = await streamToArray(
+      gherkinMessages(
+        `Feature: test
+  Scenario: test
+    Given a passed step
+`,
+        'test.feature'
+      )
+    )
+
+    const pickles = gherkinEnvelopes.filter(m => m.pickle).map(m => m.pickle)
+    const testPlan = new TestPlan(pickles, [stepDefinition], [])
+    const envelopes: messages.IEnvelope[] = []
+    const notifier: MessageNotifier = message => envelopes.push(message)
+    testPlan.execute(notifier)
+
+    const attachments = envelopes
+      .filter(m => m.attachment)
+      .map(m => m.attachment)
+    assert.deepStrictEqual(attachments.length, 1)
+    assert.strictEqual(attachments[0].data, 'hello world')
   })
 })

--- a/fake-cucumber/javascript/test/TestWorld.ts
+++ b/fake-cucumber/javascript/test/TestWorld.ts
@@ -1,0 +1,17 @@
+import IWorld from '../src/IWorld'
+import { messages } from 'cucumber-messages'
+
+export default class TestWorld implements IWorld {
+  public readonly attachments: messages.Attachment[] = []
+
+  public attach(data: string, contentType: string): void {
+    const attachment = new messages.Attachment({
+      data,
+      media: new messages.Media({
+        contentType: 'text/plain',
+        encoding: messages.Media.Encoding.UTF8,
+      }),
+    })
+    this.attachments.push(attachment)
+  }
+}

--- a/fake-cucumber/javascript/test/TestWorld.ts
+++ b/fake-cucumber/javascript/test/TestWorld.ts
@@ -2,6 +2,7 @@ import IWorld from '../src/IWorld'
 import { messages } from 'cucumber-messages'
 
 export default class TestWorld implements IWorld {
+  public testStepId: string
   public readonly attachments: messages.Attachment[] = []
 
   public attach(data: string, contentType: string): void {

--- a/json-formatter/go/json_elements.go
+++ b/json-formatter/go/json_elements.go
@@ -25,13 +25,14 @@ type jsonFeatureElement struct {
 }
 
 type jsonStep struct {
-	Keyword   string              `json:"keyword,omitempty"`
-	Line      uint32              `json:"line,omitempty"`
-	Name      string              `json:"name,omitempty"`
-	Result    *jsonStepResult     `json:"result"`
-	Match     *jsonStepMatch      `json:"match,omitempty"`
-	DocString *jsonDocString      `json:"doc_string,omitempty"`
-	Rows      []*jsonDatatableRow `json:"rows,omitempty"`
+	Keyword    string              `json:"keyword,omitempty"`
+	Line       uint32              `json:"line,omitempty"`
+	Name       string              `json:"name,omitempty"`
+	Result     *jsonStepResult     `json:"result"`
+	Match      *jsonStepMatch      `json:"match,omitempty"`
+	DocString  *jsonDocString      `json:"doc_string,omitempty"`
+	Rows       []*jsonDatatableRow `json:"rows,omitempty"`
+	Embeddings []*jsonEmbedding    `json:"embeddings,omitempty"`
 }
 
 type jsonDocString struct {
@@ -57,4 +58,9 @@ type jsonStepMatch struct {
 type jsonTag struct {
 	Line uint32 `json:"line"`
 	Name string `json:"name"`
+}
+
+type jsonEmbedding struct {
+	Data     string `json:"data"`
+	MimeType string `json:"mime_type"`
 }

--- a/json-formatter/ruby/features/step_definitions/steps.rb
+++ b/json-formatter/ruby/features/step_definitions/steps.rb
@@ -4,6 +4,10 @@ end
 Given("a passed {word} with") do |word, arg|
 end
 
+Given("a passed {word} with attachment") do |word|
+  embed('hello world', 'text/plain')
+end
+
 When("a failed {word}") do |word|
   raise "Some error"
 end

--- a/json-formatter/ruby/features/step_definitions/steps.rb
+++ b/json-formatter/ruby/features/step_definitions/steps.rb
@@ -4,8 +4,8 @@ end
 Given("a passed {word} with") do |word, arg|
 end
 
-Given("a passed {word} with attachment") do |word|
-  embed('hello world', 'text/plain')
+Given("a passed {word} with text attachment {string}") do |word, attachment_text|
+  embed(attachment_text, 'text/plain')
 end
 
 When("a failed {word}") do |word|

--- a/json-formatter/ruby/features/test_attachment.feature
+++ b/json-formatter/ruby/features/test_attachment.feature
@@ -1,4 +1,4 @@
 Feature: Attachment
 
   Scenario: A scenario
-    Given a passed step with attachment
+    Given a passed step with text attachment "Hello there!"

--- a/json-formatter/ruby/features/test_attachment.feature
+++ b/json-formatter/ruby/features/test_attachment.feature
@@ -1,0 +1,4 @@
+Feature: Attachment
+
+  Scenario: A scenario
+    Given a passed step with attachment

--- a/json-formatter/ruby/features/test_basic.feature
+++ b/json-formatter/ruby/features/test_basic.feature
@@ -1,4 +1,4 @@
 Feature: Basic
 
-Scenario: A scenario
-  Given a passed step
+  Scenario: A scenario
+    Given a passed step


### PR DESCRIPTION
This is the start of supporting attachments in the json formatter. It requires a change in fake cucumber to output attachment messages. The API is modelled after cucumber-js.