### PR TITLE
cucumber-messages/gherkin: Fix shaded dependencies

### DIFF
--- a/.templates/java/scripts/check-jar.sh
+++ b/.templates/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/c21e/java/scripts/check-jar.sh
+++ b/c21e/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/config/java/scripts/check-jar.sh
+++ b/config/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/cucumber-expressions/java/scripts/check-jar.sh
+++ b/cucumber-expressions/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/cucumber-messages/java/pom.xml
+++ b/cucumber-messages/java/pom.xml
@@ -60,10 +60,13 @@
                                 <includes>
                                     <include>com.google.protobuf:protobuf-java</include>
                                     <include>com.google.protobuf:protobuf-java-util</include>
-                                    <include>com.google.code.gson:gson</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>google.protobuf</pattern>
+                                    <shadedPattern>io.cucumber.messages.internal.google.protobuf</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>io.cucumber.messages.internal.com.google</shadedPattern>

--- a/cucumber-messages/java/pom.xml
+++ b/cucumber-messages/java/pom.xml
@@ -60,6 +60,7 @@
                                 <includes>
                                     <include>com.google.protobuf:protobuf-java</include>
                                     <include>com.google.protobuf:protobuf-java-util</include>
+                                    <include>com.google.code.gson:gson</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/cucumber-messages/java/scripts/check-jar.sh
+++ b/cucumber-messages/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/datatable/java/scripts/check-jar.sh
+++ b/datatable/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/gherkin/java/pom.xml
+++ b/gherkin/java/pom.xml
@@ -72,6 +72,11 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.eclipsesource.minimal-json:minimal-json</include>
+                                </includes>
+                            </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>com.eclipsesource.json</pattern>

--- a/gherkin/java/scripts/check-jar.sh
+++ b/gherkin/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo

--- a/tag-expressions/java/scripts/check-jar.sh
+++ b/tag-expressions/java/scripts/check-jar.sh
@@ -7,8 +7,10 @@ set -uf -o pipefail
 
 check_jar() {
   jar="$1"
+  module_name=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0"  -t -m "//pom:project.Automatic-Module-Name" -v . pom.xml)
+  module_path=$(echo $module_name | sed "s/\./\\\\\//g")
   echo "Checking contents of ${jar}"
-  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^io\/cucumber\/")
+  unshaded_classes=$(unzip -l ${jar} | grep -e "\.class" | rev | cut -d' ' -f1 | rev | grep -v "^$module_path")
   if [[ "${unshaded_classes}" != "" ]]; then
     echo "Some classes in ${jar} are not in the io.cucumber package. Rename the classes or change the maven-shade-plugin configuration."
     echo


### PR DESCRIPTION
## Summary

Fixes incorrectly shaded dependencies and adds a script to ensure all classes are within the module path of the jar file.

## Details

`cucumber-message` did not relocate the `google.protobuf` package.
`gherkin` shaded the `cucumber-messages` dependency.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
