### PR TITLE
StepDefinition.sourceReference should be StepDefinition.source_reference

### DIFF
--- a/cucumber-messages/dotnet/messages.proto
+++ b/cucumber-messages/dotnet/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {

--- a/cucumber-messages/go/messages.proto
+++ b/cucumber-messages/go/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {

--- a/cucumber-messages/java/messages.proto
+++ b/cucumber-messages/java/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {

--- a/cucumber-messages/javascript/messages.proto
+++ b/cucumber-messages/javascript/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {

--- a/cucumber-messages/messages.proto
+++ b/cucumber-messages/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {

--- a/cucumber-messages/ruby/messages.proto
+++ b/cucumber-messages/ruby/messages.proto
@@ -612,7 +612,7 @@ message Hook {
 message StepDefinition {
   string id = 1;
   StepDefinitionPattern pattern = 2;
-  SourceReference sourceReference = 3;
+  SourceReference source_reference = 3;
 }
 
 message StepDefinitionPattern {


### PR DESCRIPTION
## Summary

This follows-up #816, one of the field is still in camelCase.

## Details

Change `StepDefinition.sourceReference` to `StepDefinition.source_reference`

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
