### PR TITLE
datatable: Replace wildcard type with its upper bound

### DIFF
--- a/datatable/CHANGELOG.md
+++ b/datatable/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
+ * [Java] Replace wildcard type with its upper bound
+    ([#829](https://github.com/cucumber/cucumber/pull/829)
+    [mpkorstanje])
+    
 ## [3.0.0] - 2019-08-17
 
 ### Added
@@ -29,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  * [Java] Remove shaded dependency on Jackson Databind
     ([#682](https://github.com/cucumber/cucumber/pull/682)
     [#679](https://github.com/cucumber/cucumber/issues/679)
-    M.P. Korstanje)
+    [mpkorstanje])
 ### Fixed
 
 ## [2.0.0] 2019-08-11

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -71,10 +71,13 @@ public final class DataTableTypeRegistry {
         if (existing != null) {
             throw new DuplicateTypeException(format(
                     "There is already a data table type registered for %s.\n" +
-                            "It registered an %s. You are trying to add a %s",
+                            "It registered an %s for %s.\n" +
+                            "You are trying to add a %s for %s.",
                     dataTableType.getElementType(),
+                    existing.getTransformerType().getSimpleName(),
+                    existing.getElementType(),
                     dataTableType.getTransformerType().getSimpleName(),
-                    existing.getTransformerType().getSimpleName()
+                    dataTableType.getElementType()
             ));
         }
         tableTypeByType.put(dataTableType.getTargetType(), dataTableType);

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -71,7 +71,7 @@ public final class DataTableTypeRegistry {
         if (existing != null) {
             throw new DuplicateTypeException(format(
                     "There is already a data table type registered for %s.\n" +
-                            "It registered an %s for %s.\n" +
+                            "It registered a %s for %s.\n" +
                             "You are trying to add a %s for %s.",
                     dataTableType.getElementType(),
                     existing.getTransformerType().getSimpleName(),

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -69,15 +69,15 @@ public final class DataTableTypeRegistry {
     public void defineDataTableType(DataTableType dataTableType) {
         DataTableType existing = tableTypeByType.get(dataTableType.getTargetType());
         if (existing != null) {
-            throw new DuplicateTypeException(format(
-                    "There is already a data table type registered for %s.\n" +
-                            "It registered a %s for %s.\n" +
-                            "You are trying to add a %s for %s.",
+            throw new DuplicateTypeException(format("" +
+                            "There already is a data table type registered that can supply %s.\n" +
+                            "You are trying to register a %s for %s.\n" +
+                            "The existing data table type registered a %s for %s.\n",
+                    dataTableType.getElementType(),
+                    dataTableType.getTransformerType().getSimpleName(),
                     dataTableType.getElementType(),
                     existing.getTransformerType().getSimpleName(),
-                    existing.getElementType(),
-                    dataTableType.getTransformerType().getSimpleName(),
-                    dataTableType.getElementType()
+                    existing.getElementType()
             ));
         }
         tableTypeByType.put(dataTableType.getTargetType(), dataTableType);

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -57,9 +57,9 @@ class DataTableTypeRegistryTest {
                 )));
 
         assertThat(exception.getMessage(), is("" +
-                "There is already a data table type registered for class io.cucumber.datatable.Place.\n" +
-                "It registered an TableTransformer for class io.cucumber.datatable.Place.\n" +
-                "You are trying to add a TableTransformer for class io.cucumber.datatable.Place."
+                "There already is a data table type registered that can supply class io.cucumber.datatable.Place.\n" +
+                "You are trying to register a TableTransformer for class io.cucumber.datatable.Place.\n" +
+                "The existing data table type registered a TableTransformer for class io.cucumber.datatable.Place.\n"
         ));
     }
 

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -58,7 +58,8 @@ class DataTableTypeRegistryTest {
 
         assertThat(exception.getMessage(), is("" +
                 "There is already a data table type registered for class io.cucumber.datatable.Place.\n" +
-                "It registered an TableTransformer. You are trying to add a TableTransformer"
+                "It registered an TableTransformer for class io.cucumber.datatable.Place.\n" +
+                "You are trying to add a TableTransformer for class io.cucumber.datatable.Place."
         ));
     }
 

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/TypeFactoryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/TypeFactoryTest.java
@@ -27,11 +27,11 @@ class TypeFactoryTest {
     }.getType();
     private static final Type MAP_OF_OBJECT_OBJECT = new TypeReference<Map<Object, Object>>() {
     }.getType();
-
-    private static final Type OPTIONAL_OBJECT = new TypeReference<Optional<Object>>() {
+    private static final Type OPTIONAL_NUMBER = new TypeReference<Optional<Number>>() {
+    }.getType();
+    private static final Type OPTIONAL_WILD_CARD_NUMBER = new TypeReference<Optional<? extends Number>>() {
     }.getType();
     private static final Type UNKNOWN_TYPE = new Type() {
-
     };
 
     @Test
@@ -119,10 +119,10 @@ class TypeFactoryTest {
     }
 
     @Test
-    void other_generic_types_are_other_type() {
-        JavaType javaType = TypeFactory.constructType(OPTIONAL_OBJECT);
-        assertThat(javaType.getClass(), equalTo(TypeFactory.OtherType.class));
-        assertThat(javaType.getOriginal(), is(OPTIONAL_OBJECT));
+    void other_generic_types_are_parameterized_type() {
+        JavaType javaType = TypeFactory.constructType(OPTIONAL_NUMBER);
+        assertThat(javaType.getClass(), equalTo(TypeFactory.Parameterized.class));
+        assertThat(javaType.getOriginal(), is(OPTIONAL_NUMBER));
     }
 
     @Test
@@ -149,7 +149,7 @@ class TypeFactoryTest {
     }
 
     @Test
-    void wild_card_types_use_upper_bound_in_equality() {
+    void wild_card_list_types_use_upper_bound_in_equality() {
         JavaType javaType = TypeFactory.constructType(LIST_OF_WILD_CARD_NUMBER);
         JavaType other = TypeFactory.constructType(LIST_OF_NUMBER);
         assertThat(javaType, equalTo(other));
@@ -159,10 +159,28 @@ class TypeFactoryTest {
     }
 
     @Test
-    void upper_bound_of_wild_card_replaces_wild_card_type() {
+    void upper_bound_of_wild_card_list_type_replaces_wild_card_type() {
         JavaType javaType = TypeFactory.constructType(LIST_OF_WILD_CARD_NUMBER);
         TypeFactory.ListType listType = (TypeFactory.ListType) javaType;
         JavaType elementType = listType.getElementType();
+        assertThat(elementType.getOriginal(), equalTo(Number.class));
+    }
+
+    @Test
+    void wild_card_parameterized_types_use_upper_bound_in_equality() {
+        JavaType javaType = TypeFactory.constructType(OPTIONAL_WILD_CARD_NUMBER);
+        JavaType other = TypeFactory.constructType(OPTIONAL_NUMBER);
+        assertThat(javaType, equalTo(other));
+        TypeFactory.Parameterized parameterized = (TypeFactory.Parameterized) javaType;
+        JavaType elementType = parameterized.getElementTypes()[0];
+        assertThat(elementType.getOriginal(), equalTo(Number.class));
+    }
+
+    @Test
+    void upper_bound_of_wild_card_parameterized_type_replaces_wild_card_type() {
+        JavaType javaType = TypeFactory.constructType(OPTIONAL_WILD_CARD_NUMBER);
+        TypeFactory.Parameterized parameterized = (TypeFactory.Parameterized) javaType;
+        JavaType elementType = parameterized.getElementTypes()[0];
         assertThat(elementType.getOriginal(), equalTo(Number.class));
     }
 

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/TypeFactoryTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/TypeFactoryTest.java
@@ -21,8 +21,9 @@ class TypeFactoryTest {
     }.getType();
     private static final Type LIST_OF_LIST_OF_OBJECT = new TypeReference<List<List<Object>>>() {
     }.getType();
-
     private static final Type LIST_OF_WILD_CARD_NUMBER = new TypeReference<List<? extends Number>>() {
+    }.getType();
+    private static final Type LIST_OF_NUMBER = new TypeReference<List<Number>>() {
     }.getType();
     private static final Type MAP_OF_OBJECT_OBJECT = new TypeReference<Map<Object, Object>>() {
     }.getType();
@@ -146,4 +147,23 @@ class TypeFactoryTest {
                 "Type contained a type variable T. Types must explicit."
         ));
     }
+
+    @Test
+    void wild_card_types_use_upper_bound_in_equality() {
+        JavaType javaType = TypeFactory.constructType(LIST_OF_WILD_CARD_NUMBER);
+        JavaType other = TypeFactory.constructType(LIST_OF_NUMBER);
+        assertThat(javaType, equalTo(other));
+        TypeFactory.ListType listType = (TypeFactory.ListType) javaType;
+        JavaType elementType = listType.getElementType();
+        assertThat(elementType.getOriginal(), equalTo(Number.class));
+    }
+
+    @Test
+    void upper_bound_of_wild_card_replaces_wild_card_type() {
+        JavaType javaType = TypeFactory.constructType(LIST_OF_WILD_CARD_NUMBER);
+        TypeFactory.ListType listType = (TypeFactory.ListType) javaType;
+        JavaType elementType = listType.getElementType();
+        assertThat(elementType.getOriginal(), equalTo(Number.class));
+    }
+
 }


### PR DESCRIPTION
## Summary

When registering steps in Kotlin using Kotlin collections as an argument e.g:

```kotlin
@Given("orders with an order item and the following attributes:")
fun statusFilterOrdersInEs(attributes: Map<String, Map<String, String>>)
```

This argument is translated to Java type as

```java
Map<java.lang.String, ? extends java.util.Map<java.lang.String, java.lang.String>>
```

To handle this gracefully the simplified type system used by `DataTable`
should understand upper bounds. We do this by replacing the wild card type
with its upper bound.

We can assume this is safe because when registering a transformer to
`type ? extends SomeType` the transformer is guaranteed to produce an
object that is an instance of `SomeType`.

When transforming a data table to `? extends SomeType` a transformer that
produces `SomeType` is sufficient.

This will result in ambiguity between a transformers for `SomeType` and
transformers for ``? extends SomeType` but that seems reasonable and might be
resolved by using a more specific producer.

## Motivation and Context

https://github.com/cucumber/cucumber-jvm/issues/1838

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).