### PR TITLE
Add automatic linting and formatting

### DIFF
--- a/cucumber-expressions/ruby/.rubocop.yml
+++ b/cucumber-expressions/ruby/.rubocop.yml
@@ -1,0 +1,6 @@
+Layout/LineLength:
+  Max: 99
+
+Metrics/MethodLength:
+  Max: 20
+# Metrics/AbcSize

--- a/cucumber-expressions/ruby/Gemfile
+++ b/cucumber-expressions/ruby/Gemfile
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+
+source 'https://rubygems.org'
 gemspec

--- a/cucumber-expressions/ruby/Rakefile
+++ b/cucumber-expressions/ruby/Rakefile
@@ -1,21 +1,27 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-$:.unshift File.expand_path("../lib", __FILE__)
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
 
-Dir['./rake/*.rb'].each do |f|
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+
+Dir['./rake/*.rb'].sort.each do |f|
   require f
 end
 
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.ruby_opts  = %w[-r./spec/coverage -w]
+  t.ruby_opts = %w[-r./spec/coverage -w]
 end
 
 require_relative 'spec/capture_warnings'
+# rubocop:disable Style/MixinUsage:
 include CaptureWarnings
+# rubocop:enable Style/MixinUsage:
 namespace :spec do
   task :warnings do
     report_warnings do

--- a/cucumber-expressions/ruby/cucumber-expressions.gemspec
+++ b/cucumber-expressions/ruby/cucumber-expressions.gemspec
@@ -1,33 +1,33 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = 'cucumber-expressions'
   s.version     = '8.3.0'
-  s.authors     = ["Aslak Hellesøy"]
+  s.authors     = ['Aslak Hellesøy']
   s.description = 'Cucumber Expressions - a simpler alternative to Regular Expressions'
   s.summary     = "cucumber-expressions-#{s.version}"
   s.email       = 'cukes@googlegroups.com'
-  s.homepage    = "https://github.com/cucumber/cucumber-expressions-ruby#readme"
+  s.homepage    = 'https://github.com/cucumber/cucumber-expressions-ruby#readme'
   s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
-  s.required_ruby_version = ">= 2.3"
+  s.license     = 'MIT'
+  s.required_ruby_version = '>= 2.3'
 
-  s.metadata    = {
-                    'bug_tracker_uri'   => 'https://github.com/cucumber/cucumber/issues',
-                    'changelog_uri'     => 'https://github.com/cucumber/cucumber/blob/master/cucumber-expressions/CHANGELOG.md',
-                    'documentation_uri' => 'https://cucumber.io/docs/cucumber/cucumber-expressions/',
-                    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/cukes',
-                    'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/cucumber-expressions/ruby',
-                  }
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/cucumber/cucumber/issues',
+    'changelog_uri' => 'https://github.com/cucumber/cucumber/blob/master/cucumber-expressions/CHANGELOG.md',
+    'documentation_uri' => 'https://cucumber.io/docs/cucumber/cucumber-expressions/',
+    'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
+    'source_code_uri' => 'https://github.com/cucumber/cucumber/blob/master/cucumber-expressions/ruby'
+  }
 
+  s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
+  s.add_development_dependency 'rubocop', '~> 0.79', '>= 0.79.0'
 
-  # For coverage reports
-  s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'
-
-  s.rubygems_version = ">= 1.6.1"
-  s.files            = `git ls-files`.split("\n").reject {|path| path =~ /\.gitignore$/ }
+  s.rubygems_version = '>= 1.6.1'
+  s.files            = `git ls-files`.split("\n").reject { |path| path =~ /\.gitignore$/ }
   s.test_files       = `git ls-files -- spec/*`.split("\n")
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  s.rdoc_options     = ['--charset=UTF-8']
+  s.require_path     = 'lib'
 end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/argument.rb
@@ -1,34 +1,39 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/group'
 require 'cucumber/cucumber_expressions/errors'
 
 module Cucumber
   module CucumberExpressions
+    # An argument extracted from a match
     class Argument
       attr_reader :group, :parameter_type
 
+      # rubocop:disable Metrics/AbcSize
       def self.build(tree_regexp, text, parameter_types)
         group = tree_regexp.match(text)
         return nil if group.nil?
 
-        arg_groups = group.children
-
-        if arg_groups.length != parameter_types.length
-          raise CucumberExpressionError.new(
-              "Expression #{tree_regexp.regexp.inspect} has #{arg_groups.length} capture groups (#{arg_groups.map(&:value)}), but there were #{parameter_types.length} parameter types (#{parameter_types.map(&:name)})"
-          )
+        if group.children.length != parameter_types.length
+          # rubocop:disable Layout/LineLength
+          raise CucumberExpressionError, "Expression #{tree_regexp.regexp.inspect} has #{group.children.length} capture groups (#{group.children.map(&:value)}), but there were #{parameter_types.length} parameter types (#{parameter_types.map(&:name)})"
+          # rubocop:enable Layout/LineLength
         end
 
-        parameter_types.zip(arg_groups).map do |parameter_type, arg_group|
+        parameter_types.zip(group.children).map do |parameter_type, arg_group|
           Argument.new(arg_group, parameter_type)
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def initialize(group, parameter_type)
-        @group, @parameter_type = group, parameter_type
+        @group = group
+        @parameter_type = parameter_type
       end
 
-      def value(self_obj=:nil)
-        raise "No self_obj" if self_obj == :nil
+      def value(self_obj = :nil)
+        raise 'No self_obj' if self_obj == :nil
+
         group_values = @group ? @group.values : nil
         @parameter_type.transform(self_obj, group_values)
       end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/combinatorial_generated_expression_factory.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/combinatorial_generated_expression_factory.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require('cucumber/cucumber_expressions/generated_expression')
 
 module Cucumber
   module CucumberExpressions
-
+    # Generates multiple [GeneratedExpression] objects
     class CombinatorialGeneratedExpressionFactory
       def initialize(expression_template, parameter_type_combinations)
         @expression_template = expression_template
@@ -18,32 +20,33 @@ module Cucumber
       # 256 generated expressions ought to be enough for anybody
       MAX_EXPRESSIONS = 256
 
+      # rubocop:disable Metrics/AbcSize
       def generate_permutations(generated_expressions, depth, current_parameter_types)
-        if generated_expressions.length >= MAX_EXPRESSIONS
-          return
-        end
+        return if generated_expressions.length >= MAX_EXPRESSIONS
 
         if depth == @parameter_type_combinations.length
-          generated_expression = GeneratedExpression.new(@expression_template, current_parameter_types)
+          generated_expression = GeneratedExpression.new(
+            @expression_template,
+            current_parameter_types
+          )
           generated_expressions.push(generated_expression)
           return
         end
 
         (0...@parameter_type_combinations[depth].length).each do |i|
           # Avoid recursion if no elements can be added.
-          if generated_expressions.length >= MAX_EXPRESSIONS
-            return
-          end
+          break if generated_expressions.length >= MAX_EXPRESSIONS
+
           new_current_parameter_types = current_parameter_types.dup # clone
           new_current_parameter_types.push(@parameter_type_combinations[depth][i])
           generate_permutations(
-              generated_expressions,
-              depth + 1,
-              new_current_parameter_types
+            generated_expressions,
+            depth + 1,
+            new_current_parameter_types
           )
         end
       end
+      # rubocop:enable Metrics/AbcSize
     end
-
   end
 end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/parameter_type_matcher'
 require 'cucumber/cucumber_expressions/generated_expression'
 require 'cucumber/cucumber_expressions/combinatorial_generated_expression_factory'
 
 module Cucumber
   module CucumberExpressions
+    # Generates Cucumber Expressions from text (undefined steps)
     class CucumberExpressionGenerator
       def initialize(parameter_type_registry)
         @parameter_type_registry = parameter_type_registry
@@ -13,10 +16,11 @@ module Cucumber
         generate_expressions(text)[0]
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def generate_expressions(text)
         parameter_type_combinations = []
         parameter_type_matchers = create_parameter_type_matchers(text)
-        expression_template = ""
+        expression_template = ''
         pos = 0
 
         loop do
@@ -28,40 +32,36 @@ module Cucumber
             end
           end
 
-          if matching_parameter_type_matchers.any?
-            matching_parameter_type_matchers = matching_parameter_type_matchers.sort
-            best_parameter_type_matcher = matching_parameter_type_matchers[0]
-            best_parameter_type_matchers = matching_parameter_type_matchers.select do |m|
-              (m <=> best_parameter_type_matcher).zero?
-            end
+          break unless matching_parameter_type_matchers.any?
 
-            # Build a list of parameter types without duplicates. The reason there
-            # might be duplicates is that some parameter types have more than one regexp,
-            # which means multiple ParameterTypeMatcher objects will have a reference to the
-            # same ParameterType.
-            # We're sorting the list so prefer_for_regexp_match parameter types are listed first.
-            # Users are most likely to want these, so they should be listed at the top.
-            parameter_types = []
-            best_parameter_type_matchers.each do |parameter_type_matcher|
-              unless parameter_types.include?(parameter_type_matcher.parameter_type)
-                parameter_types.push(parameter_type_matcher.parameter_type)
-              end
-            end
-            parameter_types.sort!
-
-            parameter_type_combinations.push(parameter_types)
-
-            expression_template += escape(text.slice(pos...best_parameter_type_matcher.start))
-            expression_template += "{%s}"
-
-            pos = best_parameter_type_matcher.start + best_parameter_type_matcher.group.length
-          else
-            break
+          matching_parameter_type_matchers = matching_parameter_type_matchers.sort
+          best_parameter_type_matcher = matching_parameter_type_matchers[0]
+          best_parameter_type_matchers = matching_parameter_type_matchers.select do |m|
+            (m <=> best_parameter_type_matcher).zero?
           end
 
-          if pos >= text.length
-            break
+          # Build a list of parameter types without duplicates. The reason there
+          # might be duplicates is that some parameter types have more than one regexp,
+          # which means multiple ParameterTypeMatcher objects will have a reference to the
+          # same ParameterType.
+          # We're sorting the list so prefer_for_regexp_match parameter types are listed first.
+          # Users are most likely to want these, so they should be listed at the top.
+          parameter_types = []
+          best_parameter_type_matchers.each do |parameter_type_matcher|
+            unless parameter_types.include?(parameter_type_matcher.parameter_type)
+              parameter_types.push(parameter_type_matcher.parameter_type)
+            end
           end
+          parameter_types.sort!
+
+          parameter_type_combinations.push(parameter_types)
+
+          expression_template += escape(text.slice(pos...best_parameter_type_matcher.start))
+          expression_template += '{%s}'
+
+          pos = best_parameter_type_matcher.start + best_parameter_type_matcher.group.length
+
+          break if pos >= text.length
         end
 
         expression_template += escape(text.slice(pos..-1))
@@ -71,8 +71,9 @@ module Cucumber
           parameter_type_combinations
         ).generate_expressions
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-    private
+      private
 
       def create_parameter_type_matchers(text)
         parameter_matchers = []
@@ -94,11 +95,11 @@ module Cucumber
         result
       end
 
-      def escape(s)
-        s.gsub(/%/, '%%')
-        .gsub(/\(/, '\\(')
-        .gsub(/\{/, '\\{')
-        .gsub(/\//, '\\/')
+      def escape(string)
+        string.gsub(/%/, '%%')
+              .gsub(/\(/, '\\(')
+              .gsub(/\{/, '\\{')
+              .gsub(%r{/}, '\\/')
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
@@ -1,39 +1,49 @@
+# frozen_string_literal: true
+
 module Cucumber
   module CucumberExpressions
+    #:nodoc:
     class CucumberExpressionError < StandardError
     end
 
+    # Raised when a parameter is not defined
     class UndefinedParameterTypeError < CucumberExpressionError
       def initialize(type_name)
         super("Undefined parameter type {#{type_name}}")
       end
     end
 
+    # Raised when a regular expression capture group matches multiple parameter types
     class AmbiguousParameterTypeError < CucumberExpressionError
-      def initialize(parameter_type_regexp, expression_regexp, parameter_types, generated_expressions)
-        super(<<-EOM)
-Your Regular Expression /#{expression_regexp.source}/
-matches multiple parameter types with regexp /#{parameter_type_regexp}/:
-   #{parameter_type_names(parameter_types)}
+      def initialize(
+        parameter_type_regexp,
+        expression_regexp,
+        parameter_types,
+        generated_expressions
+      )
+        super(<<~MESSAGE)
+          Your Regular Expression /#{expression_regexp.source}/
+          matches multiple parameter types with regexp /#{parameter_type_regexp}/:
+             #{parameter_type_names(parameter_types)}
 
-I couldn't decide which one to use. You have two options:
+          I couldn't decide which one to use. You have two options:
 
-1) Use a Cucumber Expression instead of a Regular Expression. Try one of these:
-   #{expressions(generated_expressions)}
+          1) Use a Cucumber Expression instead of a Regular Expression. Try one of these:
+             #{expressions(generated_expressions)}
 
-2) Make one of the parameter types preferential and continue to use a Regular Expression.
+          2) Make one of the parameter types preferential and continue to use a Regular Expression.
 
-        EOM
+        MESSAGE
       end
 
       private
 
       def parameter_type_names(parameter_types)
-        parameter_types.map{|p| "{#{p.name}}"}.join("\n   ")
+        parameter_types.map { |p| "{#{p.name}}" }.join("\n   ")
       end
 
       def expressions(generated_expressions)
-        generated_expressions.map{|ge| ge.source}.join("\n   ")
+        generated_expressions.map(&:source).join("\n   ")
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/generated_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/generated_expression.rb
@@ -1,14 +1,18 @@
+# frozen_string_literal: true
+
 module Cucumber
   module CucumberExpressions
+    # A generated expression
     class GeneratedExpression
       attr_reader :parameter_types
 
       def initialize(expression_template, parameters_types)
-        @expression_template, @parameter_types = expression_template, parameters_types
+        @expression_template = expression_template
+        @parameter_types = parameters_types
       end
 
       def source
-        sprintf(@expression_template, *@parameter_types.map(&:name))
+        format(@expression_template, *@parameter_types.map(&:name))
       end
 
       def parameter_names

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 module Cucumber
   module CucumberExpressions
+    # A nested capture group
     class Group
       attr_reader :value, :start, :end, :children
 
-      def initialize(value, start, _end, children)
+      def initialize(value, start, end_, children)
         @value = value
         @start = start
-        @end = _end
+        @end = end_
         @children = children
       end
 

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group_builder.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group_builder.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/group'
 
 module Cucumber
   module CucumberExpressions
+    # Builds nested [Group] objects
     class GroupBuilder
       attr_accessor :source
 
@@ -16,8 +19,13 @@ module Cucumber
 
       def build(match, group_indices)
         group_index = group_indices.next
-        children = @group_builders.map {|gb| gb.build(match, group_indices)}
-        Group.new(match[group_index], match.offset(group_index)[0], match.offset(group_index)[1], children)
+        children = @group_builders.map { |gb| gb.build(match, group_indices) }
+        Group.new(
+          match[group_index],
+          match.offset(group_index)[0],
+          match.offset(group_index)[1],
+          children
+        )
       end
 
       def set_non_capturing!

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 module Cucumber
   module CucumberExpressions
     class ParameterTypeMatcher
       attr_reader :parameter_type
 
-      def initialize(parameter_type, regexp, text, match_position=0)
-        @parameter_type, @regexp, @text = parameter_type, regexp, text
+      def initialize(parameter_type, regexp, text, match_position = 0)
+        @parameter_type = parameter_type
+        @regexp = regexp
+        @text = text
         @match = @regexp.match(@text, match_position)
       end
 
       def advance_to(new_match_position)
-        (new_match_position...@text.length).each {|advancedPos|
+        (new_match_position...@text.length).each do |advancedPos|
           matcher = self.class.new(parameter_type, @regexp, @text, advancedPos)
-          if matcher.find && matcher.full_word?
-            return matcher
-          end
-        }
+          return matcher if matcher.find && matcher.full_word?
+        end
 
         self.class.new(parameter_type, @regexp, @text, @text.length)
       end
@@ -38,8 +40,10 @@ module Cucumber
       def <=>(other)
         pos_comparison = start <=> other.start
         return pos_comparison if pos_comparison != 0
+
         length_comparison = other.group.length <=> group.length
         return length_comparison if length_comparison != 0
+
         0
       end
 

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/parameter_type'
 require 'cucumber/cucumber_expressions/errors'
 require 'cucumber/cucumber_expressions/cucumber_expression_generator'
@@ -5,21 +7,21 @@ require 'cucumber/cucumber_expressions/cucumber_expression_generator'
 module Cucumber
   module CucumberExpressions
     class ParameterTypeRegistry
-      INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-      FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?/
-      WORD_REGEXP = /[^\s]+/
-      STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/
-      ANONYMOUS_REGEXP = /.*/
+      INTEGER_REGEXPS = [/-?\d+/, /\d+/].freeze
+      FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?/.freeze
+      WORD_REGEXP = /[^\s]+/.freeze
+      STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/.freeze
+      ANONYMOUS_REGEXP = /.*/.freeze
 
       def initialize
         @parameter_type_by_name = {}
-        @parameter_types_by_regexp = Hash.new {|hash, regexp| hash[regexp] = []}
+        @parameter_types_by_regexp = Hash.new { |hash, regexp| hash[regexp] = [] }
 
-        define_parameter_type(ParameterType.new('int', INTEGER_REGEXPS, Integer, lambda {|s = nil| s && s.to_i}, true, true))
-        define_parameter_type(ParameterType.new('float', FLOAT_REGEXP, Float, lambda {|s = nil| s && s.to_f}, true, false))
-        define_parameter_type(ParameterType.new('word', WORD_REGEXP, String, lambda {|s = nil| s}, false, false))
-        define_parameter_type(ParameterType.new('string', STRING_REGEXP, String, lambda {|s = nil| s && s.gsub(/\\"/, '"').gsub(/\\'/, "'")}, true, false))
-        define_parameter_type(ParameterType.new('', ANONYMOUS_REGEXP, String, lambda {|s = nil| s}, false, true))
+        define_parameter_type(ParameterType.new('int', INTEGER_REGEXPS, Integer, ->(s = nil) { s && s.to_i }, true, true))
+        define_parameter_type(ParameterType.new('float', FLOAT_REGEXP, Float, ->(s = nil) { s && s.to_f }, true, false))
+        define_parameter_type(ParameterType.new('word', WORD_REGEXP, String, ->(s = nil) { s }, false, false))
+        define_parameter_type(ParameterType.new('string', STRING_REGEXP, String, ->(s = nil) { s&.gsub(/\\"/, '"')&.gsub(/\\'/, "'") }, true, false))
+        define_parameter_type(ParameterType.new('', ANONYMOUS_REGEXP, String, ->(s = nil) { s }, false, true))
       end
 
       def lookup_by_type_name(name)
@@ -29,6 +31,7 @@ module Cucumber
       def lookup_by_regexp(parameter_type_regexp, expression_regexp, text)
         parameter_types = @parameter_types_by_regexp[parameter_type_regexp]
         return nil if parameter_types.nil?
+
         if parameter_types.length > 1 && !parameter_types[0].prefer_for_regexp_match?
           # We don't do this check on insertion because we only want to restrict
           # ambiguity when we look up by Regexp. Users of CucumberExpression should
@@ -44,12 +47,12 @@ module Cucumber
       end
 
       def define_parameter_type(parameter_type)
-        if parameter_type.name != nil
-          if @parameter_type_by_name.has_key?(parameter_type.name)
-            if parameter_type.name.length == 0
-              raise CucumberExpressionError.new("The anonymous parameter type has already been defined")
+        unless parameter_type.name.nil?
+          if @parameter_type_by_name.key?(parameter_type.name)
+            if parameter_type.name.empty?
+              raise CucumberExpressionError, 'The anonymous parameter type has already been defined'
             else
-              raise CucumberExpressionError.new("There is already a parameter with name #{parameter_type.name}")
+              raise CucumberExpressionError, "There is already a parameter with name #{parameter_type.name}"
             end
           end
           @parameter_type_by_name[parameter_type.name] = parameter_type
@@ -58,13 +61,13 @@ module Cucumber
         parameter_type.regexps.each do |parameter_type_regexp|
           parameter_types = @parameter_types_by_regexp[parameter_type_regexp]
           if parameter_types.any? && parameter_types[0].prefer_for_regexp_match? && parameter_type.prefer_for_regexp_match?
-            raise CucumberExpressionError.new("There can only be one preferential parameter type per regexp. The regexp /#{parameter_type_regexp}/ is used for two preferential parameter types, {#{parameter_types[0].name}} and {#{parameter_type.name}}")
+            raise CucumberExpressionError, "There can only be one preferential parameter type per regexp. The regexp /#{parameter_type_regexp}/ is used for two preferential parameter types, {#{parameter_types[0].name}} and {#{parameter_type.name}}"
           end
+
           parameter_types.push(parameter_type)
           parameter_types.sort!
         end
       end
-
     end
   end
 end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/argument'
 require 'cucumber/cucumber_expressions/parameter_type'
 require 'cucumber/cucumber_expressions/tree_regexp'
@@ -5,7 +7,6 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     class RegularExpression
-
       def initialize(expression_regexp, parameter_type_registry)
         @expression_regexp = expression_regexp
         @parameter_type_registry = parameter_type_registry
@@ -23,7 +24,7 @@ module Cucumber
             nil,
             parameter_type_regexp,
             String,
-            lambda {|*s| s[0]},
+            ->(*s) { s[0] },
             false,
             false
           )

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/tree_regexp.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/tree_regexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/group_builder'
 require 'cucumber/cucumber_expressions/errors'
 
@@ -44,7 +46,7 @@ module Cucumber
           elsif (c == '=' || c == '!') && last == '<' && @name_capturing_maybe
             end_non_capturing_group
           elsif @name_capturing_maybe
-            raise CucumberExpressionError.new("Named capture groups are not supported. See https://github.com/cucumber/cucumber/issues/329")
+            raise CucumberExpressionError, 'Named capture groups are not supported. See https://github.com/cucumber/cucumber/issues/329'
           end
 
           escaping = c == '\\' && !escaping
@@ -56,6 +58,7 @@ module Cucumber
       def match(s)
         match = @regexp.match(s)
         return nil if match.nil?
+
         group_indices = (0..match.length).to_a.to_enum
         @group_builder.build(match, group_indices)
       end

--- a/cucumber-expressions/ruby/spec/capture_warnings.rb
+++ b/cucumber-expressions/ruby/spec/capture_warnings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # With thanks to @myronmarston
 # https://github.com/vcr/vcr/blob/master/spec/capture_warnings.rb
 
@@ -8,24 +9,22 @@ module CaptureWarnings
     warnings, errors = capture_error(&block).partition { |line| line.include?('warning') }
     project_warnings, other_warnings = warnings.uniq.partition { |line| line.include?(current_dir) }
 
-    if errors.any?
-      puts errors.join("\n")
-    end
+    puts errors.join("\n") if errors.any?
 
     if other_warnings.any?
-      puts "#{ other_warnings.count } warnings detected, set VIEW_OTHER_WARNINGS=true to see them."
+      puts "#{other_warnings.count} warnings detected, set VIEW_OTHER_WARNINGS=true to see them."
       print_warnings('other', other_warnings) if ENV['VIEW_OTHER_WARNINGS']
     end
 
     # Until they fix https://bugs.ruby-lang.org/issues/10661
-    if RUBY_VERSION == "2.2.0"
+    if RUBY_VERSION == '2.2.0'
       project_warnings = project_warnings.reject { |w| w =~ /warning: possible reference to past scope/ }
     end
 
     if project_warnings.any?
-      puts "#{ project_warnings.count } warnings detected"
+      puts "#{project_warnings.count} warnings detected"
       print_warnings('cucumber-expressions', project_warnings)
-      fail "Please remove all cucumber-expressions warnings."
+      raise 'Please remove all cucumber-expressions warnings.'
     end
 
     ensure_system_exit_if_required
@@ -56,11 +55,11 @@ module CaptureWarnings
 
   def print_warnings(type, warnings)
     puts
-    puts "-" * 30 + " #{type} warnings: " + "-" * 30
+    puts '-' * 30 + " #{type} warnings: " + '-' * 30
     puts
     puts warnings.join("\n")
     puts
-    puts "-" * 75
+    puts '-' * 75
     puts
   end
 
@@ -69,6 +68,6 @@ module CaptureWarnings
   end
 
   def capture_system_exit
-    @system_exit = $!
+    @system_exit = $ERROR_INFO
   end
 end

--- a/cucumber-expressions/ruby/spec/coverage.rb
+++ b/cucumber-expressions/ruby/spec/coverage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 require 'simplecov'
-formatters = [ SimpleCov::Formatter::HTMLFormatter ]
+formatters = [SimpleCov::Formatter::HTMLFormatter]
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(*formatters)
 SimpleCov.add_filter 'spec/'

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/argument_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/argument_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/argument'
 require 'cucumber/cucumber_expressions/tree_regexp'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
@@ -8,9 +10,9 @@ module Cucumber
       it 'exposes parameter_type' do
         tree_regexp = TreeRegexp.new(/three (.*) mice/)
         parameter_type_registry = ParameterTypeRegistry.new
-        arguments = Argument.build(tree_regexp, "three blind mice", [parameter_type_registry.lookup_by_type_name("string")])
+        arguments = Argument.build(tree_regexp, 'three blind mice', [parameter_type_registry.lookup_by_type_name('string')])
         argument = arguments[0]
-        expect(argument.parameter_type.name).to eq("string")
+        expect(argument.parameter_type.name).to eq('string')
       end
     end
   end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/combinatorial_generated_expression_factory_test.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/combinatorial_generated_expression_factory_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/parameter_type'
 require 'cucumber/cucumber_expressions/combinatorial_generated_expression_factory'
 
 module Cucumber
   module CucumberExpressions
-
     class Color; end
     class CssColor; end
     class Date; end
@@ -14,13 +15,13 @@ module Cucumber
       it 'generates multiple expressions' do
         parameter_type_combinations = [
           [
-            ParameterType.new('color', /red|blue|yellow/, Color, lambda {|s| Color.new}, true, false),
-            ParameterType.new('csscolor', /red|blue|yellow/, CssColor, lambda {|s| CssColor.new}, true, false)
+            ParameterType.new('color', /red|blue|yellow/, Color, ->(_s) { Color.new }, true, false),
+            ParameterType.new('csscolor', /red|blue|yellow/, CssColor, ->(_s) { CssColor.new }, true, false)
           ],
           [
-            ParameterType.new('date', /\d{4}-\d{2}-\d{2}/, Date, lambda {|s| Date.new}, true, false),
-            ParameterType.new('datetime', /\d{4}-\d{2}-\d{2}/, DateTime, lambda {|s| DateTime.new}, true, false),
-            ParameterType.new('timestamp', /\d{4}-\d{2}-\d{2}/, Timestamp, lambda {|s| Timestamp.new}, true, false)
+            ParameterType.new('date', /\d{4}-\d{2}-\d{2}/, Date, ->(_s) { Date.new }, true, false),
+            ParameterType.new('datetime', /\d{4}-\d{2}-\d{2}/, DateTime, ->(_s) { DateTime.new }, true, false),
+            ParameterType.new('timestamp', /\d{4}-\d{2}-\d{2}/, Timestamp, ->(_s) { Timestamp.new }, true, false)
           ]
         ]
 
@@ -28,15 +29,15 @@ module Cucumber
           'I bought a {%s} ball on {%s}',
           parameter_type_combinations
         )
-        expressions = factory.generate_expressions.map {|ge| ge.source}
+        expressions = factory.generate_expressions.map(&:source)
         expect(expressions).to eq([
-            'I bought a {color} ball on {date}',
-            'I bought a {color} ball on {datetime}',
-            'I bought a {color} ball on {timestamp}',
-            'I bought a {csscolor} ball on {date}',
-            'I bought a {csscolor} ball on {datetime}',
-            'I bought a {csscolor} ball on {timestamp}',
-        ])
+                                    'I bought a {color} ball on {date}',
+                                    'I bought a {color} ball on {datetime}',
+                                    'I bought a {color} ball on {timestamp}',
+                                    'I bought a {csscolor} ball on {date}',
+                                    'I bought a {csscolor} ball on {datetime}',
+                                    'I bought a {csscolor} ball on {timestamp}'
+                                  ])
       end
     end
   end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/cucumber_expression_generator'
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/parameter_type'
@@ -14,203 +16,212 @@ module Cucumber
         @generator = CucumberExpressionGenerator.new(@parameter_type_registry)
       end
 
-      it "documents expression generation" do
+      it 'documents expression generation' do
         parameter_registry = ParameterTypeRegistry.new
         ### [generate-expression]
         generator = CucumberExpressionGenerator.new(parameter_registry)
-        undefined_step_text = "I have 2 cucumbers and 1.5 tomato"
+        undefined_step_text = 'I have 2 cucumbers and 1.5 tomato'
         generated_expression = generator.generate_expression(undefined_step_text)
-        expect(generated_expression.source).to eq("I have {int} cucumbers and {float} tomato")
+        expect(generated_expression.source).to eq('I have {int} cucumbers and {float} tomato')
         expect(generated_expression.parameter_types[1].type).to eq(Float)
         ### [generate-expression]
       end
 
-      it "generates expression for no args" do
-        assert_expression("hello", [], "hello")
+      it 'generates expression for no args' do
+        assert_expression('hello', [], 'hello')
       end
 
-      it "generates expression with escaped left parenthesis" do
+      it 'generates expression with escaped left parenthesis' do
         assert_expression(
-          "\\(iii)", [],
-          "(iii)")
+          '\\(iii)', [],
+          '(iii)'
+        )
       end
 
-      it "generates expression with escaped left curly brace" do
+      it 'generates expression with escaped left curly brace' do
         assert_expression(
-          "\\{iii}", [],
-          "{iii}")
+          '\\{iii}', [],
+          '{iii}'
+        )
       end
 
-      it "generates expression with escaped slashes" do
+      it 'generates expression with escaped slashes' do
         assert_expression(
-          "The {int}\\/{int}\\/{int} hey", ["int", "int2", "int3"],
-          "The 1814/05/17 hey")
+          'The {int}\\/{int}\\/{int} hey', %w[int int2 int3],
+          'The 1814/05/17 hey'
+        )
       end
 
-      it "generates expression for int float arg" do
+      it 'generates expression for int float arg' do
         assert_expression(
-          "I have {int} cukes and {float} euro", ["int", "float"],
-          "I have 2 cukes and 1.5 euro")
+          'I have {int} cukes and {float} euro', %w[int float],
+          'I have 2 cukes and 1.5 euro'
+        )
       end
 
-      it "generates expression for strings" do
+      it 'generates expression for strings' do
         assert_expression(
-            "I like {string} and {string}", ["string", "string2"],
-            'I like "bangers" and \'mash\'')
+          'I like {string} and {string}', %w[string string2],
+          'I like "bangers" and \'mash\''
+        )
       end
 
-      it "generates expression with % sign" do
+      it 'generates expression with % sign' do
         assert_expression(
-            "I am {int}% foobar", ["int"],
-            'I am 20% foobar')
+          'I am {int}% foobar', ['int'],
+          'I am 20% foobar'
+        )
       end
 
-      it "generates expression for just int" do
+      it 'generates expression for just int' do
         assert_expression(
-          "{int}", ["int"],
-          "99999")
+          '{int}', ['int'],
+          '99999'
+        )
       end
 
-      it "numbers only second argument when builtin type is not reserved keyword" do
+      it 'numbers only second argument when builtin type is not reserved keyword' do
         assert_expression(
-          "I have {int} cukes and {int} euro", ["int", "int2"],
-          "I have 2 cukes and 5 euro")
+          'I have {int} cukes and {int} euro', %w[int int2],
+          'I have 2 cukes and 5 euro'
+        )
       end
 
-      it "numbers only second argument when type is not reserved keyword" do
+      it 'numbers only second argument when type is not reserved keyword' do
         @parameter_type_registry.define_parameter_type(ParameterType.new(
-          'currency',
-          '[A-Z]{3}',
-          Currency,
-          lambda {|s| Currency.new(s)},
-          true,
-          true
-        ))
+                                                         'currency',
+                                                         '[A-Z]{3}',
+                                                         Currency,
+                                                         ->(s) { Currency.new(s) },
+                                                         true,
+                                                         true
+                                                       ))
 
         assert_expression(
-          "I have a {currency} account and a {currency} account", ["currency", "currency2"],
-          "I have a EUR account and a GBP account")
+          'I have a {currency} account and a {currency} account', %w[currency currency2],
+          'I have a EUR account and a GBP account'
+        )
       end
 
-      it "exposes parameters in generated expression" do
-        expression = @generator.generate_expression("I have 2 cukes and 1.5 euro")
+      it 'exposes parameters in generated expression' do
+        expression = @generator.generate_expression('I have 2 cukes and 1.5 euro')
         types = expression.parameter_types.map(&:type)
         expect(types).to eq([Integer, Float])
       end
 
-      it "matches parameter types with optional capture groups" do
+      it 'matches parameter types with optional capture groups' do
         @parameter_type_registry.define_parameter_type(ParameterType.new(
-            'optional-flight',
-            /(1st flight)?/,
-            String,
-            lambda {|s| s},
-            true,
-            false
-        ))
+                                                         'optional-flight',
+                                                         /(1st flight)?/,
+                                                         String,
+                                                         ->(s) { s },
+                                                         true,
+                                                         false
+                                                       ))
         @parameter_type_registry.define_parameter_type(ParameterType.new(
-            'optional-hotel',
-            /(1 hotel)?/,
-            String,
-            lambda {|s| s},
-            true,
-            false
-        ))
+                                                         'optional-hotel',
+                                                         /(1 hotel)?/,
+                                                         String,
+                                                         ->(s) { s },
+                                                         true,
+                                                         false
+                                                       ))
 
-        expression = @generator.generate_expressions("I reach Stage 4: 1st flight -1 hotel")[0]
+        expression = @generator.generate_expressions('I reach Stage 4: 1st flight -1 hotel')[0]
         # While you would expect this to be `I reach Stage {int}: {optional-flight} -{optional-hotel}`
         # the `-1` causes {int} to match just before {optional-hotel}.
-        expect(expression.source).to eq("I reach Stage {int}: {optional-flight} {int} hotel")
+        expect(expression.source).to eq('I reach Stage {int}: {optional-flight} {int} hotel')
       end
 
-      it "generates at most 256 expressions" do
-        for i in 0..3
+      it 'generates at most 256 expressions' do
+        (0..3).each do |i|
           @parameter_type_registry.define_parameter_type(ParameterType.new(
-              "my-type-#{i}",
-              /([a-z] )*?[a-z]/,
-              String,
-              lambda {|s| s},
-              true,
-              false
-          ))
+                                                           "my-type-#{i}",
+                                                           /([a-z] )*?[a-z]/,
+                                                           String,
+                                                           ->(s) { s },
+                                                           true,
+                                                           false
+                                                         ))
         end
         # This would otherwise generate 4^11=4194300 expressions and consume just shy of 1.5GB.
-        expressions = @generator.generate_expressions("a s i m p l e s t e p")
+        expressions = @generator.generate_expressions('a s i m p l e s t e p')
         expect(expressions.length).to eq(256)
       end
 
-      it "prefers expression with longest non empty match" do
+      it 'prefers expression with longest non empty match' do
         @parameter_type_registry.define_parameter_type(ParameterType.new(
-            'zero-or-more',
-            /[a-z]*/,
-            String,
-            lambda {|s| s},
-            true,
-            false
-        ))
+                                                         'zero-or-more',
+                                                         /[a-z]*/,
+                                                         String,
+                                                         ->(s) { s },
+                                                         true,
+                                                         false
+                                                       ))
         @parameter_type_registry.define_parameter_type(ParameterType.new(
-            'exactly-one',
-            /[a-z]/,
-            String,
-            lambda {|s| s},
-            true,
-            false
-        ))
+                                                         'exactly-one',
+                                                         /[a-z]/,
+                                                         String,
+                                                         ->(s) { s },
+                                                         true,
+                                                         false
+                                                       ))
 
-        expressions = @generator.generate_expressions("a simple step")
+        expressions = @generator.generate_expressions('a simple step')
         expect(expressions.length).to eq(2)
-        expect(expressions[0].source).to eq("{exactly-one} {zero-or-more} {zero-or-more}")
-        expect(expressions[1].source).to eq("{zero-or-more} {zero-or-more} {zero-or-more}")
+        expect(expressions[0].source).to eq('{exactly-one} {zero-or-more} {zero-or-more}')
+        expect(expressions[1].source).to eq('{zero-or-more} {zero-or-more} {zero-or-more}')
       end
 
-      context "does not suggest parameter when match is" do
+      context 'does not suggest parameter when match is' do
         before do
           @parameter_type_registry.define_parameter_type(ParameterType.new(
-              'direction',
-              /(up|down)/,
-              String,
-              lambda {|s| s},
-              true,
-              false
-          ))
+                                                           'direction',
+                                                           /(up|down)/,
+                                                           String,
+                                                           ->(s) { s },
+                                                           true,
+                                                           false
+                                                         ))
         end
 
-        it "at the beginning of a word" do
-          expect(@generator.generate_expression("When I download a picture").source).not_to eq("When I {direction}load a picture")
-          expect(@generator.generate_expression("When I download a picture").source).to eq("When I download a picture")
+        it 'at the beginning of a word' do
+          expect(@generator.generate_expression('When I download a picture').source).not_to eq('When I {direction}load a picture')
+          expect(@generator.generate_expression('When I download a picture').source).to eq('When I download a picture')
         end
 
-        it "inside a word" do
-          expect(@generator.generate_expression("When I watch the muppet show").source).not_to eq("When I watch the m{direction}pet show")
-          expect(@generator.generate_expression("When I watch the muppet show").source).to eq("When I watch the muppet show")
+        it 'inside a word' do
+          expect(@generator.generate_expression('When I watch the muppet show').source).not_to eq('When I watch the m{direction}pet show')
+          expect(@generator.generate_expression('When I watch the muppet show').source).to eq('When I watch the muppet show')
         end
 
-        it "at the end of a word" do
-          expect(@generator.generate_expression("When I create a group").source).not_to eq("When I create a gro{direction}")
-          expect(@generator.generate_expression("When I create a group").source).to eq("When I create a group")
+        it 'at the end of a word' do
+          expect(@generator.generate_expression('When I create a group').source).not_to eq('When I create a gro{direction}')
+          expect(@generator.generate_expression('When I create a group').source).to eq('When I create a group')
         end
       end
 
-      context "does suggest parameter when match is" do
+      context 'does suggest parameter when match is' do
         before do
           @parameter_type_registry.define_parameter_type(ParameterType.new(
-              'direction',
-              /(up|down)/,
-              String,
-              lambda {|s| s},
-              true,
-              false
-          ))
+                                                           'direction',
+                                                           /(up|down)/,
+                                                           String,
+                                                           ->(s) { s },
+                                                           true,
+                                                           false
+                                                         ))
         end
 
-        it "a full word" do
-          expect(@generator.generate_expression("When I go down the road").source).to eq("When I go {direction} the road")
-          expect(@generator.generate_expression("When I walk up the hill").source).to eq("When I walk {direction} the hill")
-          expect(@generator.generate_expression("up the hill, the road goes down").source).to eq("{direction} the hill, the road goes {direction}")
+        it 'a full word' do
+          expect(@generator.generate_expression('When I go down the road').source).to eq('When I go {direction} the road')
+          expect(@generator.generate_expression('When I walk up the hill').source).to eq('When I walk {direction} the hill')
+          expect(@generator.generate_expression('up the hill, the road goes down').source).to eq('{direction} the hill, the road goes {direction}')
         end
 
         it 'wrapped around punctuation characters' do
-          expect(@generator.generate_expression("When direction is:down").source).to eq("When direction is:{direction}")
-          expect(@generator.generate_expression("Then direction is down.").source).to eq("Then direction is {direction}.")
+          expect(@generator.generate_expression('When direction is:down').source).to eq('When direction is:{direction}')
+          expect(@generator.generate_expression('Then direction is down.').source).to eq('Then direction is {direction}.')
         end
       end
 
@@ -224,6 +235,7 @@ module Cucumber
         if match.nil?
           raise "Expected text '#{text}' to match generated expression '#{generated_expression.source}'"
         end
+
         expect(match.length).to eq(expected_argument_names.length)
       end
     end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_regexp_spec.rb
@@ -1,53 +1,55 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
 
 module Cucumber
   module CucumberExpressions
     describe CucumberExpression do
-      context "Regexp translation" do
+      context 'Regexp translation' do
         def assert_regexp(expression, regexp)
           cucumber_expression = CucumberExpression.new(expression, ParameterTypeRegistry.new)
           expect(regexp).to eq(cucumber_expression.regexp)
         end
 
-        it "translates no arguments" do
+        it 'translates no arguments' do
           assert_regexp(
-            "I have 10 cukes in my belly now",
+            'I have 10 cukes in my belly now',
             /^I have 10 cukes in my belly now$/
           )
         end
 
-        it "translates alternation" do
+        it 'translates alternation' do
           assert_regexp(
-            "I had/have a great/nice/charming friend",
+            'I had/have a great/nice/charming friend',
             /^I (?:had|have) a (?:great|nice|charming) friend$/
           )
         end
 
-        it "translates alternation with non-alpha" do
+        it 'translates alternation with non-alpha' do
           assert_regexp(
-            "I said Alpha1/Beta1",
+            'I said Alpha1/Beta1',
             /^I said (?:Alpha1|Beta1)$/
           )
         end
 
-        it "translates parameters" do
+        it 'translates parameters' do
           assert_regexp(
             "I have {float} cukes at {int} o'clock",
             /^I have ((?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?) cukes at ((?:-?\d+)|(?:\d+)) o'clock$/
           )
         end
 
-        it "translates parenthesis to non-capturing optional capture group" do
+        it 'translates parenthesis to non-capturing optional capture group' do
           assert_regexp(
-            "I have many big(ish) cukes",
+            'I have many big(ish) cukes',
             /^I have many big(?:ish)? cukes$/
           )
         end
 
-        it "translates parenthesis with alpha unicode" do
+        it 'translates parenthesis with alpha unicode' do
           assert_regexp(
-            "Привет, Мир(ы)!",
+            'Привет, Мир(ы)!',
             /^Привет, Мир(?:ы)?!$/
           )
         end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
 
 module Cucumber
   module CucumberExpressions
     describe CucumberExpression do
-      it "documents match arguments" do
+      it 'documents match arguments' do
         parameter_registry = ParameterTypeRegistry.new
 
         ### [capture-match-arguments]
-        expr = "I have {int} cuke(s)"
+        expr = 'I have {int} cuke(s)'
         expression = CucumberExpression.new(expr, parameter_registry)
-        args = expression.match("I have 7 cukes")
+        args = expression.match('I have 7 cukes')
         expect(args[0].value(nil)).to eq(7)
         ### [capture-match-arguments]
       end
 
-      it "matches word" do
-        expect(match("three {word} mice", "three blind mice")).to eq(['blind'])
+      it 'matches word' do
+        expect(match('three {word} mice', 'three blind mice')).to eq(['blind'])
       end
 
       it('matches double quoted string') do
@@ -24,7 +26,7 @@ module Cucumber
       end
 
       it('matches multiple double quoted strings') do
-        expect(match('three {string} and {string} mice', 'three "blind" and "crippled" mice')).to eq(['blind', 'crippled'])
+        expect(match('three {string} and {string} mice', 'three "blind" and "crippled" mice')).to eq(%w[blind crippled])
       end
 
       it('matches single quoted string') do
@@ -32,7 +34,7 @@ module Cucumber
       end
 
       it('matches multiple single quoted strings') do
-        expect(match('three {string} and {string} mice', "three 'blind' and 'crippled' mice")).to eq(['blind', 'crippled'])
+        expect(match('three {string} and {string} mice', "three 'blind' and 'crippled' mice")).to eq(%w[blind crippled])
       end
 
       it('does not match misquoted string') do
@@ -75,105 +77,105 @@ module Cucumber
         expect(match('three \\(exceptionally) {string} mice', 'three (exceptionally) "blind" mice')).to eq(['blind'])
       end
 
-      it "matches escaped slash" do
-        expect(match("12\\/2020", "12/2020")).to eq([])
+      it 'matches escaped slash' do
+        expect(match('12\\/2020', '12/2020')).to eq([])
       end
 
-      it "matches int" do
-        expect(match("{int}", "22")).to eq([22])
+      it 'matches int' do
+        expect(match('{int}', '22')).to eq([22])
       end
 
       it "doesn't match float as int" do
-        expect(match("{int}", "1.22")).to be_nil
+        expect(match('{int}', '1.22')).to be_nil
       end
 
-      it "matches int as float" do
-        expect(match("{float}", "0")).to eq([0.0])
+      it 'matches int as float' do
+        expect(match('{float}', '0')).to eq([0.0])
       end
 
-      it "matches float" do
-        expect(match("{float}", "")).to eq(nil)
-        expect(match("{float}", ".")).to eq(nil)
-        expect(match("{float}", ",")).to eq(nil)
-        expect(match("{float}", "-")).to eq(nil)
-        expect(match("{float}", "E")).to eq(nil)
-        expect(match("{float}", "1,")).to eq(nil)
-        expect(match("{float}", ",1")).to eq(nil)
-        expect(match("{float}", "1.")).to eq(nil)
+      it 'matches float' do
+        expect(match('{float}', '')).to eq(nil)
+        expect(match('{float}', '.')).to eq(nil)
+        expect(match('{float}', ',')).to eq(nil)
+        expect(match('{float}', '-')).to eq(nil)
+        expect(match('{float}', 'E')).to eq(nil)
+        expect(match('{float}', '1,')).to eq(nil)
+        expect(match('{float}', ',1')).to eq(nil)
+        expect(match('{float}', '1.')).to eq(nil)
 
-        expect(match("{float}", "1")).to eq([1])
-        expect(match("{float}", "-1")).to eq([-1])
-        expect(match("{float}", "1.1")).to eq([1.1])
-        expect(match("{float}", "1,000")).to eq(nil)
-        expect(match("{float}", "1,000,0")).to eq(nil)
-        expect(match("{float}", "1,000.1")).to eq(nil)
-        expect(match("{float}", "1,000,10")).to eq(nil)
-        expect(match("{float}", "1,0.1")).to eq(nil)
-        expect(match("{float}", "1,000,000.1")).to eq(nil)
-        expect(match("{float}", "-1.1")).to eq([-1.1])
+        expect(match('{float}', '1')).to eq([1])
+        expect(match('{float}', '-1')).to eq([-1])
+        expect(match('{float}', '1.1')).to eq([1.1])
+        expect(match('{float}', '1,000')).to eq(nil)
+        expect(match('{float}', '1,000,0')).to eq(nil)
+        expect(match('{float}', '1,000.1')).to eq(nil)
+        expect(match('{float}', '1,000,10')).to eq(nil)
+        expect(match('{float}', '1,0.1')).to eq(nil)
+        expect(match('{float}', '1,000,000.1')).to eq(nil)
+        expect(match('{float}', '-1.1')).to eq([-1.1])
 
-        expect(match("{float}", ".1")).to eq([0.1])
-        expect(match("{float}", "-.1")).to eq([-0.1])
-        expect(match("{float}", "-.1000001")).to eq([-0.1000001])
-        expect(match("{float}", "1E1")).to eq([10.0])
-        expect(match("{float}", ".1E1")).to eq([1])
-        expect(match("{float}", "E1")).to eq(nil)
-        expect(match("{float}", "-.1E-1")).to eq([-0.01])
-        expect(match("{float}", "-.1E-2")).to eq([-0.001])
-        expect(match("{float}", "-.1E+1")).to eq([-1])
-        expect(match("{float}", "-.1E+2")).to eq([-10])
-        expect(match("{float}", "-.1E1")).to eq([-1])
-        expect(match("{float}", "-.1E2")).to eq([-10])
+        expect(match('{float}', '.1')).to eq([0.1])
+        expect(match('{float}', '-.1')).to eq([-0.1])
+        expect(match('{float}', '-.1000001')).to eq([-0.1000001])
+        expect(match('{float}', '1E1')).to eq([10.0])
+        expect(match('{float}', '.1E1')).to eq([1])
+        expect(match('{float}', 'E1')).to eq(nil)
+        expect(match('{float}', '-.1E-1')).to eq([-0.01])
+        expect(match('{float}', '-.1E-2')).to eq([-0.001])
+        expect(match('{float}', '-.1E+1')).to eq([-1])
+        expect(match('{float}', '-.1E+2')).to eq([-10])
+        expect(match('{float}', '-.1E1')).to eq([-1])
+        expect(match('{float}', '-.1E2')).to eq([-10])
       end
 
-      it "matches anonymous" do
-        expect(match("{}", "0.22")).to eq(["0.22"])
+      it 'matches anonymous' do
+        expect(match('{}', '0.22')).to eq(['0.22'])
       end
 
       '[]()$.|?*+'.split('').each do |char|
         it "does not allow parameter type with #{char}" do
-          expect {match("{#{char}string}", "something")}.to raise_error("Illegal character '#{char}' in parameter name {#{char}string}")
+          expect { match("{#{char}string}", 'something') }.to raise_error("Illegal character '#{char}' in parameter name {#{char}string}")
         end
       end
 
-      it "throws unknown parameter type" do
-        expect {match("{unknown}", "something")}.to raise_error('Undefined parameter type {unknown}')
+      it 'throws unknown parameter type' do
+        expect { match('{unknown}', 'something') }.to raise_error('Undefined parameter type {unknown}')
       end
 
-      it "does not allow optional parameter types" do
-        expect {match("({int})", "3")}.to raise_error('Parameter types cannot be optional: ({int})')
+      it 'does not allow optional parameter types' do
+        expect { match('({int})', '3') }.to raise_error('Parameter types cannot be optional: ({int})')
       end
 
-      it "does allow escaped optional parameter types" do
-        expect(match("\\({int})", "(3)")).to eq([3])
+      it 'does allow escaped optional parameter types' do
+        expect(match('\\({int})', '(3)')).to eq([3])
       end
 
-      it "does not allow text/parameter type alternation" do
-        expect {match("x/{int}", "3")}.to raise_error('Parameter types cannot be alternative: x/{int}')
+      it 'does not allow text/parameter type alternation' do
+        expect { match('x/{int}', '3') }.to raise_error('Parameter types cannot be alternative: x/{int}')
       end
 
-      it "does not allow parameter type/text alternation" do
-        expect {match("{int}/x", "3")}.to raise_error('Parameter types cannot be alternative: {int}/x')
+      it 'does not allow parameter type/text alternation' do
+        expect { match('{int}/x', '3') }.to raise_error('Parameter types cannot be alternative: {int}/x')
       end
 
-      it "exposes source" do
-        expr = "I have {int} cuke(s)"
+      it 'exposes source' do
+        expr = 'I have {int} cuke(s)'
         expect(CucumberExpression.new(expr, ParameterTypeRegistry.new).source).to eq(expr)
       end
 
-      it "delegates transform to custom object" do
+      it 'delegates transform to custom object' do
         parameter_type_registry = ParameterTypeRegistry.new
         parameter_type_registry.define_parameter_type(
           ParameterType.new(
-                  'widget',
-                  /\w+/,
-                  Object,
-                  -> (s) {
-                    self.create_widget(s)
-                  },
-                  false,
-                  true
-              )
+            'widget',
+            /\w+/,
+            Object,
+            lambda { |s|
+              create_widget(s)
+            },
+            false,
+            true
+          )
         )
         expression = CucumberExpression.new(
           'I have a {widget}',
@@ -186,11 +188,11 @@ module Cucumber
           end
         end
 
-        args = expression.match("I have a bolt")
+        args = expression.match('I have a bolt')
         expect(args[0].value(World.new)).to eq('widget:bolt')
       end
 
-      describe "escapes special characters" do
+      describe 'escapes special characters' do
         %w(\\ [ ] ^ $ . | ? * +).each do |character|
           it "escapes #{character}" do
             expr = "I have {int} cuke(s) and #{character}"
@@ -205,7 +207,8 @@ module Cucumber
         cucumber_expression = CucumberExpression.new(expression, ParameterTypeRegistry.new)
         args = cucumber_expression.match(text)
         return nil if args.nil?
-        args.map {|arg| arg.value(nil)}
+
+        args.map { |arg| arg.value(nil) }
       end
     end
   end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/custom_parameter_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/regular_expression'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
@@ -35,7 +37,9 @@ module Cucumber
       attr_reader :x, :y, :z
 
       def initialize(x, y, z)
-        @x, @y, @z = x, y, z
+        @x = x
+        @y = y
+        @z = z
       end
 
       def ==(other)
@@ -43,55 +47,55 @@ module Cucumber
       end
     end
 
-    describe "Custom parameter type" do
+    describe 'Custom parameter type' do
       before do
         parameter_type_registry = ParameterTypeRegistry.new
         ### [add-color-parameter-type]
         parameter_type_registry.define_parameter_type(ParameterType.new(
-            'color',                   # name
-            /red|blue|yellow/,         # regexp
-            Color,                     # type
-            lambda {|s| Color.new(s)}, # transform
-            true,                      # use_for_snippets
-            false                      # prefer_for_regexp_match
-        ))
+                                                        'color', # name
+                                                        /red|blue|yellow/,         # regexp
+                                                        Color,                     # type
+                                                        ->(s) { Color.new(s) }, # transform
+                                                        true,                      # use_for_snippets
+                                                        false                      # prefer_for_regexp_match
+                                                      ))
         ### [add-color-parameter-type]
         @parameter_type_registry = parameter_type_registry
       end
 
-      it "throws exception for illegal character in parameter name" do
+      it 'throws exception for illegal character in parameter name' do
         expect do
           ParameterType.new(
-              '[string]',
-              /.*/,
-              String,
-              lambda {|s| s},
-              true,
-              false
+            '[string]',
+            /.*/,
+            String,
+            ->(s) { s },
+            true,
+            false
           )
         end.to raise_error("Illegal character '[' in parameter name {[string]}")
       end
 
       describe CucumberExpression do
-        it "matches parameters with custom parameter type" do
-          expression = CucumberExpression.new("I have a {color} ball", @parameter_type_registry)
-          transformed_argument_value = expression.match("I have a red ball")[0].value(nil)
+        it 'matches parameters with custom parameter type' do
+          expression = CucumberExpression.new('I have a {color} ball', @parameter_type_registry)
+          transformed_argument_value = expression.match('I have a red ball')[0].value(nil)
           expect(transformed_argument_value).to eq(Color.new('red'))
         end
 
-        it "matches parameters with multiple capture groups" do
+        it 'matches parameters with multiple capture groups' do
           @parameter_type_registry.define_parameter_type(ParameterType.new(
-              'coordinate',
-              /(\d+),\s*(\d+),\s*(\d+)/,
-              Coordinate,
-              lambda {|x, y, z| Coordinate.new(x.to_i, y.to_i, z.to_i)},
-              true,
-              false
-          ))
+                                                           'coordinate',
+                                                           /(\d+),\s*(\d+),\s*(\d+)/,
+                                                           Coordinate,
+                                                           ->(x, y, z) { Coordinate.new(x.to_i, y.to_i, z.to_i) },
+                                                           true,
+                                                           false
+                                                         ))
 
           expression = CucumberExpression.new(
-              'A {int} thick line from {coordinate} to {coordinate}',
-              @parameter_type_registry
+            'A {int} thick line from {coordinate} to {coordinate}',
+            @parameter_type_registry
           )
           args = expression.match('A 5 thick line from 10,20,30 to 40,50,60')
 
@@ -105,95 +109,95 @@ module Cucumber
           expect(to).to eq(Coordinate.new(40, 50, 60))
         end
 
-        it "matches parameters with custom parameter type using optional capture group" do
+        it 'matches parameters with custom parameter type using optional capture group' do
           parameter_type_registry = ParameterTypeRegistry.new
           parameter_type_registry.define_parameter_type(ParameterType.new(
-              'color',
-              [/red|blue|yellow/, /(?:dark|light) (?:red|blue|yellow)/],
-              Color,
-              lambda {|s| Color.new(s)},
-              true,
-              false
-          ))
-          expression = CucumberExpression.new("I have a {color} ball", parameter_type_registry)
-          transformed_argument_value = expression.match("I have a dark red ball")[0].value(nil)
+                                                          'color',
+                                                          [/red|blue|yellow/, /(?:dark|light) (?:red|blue|yellow)/],
+                                                          Color,
+                                                          ->(s) { Color.new(s) },
+                                                          true,
+                                                          false
+                                                        ))
+          expression = CucumberExpression.new('I have a {color} ball', parameter_type_registry)
+          transformed_argument_value = expression.match('I have a dark red ball')[0].value(nil)
           expect(transformed_argument_value).to eq(Color.new('dark red'))
         end
 
-        it "defers transformation until queried from argument" do
+        it 'defers transformation until queried from argument' do
           @parameter_type_registry.define_parameter_type(ParameterType.new(
-              'throwing',
-              /bad/,
-              CssColor,
-              lambda {|s| raise "Can't transform [#{s}]"},
-              true,
-              false
-          ))
-          expression = CucumberExpression.new("I have a {throwing} parameter", @parameter_type_registry)
-          args = expression.match("I have a bad parameter")
-          expect {args[0].value(nil)}.to raise_error("Can't transform [bad]")
+                                                           'throwing',
+                                                           /bad/,
+                                                           CssColor,
+                                                           ->(s) { raise "Can't transform [#{s}]" },
+                                                           true,
+                                                           false
+                                                         ))
+          expression = CucumberExpression.new('I have a {throwing} parameter', @parameter_type_registry)
+          args = expression.match('I have a bad parameter')
+          expect { args[0].value(nil) }.to raise_error("Can't transform [bad]")
         end
 
-        describe "conflicting parameter type" do
-          it "is detected for type name" do
-            expect {
+        describe 'conflicting parameter type' do
+          it 'is detected for type name' do
+            expect do
               @parameter_type_registry.define_parameter_type(ParameterType.new(
-                  'color',
-                  /.*/,
-                  CssColor,
-                  lambda {|s| CssColor.new(s)},
-                  true,
-                  false
-              ))
-            }.to raise_error("There is already a parameter with name color")
+                                                               'color',
+                                                               /.*/,
+                                                               CssColor,
+                                                               ->(s) { CssColor.new(s) },
+                                                               true,
+                                                               false
+                                                             ))
+            end.to raise_error('There is already a parameter with name color')
           end
 
-          it "is not detected for type" do
+          it 'is not detected for type' do
             @parameter_type_registry.define_parameter_type(ParameterType.new(
-                'whatever',
-                /.*/,
-                Color,
-                lambda {|s| Color.new(s)},
-                false,
-                false
-            ))
+                                                             'whatever',
+                                                             /.*/,
+                                                             Color,
+                                                             ->(s) { Color.new(s) },
+                                                             false,
+                                                             false
+                                                           ))
           end
 
-          it "is not detected for regexp" do
+          it 'is not detected for regexp' do
             @parameter_type_registry.define_parameter_type(ParameterType.new(
-                'css-color',
-                /red|blue|yellow/,
-                CssColor,
-                lambda {|s| CssColor.new(s)},
-                true,
-                false
-            ))
+                                                             'css-color',
+                                                             /red|blue|yellow/,
+                                                             CssColor,
+                                                             ->(s) { CssColor.new(s) },
+                                                             true,
+                                                             false
+                                                           ))
 
-            css_color = CucumberExpression.new("I have a {css-color} ball", @parameter_type_registry)
-            css_color_value = css_color.match("I have a blue ball")[0].value(nil)
-            expect(css_color_value).to eq(CssColor.new("blue"))
+            css_color = CucumberExpression.new('I have a {css-color} ball', @parameter_type_registry)
+            css_color_value = css_color.match('I have a blue ball')[0].value(nil)
+            expect(css_color_value).to eq(CssColor.new('blue'))
 
-            color = CucumberExpression.new("I have a {color} ball", @parameter_type_registry)
-            color_value = color.match("I have a blue ball")[0].value(nil)
-            expect(color_value).to eq(Color.new("blue"))
+            color = CucumberExpression.new('I have a {color} ball', @parameter_type_registry)
+            color_value = color.match('I have a blue ball')[0].value(nil)
+            expect(color_value).to eq(Color.new('blue'))
           end
         end
       end
 
       describe RegularExpression do
-        it "matches arguments with custom parameter type without name" do
+        it 'matches arguments with custom parameter type without name' do
           parameter_type_registry = ParameterTypeRegistry.new
           parameter_type_registry.define_parameter_type(ParameterType.new(
-              nil,
-              /red|blue|yellow/,
-              Color,
-              lambda {|s| Color.new(s)},
-              true,
-              false
-          ))
+                                                          nil,
+                                                          /red|blue|yellow/,
+                                                          Color,
+                                                          ->(s) { Color.new(s) },
+                                                          true,
+                                                          false
+                                                        ))
 
           expression = RegularExpression.new(/I have a (red|blue|yellow) ball/, parameter_type_registry)
-          value = expression.match("I have a red ball")[0].value(nil)
+          value = expression.match('I have a red ball')[0].value(nil)
           expect(value).to eq(Color.new('red'))
         end
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/expression_examples_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/expression_examples_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/cucumber_expression'
 require 'cucumber/cucumber_expressions/regular_expression'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
@@ -7,21 +9,22 @@ module Cucumber
   module CucumberExpressions
     describe 'examples.txt' do
       def match(expression_text, text)
-        expression = expression_text =~ /\/(.*)\// ?
-          RegularExpression.new(Regexp.new($1), ParameterTypeRegistry.new) :
+        expression = expression_text =~ %r{/(.*)/} ?
+          RegularExpression.new(Regexp.new(Regexp.last_match(1)), ParameterTypeRegistry.new) :
           CucumberExpression.new(expression_text, ParameterTypeRegistry.new)
 
         arguments = expression.match(text)
         return nil if arguments.nil?
+
         arguments.map { |arg| arg.value(nil) }
       end
 
-      File.open(File.expand_path("../../../../examples.txt", __FILE__), "r:utf-8") do |io|
+      File.open(File.expand_path('../../../examples.txt', __dir__), 'r:utf-8') do |io|
         chunks = io.read.split(/^---/m)
         chunks.each do |chunk|
           expression_text, text, expected_args = *chunk.strip.split(/\n/m)
           it "Works with: #{expression_text}" do
-            expect( match(expression_text, text).to_json ).to eq(expected_args)
+            expect(match(expression_text, text).to_json).to eq(expected_args)
           end
         end
       end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_registry_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_registry_spec.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/parameter_type_registry'
 require 'cucumber/cucumber_expressions/parameter_type'
 require 'cucumber/cucumber_expressions/errors'
 
 module Cucumber
   module CucumberExpressions
-
-    CAPITALISED_WORD = /[A-Z]+\w+/
+    CAPITALISED_WORD = /[A-Z]+\w+/.freeze
 
     class Name
     end
@@ -22,65 +23,64 @@ module Cucumber
       end
 
       it 'does not allow more than one prefer_for_regexp_match parameter type for each regexp' do
-        @registry.define_parameter_type(ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, true, true))
-        @registry.define_parameter_type(ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, true, false))
+        @registry.define_parameter_type(ParameterType.new('name', CAPITALISED_WORD, Name, ->(_s) { Name.new }, true, true))
+        @registry.define_parameter_type(ParameterType.new('person', CAPITALISED_WORD, Person, ->(_s) { Person.new }, true, false))
         expect do
-          @registry.define_parameter_type(ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, true, true))
+          @registry.define_parameter_type(ParameterType.new('place', CAPITALISED_WORD, Place, ->(_s) { Place.new }, true, true))
         end.to raise_error(
-                   CucumberExpressionError,
-                   "There can only be one preferential parameter type per regexp. The regexp /[A-Z]+\\w+/ is used for two preferential parameter types, {name} and {place}"
-               )
+          CucumberExpressionError,
+          'There can only be one preferential parameter type per regexp. The regexp /[A-Z]+\\w+/ is used for two preferential parameter types, {name} and {place}'
+        )
       end
 
       it 'looks up prefer_for_regexp_match parameter type by regexp' do
-        name = ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, true, false)
-        person = ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, true, true)
-        place = ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, true, false)
+        name = ParameterType.new('name', CAPITALISED_WORD, Name, ->(_s) { Name.new }, true, false)
+        person = ParameterType.new('person', CAPITALISED_WORD, Person, ->(_s) { Person.new }, true, true)
+        place = ParameterType.new('place', CAPITALISED_WORD, Place, ->(_s) { Place.new }, true, false)
 
         @registry.define_parameter_type(name)
         @registry.define_parameter_type(person)
         @registry.define_parameter_type(place)
 
-        expect(@registry.lookup_by_regexp(CAPITALISED_WORD.source, /([A-Z]+\w+) and ([A-Z]+\w+)/, "Lisa and Bob")).to eq(person)
+        expect(@registry.lookup_by_regexp(CAPITALISED_WORD.source, /([A-Z]+\w+) and ([A-Z]+\w+)/, 'Lisa and Bob')).to eq(person)
       end
 
       it 'throws ambiguous exception when no parameter types are prefer_for_regexp_match' do
-        name = ParameterType.new("name", CAPITALISED_WORD, Name, lambda {|s| Name.new}, true, false)
-        person = ParameterType.new("person", CAPITALISED_WORD, Person, lambda {|s| Person.new}, true, false)
-        place = ParameterType.new("place", CAPITALISED_WORD, Place, lambda {|s| Place.new}, true, false)
+        name = ParameterType.new('name', CAPITALISED_WORD, Name, ->(_s) { Name.new }, true, false)
+        person = ParameterType.new('person', CAPITALISED_WORD, Person, ->(_s) { Person.new }, true, false)
+        place = ParameterType.new('place', CAPITALISED_WORD, Place, ->(_s) { Place.new }, true, false)
 
         @registry.define_parameter_type(name)
         @registry.define_parameter_type(person)
         @registry.define_parameter_type(place)
 
         expect do
-          expect(@registry.lookup_by_regexp(CAPITALISED_WORD.source, /([A-Z]+\w+) and ([A-Z]+\w+)/, "Lisa and Bob")).to eq(person)
+          expect(@registry.lookup_by_regexp(CAPITALISED_WORD.source, /([A-Z]+\w+) and ([A-Z]+\w+)/, 'Lisa and Bob')).to eq(person)
         end.to raise_error(
-                   CucumberExpressionError,
-                   "Your Regular Expression /([A-Z]+\\w+) and ([A-Z]+\\w+)/\n" +
-                       "matches multiple parameter types with regexp /[A-Z]+\\w+/:\n" +
-                       "   {name}\n" +
-                       "   {person}\n" +
-                       "   {place}\n" +
-                       "\n" +
-                       "I couldn't decide which one to use. You have two options:\n" +
-                       "\n" +
-                       "1) Use a Cucumber Expression instead of a Regular Expression. Try one of these:\n" +
-                       "   {name} and {name}\n" +
-                       "   {name} and {person}\n" +
-                       "   {name} and {place}\n" +
-                       "   {person} and {name}\n" +
-                       "   {person} and {person}\n" +
-                       "   {person} and {place}\n" +
-                       "   {place} and {name}\n" +
-                       "   {place} and {person}\n" +
-                       "   {place} and {place}\n" +
-                       "\n" +
-                       "2) Make one of the parameter types preferential and continue to use a Regular Expression.\n" +
-                       "\n"
-               )
+          CucumberExpressionError,
+          "Your Regular Expression /([A-Z]+\\w+) and ([A-Z]+\\w+)/\n" \
+              "matches multiple parameter types with regexp /[A-Z]+\\w+/:\n" \
+              "   {name}\n" \
+              "   {person}\n" \
+              "   {place}\n" \
+              "\n" \
+              "I couldn't decide which one to use. You have two options:\n" \
+              "\n" \
+              "1) Use a Cucumber Expression instead of a Regular Expression. Try one of these:\n" \
+              "   {name} and {name}\n" \
+              "   {name} and {person}\n" \
+              "   {name} and {place}\n" \
+              "   {person} and {name}\n" \
+              "   {person} and {person}\n" \
+              "   {person} and {place}\n" \
+              "   {place} and {name}\n" \
+              "   {place} and {person}\n" \
+              "   {place} and {place}\n" \
+              "\n" \
+              "2) Make one of the parameter types preferential and continue to use a Regular Expression.\n" \
+              "\n"
+        )
       end
     end
   end
 end
-

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/parameter_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/parameter_type'
 
 module Cucumber
@@ -5,10 +7,11 @@ module Cucumber
     describe ParameterType do
       it 'does not allow ignore flag on regexp' do
         expect do
-          ParameterType.new("case-insensitive", /[a-z]+/i, String, lambda {|s| s}, true, true)
+          ParameterType.new('case-insensitive', /[a-z]+/i, String, ->(s) { s }, true, true)
         end.to raise_error(
           CucumberExpressionError,
-          "ParameterType Regexps can't use option Regexp::IGNORECASE")
+          "ParameterType Regexps can't use option Regexp::IGNORECASE"
+        )
       end
     end
   end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -1,68 +1,70 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/regular_expression'
 require 'cucumber/cucumber_expressions/parameter_type_registry'
 
 module Cucumber
   module CucumberExpressions
     describe RegularExpression do
-      it "documents match arguments" do
+      it 'documents match arguments' do
         parameter_type_registry = ParameterTypeRegistry.new
 
         ### [capture-match-arguments]
         expr = /I have (\d+) cukes? in my (\w*) now/
         expression = RegularExpression.new(expr, parameter_type_registry)
-        args = expression.match("I have 7 cukes in my belly now")
-        expect( args[0].value(nil) ).to eq(7)
-        expect( args[1].value(nil) ).to eq("belly")
+        args = expression.match('I have 7 cukes in my belly now')
+        expect(args[0].value(nil)).to eq(7)
+        expect(args[1].value(nil)).to eq('belly')
         ### [capture-match-arguments]
       end
 
-      it "does no transform by default" do
-        expect( match(/(\d\d)/, "22") ).to eq(["22"])
+      it 'does no transform by default' do
+        expect(match(/(\d\d)/, '22')).to eq(['22'])
       end
 
-      it "does not transform anonymous" do
-        expect( match(/(.*)/, "22") ).to eq(["22"])
+      it 'does not transform anonymous' do
+        expect(match(/(.*)/, '22')).to eq(['22'])
       end
 
-      it "transforms negative int" do
-        expect( match(/(-?\d+)/, "-22") ).to eq([-22])
+      it 'transforms negative int' do
+        expect(match(/(-?\d+)/, '-22')).to eq([-22])
       end
 
-      it "transforms positive int" do
-        expect( match(/(\d+)/, "22") ).to eq([22])
+      it 'transforms positive int' do
+        expect(match(/(\d+)/, '22')).to eq([22])
       end
 
-      it "returns nil when there is no match" do
-        expect( match(/hello/, "world") ).to be_nil
+      it 'returns nil when there is no match' do
+        expect(match(/hello/, 'world')).to be_nil
       end
 
-      it "matches nested capture group without match" do
-        expect( match(/^a user( named "([^"]*)")?$/, 'a user') ).to eq([nil])
+      it 'matches nested capture group without match' do
+        expect(match(/^a user( named "([^"]*)")?$/, 'a user')).to eq([nil])
       end
 
-      it "matches nested capture group with match" do
-        expect( match(/^a user( named "([^"]*)")?$/, 'a user named "Charlie"') ).to eq(['Charlie'])
+      it 'matches nested capture group with match' do
+        expect(match(/^a user( named "([^"]*)")?$/, 'a user named "Charlie"')).to eq(['Charlie'])
       end
 
-      it "ignores non capturing groups" do
-        expect( match(
-          /(\S+) ?(can|cannot) (?:delete|cancel) the (\d+)(?:st|nd|rd|th) (attachment|slide) ?(?:upload)?/,
-          "I can cancel the 1st slide upload")
-        ).to eq(["I", "can", 1, "slide"])
+      it 'ignores non capturing groups' do
+        expect(match(
+                 /(\S+) ?(can|cannot) (?:delete|cancel) the (\d+)(?:st|nd|rd|th) (attachment|slide) ?(?:upload)?/,
+                 'I can cancel the 1st slide upload'
+               )).to eq(['I', 'can', 1, 'slide'])
       end
 
-      it "matches capture group nested in optional one" do
+      it 'matches capture group nested in optional one' do
         regexp = /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
-        expect( match(regexp, 'a purchase') ).to eq([nil, nil])
-        expect( match(regexp, 'a purchase for $33') ).to eq([nil, 33])
-        expect( match(regexp, 'a pre buyer fee model purchase') ).to eq(['pre buyer fee model ', nil])
+        expect(match(regexp, 'a purchase')).to eq([nil, nil])
+        expect(match(regexp, 'a purchase for $33')).to eq([nil, 33])
+        expect(match(regexp, 'a pre buyer fee model purchase')).to eq(['pre buyer fee model ', nil])
       end
 
-      it "works with escaped parenthesis" do
-        expect( match(/Across the line\(s\)/, 'Across the line(s)') ).to eq([])
+      it 'works with escaped parenthesis' do
+        expect(match(/Across the line\(s\)/, 'Across the line(s)')).to eq([])
       end
 
-      it "exposes source and regexp" do
+      it 'exposes source and regexp' do
         regexp = /I have (\d+) cukes? in my (\+) now/
         expression = RegularExpression.new(regexp, ParameterTypeRegistry.new)
         expect(expression.regexp).to eq(regexp)
@@ -73,6 +75,7 @@ module Cucumber
         regular_expression = RegularExpression.new(expression, ParameterTypeRegistry.new)
         arguments = regular_expression.match(text)
         return nil if arguments.nil?
+
         arguments.map { |arg| arg.value(nil) }
       end
     end

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/tree_regexp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/cucumber_expressions/tree_regexp'
 
 module Cucumber
@@ -5,7 +7,7 @@ module Cucumber
     describe TreeRegexp do
       it 'exposes group source' do
         tr = TreeRegexp.new(/(a(?:b)?)(c)/)
-        expect(tr.group_builder.children.map{|gb| gb.source}).to eq(['a(?:b)?', 'c'])
+        expect(tr.group_builder.children.map(&:source)).to eq(['a(?:b)?', 'c'])
       end
 
       it 'builds tree' do
@@ -78,40 +80,40 @@ module Cucumber
 
       it 'detects multiple non capturing groups' do
         tr = TreeRegexp.new(/(?:a)(:b)(\?c)(d)/)
-        group = tr.match("a:b?cd")
+        group = tr.match('a:b?cd')
         expect(group.children.length).to eq(3)
       end
 
       it 'works with escaped backslash' do
         tr = TreeRegexp.new(/foo\\(bar|baz)/)
-        group = tr.match("foo\\bar")
+        group = tr.match('foo\\bar')
         expect(group.children.length).to eq(1)
       end
 
       it 'works with escaped slash' do
-        tr = TreeRegexp.new(/^I go to '\/(.+)'$/)
+        tr = TreeRegexp.new(%r{^I go to '/(.+)'$})
         group = tr.match("I go to '/hello'")
         expect(group.children.length).to eq(1)
       end
 
       it 'works with digit and word' do
         tr = TreeRegexp.new(/^(\d) (\w+)$/)
-        group = tr.match("2 you")
+        group = tr.match('2 you')
         expect(group.children.length).to eq(2)
       end
 
       it 'captures non capturing groups with capturing groups inside' do
         tr = TreeRegexp.new(/the stdout(?: from "(.*?)")?/)
-        group = tr.match("the stdout")
-        expect(group.value).to eq("the stdout")
+        group = tr.match('the stdout')
+        expect(group.value).to eq('the stdout')
         expect(group.children[0].value).to eq(nil)
         expect(group.children.length).to eq(1)
       end
 
       it 'works with flags' do
         tr = TreeRegexp.new(/HELLO/i)
-        group = tr.match("hello")
-        expect(group.value).to eq("hello")
+        group = tr.match('hello')
+        expect(group.value).to eq('hello')
       end
 
       it('does not consider parenthesis in character class as group') do
@@ -124,9 +126,9 @@ module Cucumber
 
       it 'throws an error when there are named capture groups because they are buggy in Ruby' do
         # https://github.com/cucumber/cucumber/issues/329
-        expect {
+        expect do
           TreeRegexp.new(/^I am a person( named "(?<first_name>.+) (?<last_name>.+)")?$/)
-        }.to raise_error(/Named capture groups are not supported/)
+        end.to raise_error(/Named capture groups are not supported/)
       end
     end
   end


### PR DESCRIPTION
We should add RuboCop and integrate it in the build in the same way as tslint/eslint for TypeScript.

This is a start, there are a lot of warnings to fix/ignore. The config and execution of rubocop also needs to be lifted up to `.templates/ruby`