### PR TITLE
Drop Gherkin::Query#argument_location which will not be useful

### DIFF
--- a/gherkin/ruby/lib/gherkin/query.rb
+++ b/gherkin/ruby/lib/gherkin/query.rb
@@ -2,7 +2,6 @@ module Gherkin
   class Query
     def initialize
       @ast_node_locations = {}
-      @argument_location_by_step_id = {}
     end
 
     def update(message)
@@ -12,10 +11,6 @@ module Gherkin
     def location(ast_node_id)
       return @ast_node_locations[ast_node_id] if @ast_node_locations.has_key?(ast_node_id)
       raise AstNodeNotLocatedException, "No location found for #{ast_node_id} }. Known: #{@ast_node_locations.keys}"
-    end
-
-    def argument_location(step_id)
-      return @argument_location_by_step_id[step_id]
     end
 
     private
@@ -52,17 +47,7 @@ module Gherkin
     end
 
     def update_steps(steps)
-      steps.map do |step|
-        store_node_location(step)
-
-        unless step.data_table.nil?
-          @argument_location_by_step_id[step.id] = step.data_table.location
-        end
-
-        unless step.doc_string.nil?
-          @argument_location_by_step_id[step.id] = step.doc_string.location
-        end
-      end
+      store_nodes_location(steps)
     end
 
     def store_nodes_location(nodes)

--- a/gherkin/ruby/spec/gherkin/query_spec.rb
+++ b/gherkin/ruby/spec/gherkin/query_spec.rb
@@ -17,7 +17,6 @@ describe Gherkin::Query do
   end
 
   let(:gherkin_document) { find_message_by_attribute(messages, :gherkin_document) }
-  let(:scenarios) { filter_messages_by_attribute(gherkin_document.feature.children, :scenario) }
 
   let(:messages) {
     Gherkin.from_source(
@@ -68,6 +67,7 @@ describe Gherkin::Query do
 
   context '#location' do
     let(:background) { find_message_by_attribute(gherkin_document.feature.children, :background) }
+    let(:scenarios) { filter_messages_by_attribute(gherkin_document.feature.children, :scenario) }
     let(:scenario) { scenarios.first }
 
     it 'raises an exception when the AST node ID is unknown' do
@@ -137,43 +137,6 @@ describe Gherkin::Query do
       it 'provides the location of a scenario step' do
         expect(subject.location(rule_scenario_step.id)).to eq(rule_scenario_step.location)
       end
-    end
-  end
-
-  context '#argument_location' do
-    let(:feature_content) {
-      """
-      Feature: my feature
-
-      Scenario: my scenario
-          Given a step with a datatable
-            | name   | value |
-            | things | stuff |
-          And a step with a docstring
-            \"\"\"
-            This contains things but also stuff in it
-            \"\"\"
-          And a step without arguments
-      """
-    }
-
-    let(:scenario) { scenarios.first }
-    let(:datatable_step) { scenario.steps.first }
-    let(:datatable) { datatable_step.data_table }
-    let(:docstring_step) { scenario.steps[1] }
-    let(:docstring) { docstring_step.doc_string }
-    let(:no_argument_step) { scenario.steps.last }
-
-    it 'provides the location of a step datatable when it is present' do
-      expect(subject.argument_location(datatable_step.id)).to eq(datatable.location)
-    end
-
-    it 'provides the location of a step docstring if it is present' do
-      expect(subject.argument_location(docstring_step.id)).to eq(docstring.location)
-    end
-
-    it 'returns nil if the step has no arguments' do
-      expect(subject.argument_location(no_argument_step.id)).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

This was added in #845 as a fix until #848 would be merged. But in fact, the location for the `DocStrings` and `DataTable` arguments are not used.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
