### PR TITLE
datatable/java: Add getter for TableConverter

### DIFF
--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTable.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/DataTable.java
@@ -3,9 +3,7 @@ package io.cucumber.datatable;
 import org.apiguardian.api.API;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -123,6 +121,15 @@ public final class DataTable {
      */
     public static DataTable emptyDataTable() {
         return new DataTable(Collections.emptyList(), new NoConverterDefined());
+    }
+
+    /**
+     * Returns the table converter of this data table.
+     *
+     * @return the tables table converter
+     */
+    public TableConverter getTableConverter() {
+        return tableConverter;
     }
 
     /**

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
@@ -7,16 +7,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static io.cucumber.datatable.DataTable.emptyDataTable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +36,20 @@ class DataTableTest {
         assertTrue(table.cells().isEmpty());
     }
 
+    @Test
+    void can_modify_data_tables() {
+        List<List<String>> raw = singletonList(emptyList());
+        DataTable table = DataTable.create(raw, tableConverter);
+        DataTable lowerCaseTable = DataTable.create(
+                raw.stream()
+                        .map(row -> row.stream()
+                                .map(String::toLowerCase)
+                                .collect(Collectors.toList()))
+                        .collect(Collectors.toList()),
+                table.getTableConverter()
+        );
+        assertSame(tableConverter, lowerCaseTable.getTableConverter());
+    }
 
     @Test
     void raw_should_equal_raw() {
@@ -295,7 +313,7 @@ class DataTableTest {
 
     @Test
     void empty_rows_are_ignored() {
-        List<List<String>> table1 = asList(Collections.emptyList(), Collections.emptyList());
+        List<List<String>> table1 = asList(emptyList(), emptyList());
         DataTable table = DataTable.create(table1, tableConverter);
         assertTrue(table.isEmpty());
         assertTrue(table.cells().isEmpty());


### PR DESCRIPTION
## Summary
DataTables are immutable. Changing the contents means they have to be
recreated. However it is not possible to recreate a data table and have
it use the same table converter as the original table.

Adding `DataTable.getTableConverter` makes this possible.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
