### PR TITLE
Json formatter hooks

### DIFF
--- a/json-formatter/CHANGELOG.md
+++ b/json-formatter/CHANGELOG.md
@@ -19,6 +19,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* Process rules
+
 ## [2.2.0] - 2020-01-10
 
 ### Changed

--- a/json-formatter/go/json.go
+++ b/json-formatter/go/json.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 	gio "github.com/gogo/protobuf/io"
 )
 

--- a/json-formatter/go/json.go
+++ b/json-formatter/go/json.go
@@ -47,14 +47,23 @@ func (self *Formatter) ProcessMessages(reader gio.ReadCloser, stdout io.Writer) 
 		switch m := envelope.Message.(type) {
 		case *messages.Envelope_TestCaseStarted:
 			testCase := ProcessTestCaseStarted(m.TestCaseStarted, self.lookup)
-			if testCase != nil {
-				self.testCaseById[testCase.TestCase.Id] = testCase
+			if testCase == nil {
+				panic(fmt.Sprintf("No testCase crested for %s", m.TestCaseStarted))
 			}
+			self.testCaseById[testCase.TestCase.Id] = testCase
 
 		case *messages.Envelope_TestStepFinished:
 			testStep := ProcessTestStepFinished(m.TestStepFinished, self.lookup)
 			if testStep != nil {
-				self.testCaseById[testStep.TestCaseID].appendStep(testStep)
+				testCase := self.testCaseById[testStep.TestCaseID]
+				if testCase == nil {
+					keys := make([]string, 0, len(self.testCaseById))
+					for k := range self.testCaseById {
+						keys = append(keys, k)
+					}
+					panic("No testCase for " + testStep.TestCaseID + strings.Join(keys, ", "))
+				}
+				testCase.appendStep(testStep)
 			}
 
 		case *messages.Envelope_TestCaseFinished:

--- a/json-formatter/go/json.go
+++ b/json-formatter/go/json.go
@@ -46,25 +46,26 @@ func (self *Formatter) ProcessMessages(reader gio.ReadCloser, stdout io.Writer) 
 
 		switch m := envelope.Message.(type) {
 		case *messages.Envelope_TestCaseStarted:
-			testCase := ProcessTestCaseStarted(m.TestCaseStarted, self.lookup)
-			if testCase == nil {
-				panic(fmt.Sprintf("No testCase crested for %s", m.TestCaseStarted))
+			err, testCase := ProcessTestCaseStarted(m.TestCaseStarted, self.lookup)
+			if err != nil {
+				return err
 			}
 			self.testCaseById[testCase.TestCase.Id] = testCase
 
 		case *messages.Envelope_TestStepFinished:
-			testStep := ProcessTestStepFinished(m.TestStepFinished, self.lookup)
-			if testStep != nil {
-				testCase := self.testCaseById[testStep.TestCaseID]
-				if testCase == nil {
-					keys := make([]string, 0, len(self.testCaseById))
-					for k := range self.testCaseById {
-						keys = append(keys, k)
-					}
-					panic("No testCase for " + testStep.TestCaseID + strings.Join(keys, ", "))
-				}
-				testCase.appendStep(testStep)
+			err, testStep := ProcessTestStepFinished(m.TestStepFinished, self.lookup)
+			if err != nil {
+				return err
 			}
+			testCase := self.testCaseById[testStep.TestCaseID]
+			if testCase == nil {
+				keys := make([]string, 0, len(self.testCaseById))
+				for k := range self.testCaseById {
+					keys = append(keys, k)
+				}
+				panic("No testCase for " + testStep.TestCaseID + strings.Join(keys, ", "))
+			}
+			testCase.appendStep(testStep)
 
 		case *messages.Envelope_TestCaseFinished:
 			testCaseStarted := self.lookup.LookupTestCaseStarted(m.TestCaseFinished.TestCaseStartedId)

--- a/json-formatter/go/message_lookup.go
+++ b/json-formatter/go/message_lookup.go
@@ -55,38 +55,12 @@ func (self *MessageLookup) ProcessMessage(envelope *messages.Envelope) (err erro
 		if m.GherkinDocument.Feature == nil {
 			return nil
 		}
-		for _, tag := range m.GherkinDocument.Feature.Tags {
-			self.tagByID[tag.Id] = tag
-		}
+		self.processTags(m.GherkinDocument.Feature.Tags)
 
 		for _, child := range m.GherkinDocument.Feature.Children {
-			background := child.GetBackground()
-			if background != nil {
-				for _, step := range background.Steps {
-					self.backgroundByStepID[step.Id] = background
-					self.stepByID[step.Id] = step
-				}
-			}
-
-			scenario := child.GetScenario()
-			if scenario != nil {
-				self.scenarioByID[scenario.Id] = scenario
-				for _, tag := range scenario.Tags {
-					self.tagByID[tag.Id] = tag
-				}
-
-				for _, step := range scenario.Steps {
-					self.stepByID[step.Id] = step
-				}
-
-				for _, example := range scenario.Examples {
-					for _, row := range example.TableBody {
-						// TODO: we may also need to add IDs to the examples
-						self.exampleByRowID[row.Id] = example
-						self.exampleRowByID[row.Id] = row
-					}
-				}
-			}
+			self.processRule(child.GetRule())
+			self.processBackground(child.GetBackground())
+			self.processScenario(child.GetScenario())
 		}
 
 	case *messages.Envelope_Pickle:
@@ -123,6 +97,49 @@ func (self *MessageLookup) ProcessMessage(envelope *messages.Envelope) (err erro
 	}
 
 	return nil
+}
+
+func (self *MessageLookup) processTags(tags []*messages.GherkinDocument_Feature_Tag) {
+	for _, tag := range tags {
+		self.tagByID[tag.Id] = tag
+	}
+}
+
+func (self *MessageLookup) processRule(rule *messages.GherkinDocument_Feature_FeatureChild_Rule) {
+	if rule != nil {
+		for _, ruleChild := range rule.Children {
+			self.processBackground(ruleChild.GetBackground())
+			self.processScenario(ruleChild.GetScenario())
+		}
+	}
+}
+
+func (self *MessageLookup) processBackground(background *messages.GherkinDocument_Feature_Background) {
+	if background != nil {
+		for _, step := range background.Steps {
+			self.backgroundByStepID[step.Id] = background
+			self.stepByID[step.Id] = step
+		}
+	}
+}
+
+func (self *MessageLookup) processScenario(scenario *messages.GherkinDocument_Feature_Scenario) {
+	if scenario != nil {
+		self.scenarioByID[scenario.Id] = scenario
+		self.processTags(scenario.Tags)
+
+		for _, step := range scenario.Steps {
+			self.stepByID[step.Id] = step
+		}
+
+		for _, example := range scenario.Examples {
+			for _, row := range example.TableBody {
+				// TODO: we may also need to add IDs to the examples
+				self.exampleByRowID[row.Id] = example
+				self.exampleRowByID[row.Id] = row
+			}
+		}
+	}
 }
 
 func (self *MessageLookup) LookupGherkinDocument(uri string) *messages.GherkinDocument {

--- a/json-formatter/go/message_lookup.go
+++ b/json-formatter/go/message_lookup.go
@@ -2,7 +2,7 @@ package json
 
 import (
 	"fmt"
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 )
 
 type MessageLookup struct {

--- a/json-formatter/go/test_case.go
+++ b/json-formatter/go/test_case.go
@@ -2,7 +2,7 @@ package json
 
 import (
 	"fmt"
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 	"strings"
 )
 

--- a/json-formatter/go/test_case.go
+++ b/json-formatter/go/test_case.go
@@ -25,17 +25,20 @@ type SortedSteps struct {
 func ProcessTestCaseStarted(testCaseStarted *messages.TestCaseStarted, lookup *MessageLookup) *TestCase {
 	testCase := lookup.LookupTestCase(testCaseStarted.TestCaseId)
 	if testCase == nil {
+		panic("No testCase for " + testCaseStarted.TestCaseId)
 		return nil
 	}
 
 	pickle := lookup.LookupPickle(testCase.PickleId)
 	if pickle == nil || len(pickle.AstNodeIds) == 0 {
+		panic("No pickle for " + testCase.PickleId)
 		return nil
 	}
 	tags := make([]*messages.GherkinDocument_Feature_Tag, len(pickle.Tags))
 	for index, tag := range pickle.Tags {
 		sourceTag := lookup.LookupTag(tag.AstNodeId)
 		if sourceTag == nil {
+			panic("No sourceTag for " + tag.AstNodeId)
 			return nil
 		}
 		tags[index] = sourceTag
@@ -43,11 +46,13 @@ func ProcessTestCaseStarted(testCaseStarted *messages.TestCaseStarted, lookup *M
 
 	scenario := lookup.LookupScenario(pickle.AstNodeIds[0])
 	if scenario == nil {
+		panic(fmt.Sprintf("No scenario for %s", strings.Join(pickle.AstNodeIds, ", ")))
 		return nil
 	}
 
 	feature := lookup.LookupGherkinDocument(pickle.Uri)
 	if feature == nil {
+		panic("No feature for " + pickle.Uri)
 		return nil
 	}
 	featureName := feature.Feature.Name
@@ -57,6 +62,7 @@ func ProcessTestCaseStarted(testCaseStarted *messages.TestCaseStarted, lookup *M
 		Scenario:    scenario,
 		Pickle:      pickle,
 		TestCase:    testCase,
+		Steps:       make([]*TestStep, 0),
 		Tags:        tags,
 	}
 }
@@ -150,6 +156,12 @@ func makeJSONTags(tags []*messages.GherkinDocument_Feature_Tag) []*jsonTag {
 }
 
 func (self *TestCase) appendStep(step *TestStep) {
+	if step == nil {
+		panic("step is nil")
+	}
+	if self.Steps == nil {
+		panic("self.Steps is nil")
+	}
 	self.Steps = append(self.Steps, step)
 }
 

--- a/json-formatter/go/test_case_test.go
+++ b/json-formatter/go/test_case_test.go
@@ -1,7 +1,7 @@
 package json
 
 import (
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/json-formatter/go/test_case_test.go
+++ b/json-formatter/go/test_case_test.go
@@ -14,7 +14,9 @@ var _ = Describe("TestCase.appendStep", func() {
 	)
 
 	BeforeEach(func() {
-		testCase = &TestCase{}
+		testCase = &TestCase{
+			Steps: make([]*TestStep, 0),
+		}
 		hookTestStep = &TestStep{
 			Hook: &messages.Hook{
 				Id: "my-hook",
@@ -233,7 +235,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		)
 		lookup.ProcessMessage(makeTestCaseEnvelope(testCaseMsg))
 
-		testCase = ProcessTestCaseStarted(&messages.TestCaseStarted{
+		_, testCase = ProcessTestCaseStarted(&messages.TestCaseStarted{
 			TestCaseId: testCaseMsg.Id,
 		}, lookup)
 	})
@@ -336,7 +338,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns nil if the TestCase has not been defined", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: "unknown-test-case-id",
 			}, lookup)
 
@@ -344,7 +346,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns nil if the Pickle is Unknown", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: testCaseReferencingUnknownPickle.Id,
 			}, lookup)
 
@@ -352,7 +354,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns nil if the Pickle has no source", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: testCaseForPickleWithoutSource.Id,
 			}, lookup)
 
@@ -360,7 +362,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns nil if the Pickle references an unknown scenario", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: testCaseForPickleWithWrongScenarioReference.Id,
 			}, lookup)
 
@@ -368,7 +370,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns nil if the Pickle does not reference an existing Gherkin document", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: testCaseForPickleWithWrongDocumentURI.Id,
 			}, lookup)
 
@@ -376,7 +378,7 @@ var _ = Describe("ProcessTestCaseStarted", func() {
 		})
 
 		It("returns Nil at least one PickleTag references a non-existing tag", func() {
-			testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
+			_, testCase := ProcessTestCaseStarted(&messages.TestCaseStarted{
 				TestCaseId: testCaseForPickleWithUnknownTag.Id,
 			}, lookup)
 
@@ -426,6 +428,7 @@ var _ = Describe("TestCaseToJSON", func() {
 					Name: "@foo",
 				},
 			},
+			Steps: make([]*TestStep, 0),
 		}
 
 		testCase.appendStep(&TestStep{

--- a/json-formatter/go/test_helpers.go
+++ b/json-formatter/go/test_helpers.go
@@ -1,7 +1,7 @@
 package json
 
 import (
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 )
 
 func makeScenario(id string, steps []*messages.GherkinDocument_Feature_Step) *messages.GherkinDocument_Feature_Scenario {

--- a/json-formatter/go/test_step.go
+++ b/json-formatter/go/test_step.go
@@ -3,7 +3,7 @@ package json
 import (
 	"encoding/base64"
 	"fmt"
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 	"strings"
 )
 

--- a/json-formatter/go/test_step.go
+++ b/json-formatter/go/test_step.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"github.com/cucumber/messages-go/v9"
 	"strings"
@@ -19,29 +20,29 @@ type TestStep struct {
 	Attachments     []*messages.Attachment
 }
 
-func ProcessTestStepFinished(testStepFinished *messages.TestStepFinished, lookup *MessageLookup) *TestStep {
+func ProcessTestStepFinished(testStepFinished *messages.TestStepFinished, lookup *MessageLookup) (error, *TestStep) {
 	testCaseStarted := lookup.LookupTestCaseStarted(testStepFinished.TestCaseStartedId)
 	if testCaseStarted == nil {
-		return nil
+		return errors.New("No testCaseStarted for " + testStepFinished.TestCaseStartedId), nil
 	}
 
 	testCase := lookup.LookupTestCase(testCaseStarted.TestCaseId)
 	if testCase == nil {
-		return nil
+		return errors.New("No testCase for " + testCaseStarted.TestCaseId), nil
 	}
 
 	testStep := lookup.LookupTestStep(testStepFinished.TestStepId)
 	if testStep == nil {
-		return nil
+		return errors.New("No testStep for " + testStepFinished.TestStepId), nil
 	}
 
 	if testStep.HookId != "" {
 		hook := lookup.LookupHook(testStep.HookId)
 		if hook == nil {
-			return nil
+			return errors.New("No hook for " + testStep.HookId), nil
 		}
 
-		return &TestStep{
+		return nil, &TestStep{
 			TestCaseID: testCase.Id,
 			Hook:       hook,
 			Result:     testStepFinished.TestResult,
@@ -50,12 +51,12 @@ func ProcessTestStepFinished(testStepFinished *messages.TestStepFinished, lookup
 
 	pickle := lookup.LookupPickle(testCase.PickleId)
 	if pickle == nil {
-		return nil
+		return errors.New("No pickle for " + testCase.PickleId), nil
 	}
 
 	pickleStep := lookup.LookupPickleStep(testStep.PickleStepId)
 	if pickleStep == nil {
-		return nil
+		return errors.New("No pickleStep for " + testStep.PickleStepId), nil
 	}
 
 	var background *messages.GherkinDocument_Feature_Background
@@ -64,7 +65,7 @@ func ProcessTestStepFinished(testStepFinished *messages.TestStepFinished, lookup
 		background = lookup.LookupBackgroundByStepID(scenarioStep.Id)
 	}
 
-	return &TestStep{
+	return nil, &TestStep{
 		TestCaseID:      testCase.Id,
 		Step:            lookup.LookupStep(pickleStep.AstNodeIds[0]),
 		Pickle:          pickle,

--- a/json-formatter/go/test_step_test.go
+++ b/json-formatter/go/test_step_test.go
@@ -1,7 +1,7 @@
 package json
 
 import (
-	messages "github.com/cucumber/messages-go/v9"
+	"github.com/cucumber/messages-go/v9"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/json-formatter/go/test_step_test.go
+++ b/json-formatter/go/test_step_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 			TestStepId:        "test-step-id",
 		}
 
-		testStep := ProcessTestStepFinished(testStepFinished, lookup)
+		_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 		Expect(testStep.TestCaseID).To(Equal("test-case-id"))
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestCaseStartedId: "test-case-started-id",
 				TestStepId:        "unknown-step",
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(testStep).To(BeNil())
 		})
 
@@ -70,7 +70,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestCaseStartedId: "unknown-test-case-started",
 				TestStepId:        "test-step-id",
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(testStep).To(BeNil())
 		})
 
@@ -85,7 +85,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestCaseStartedId: testCaseStarted.Id,
 				TestStepId:        "test-step-id",
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(testStep).To(BeNil())
 		})
 	})
@@ -123,7 +123,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				},
 			}
 
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 
 			Expect(testStep.Hook.Id).To(Equal("hook-id"))
 			Expect(testStep.Result.Status).To(Equal(messages.TestResult_PASSED))
@@ -135,7 +135,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestStepId:        "hook-step-id",
 			}
 
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 
 			Expect(testStep.Step).To(BeNil())
 		})
@@ -145,7 +145,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestCaseStartedId: "test-case-started-id",
 				TestStepId:        "wrong-hook-step-id",
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 
 			Expect(testStep).To(BeNil())
 		})
@@ -226,7 +226,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestCaseStartedId: testCaseStarted.Id,
 			}
 
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(testStep.Step.Id).To(Equal("step-id"))
 		})
 
@@ -235,7 +235,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestStepId:        "test-step-id",
 				TestCaseStartedId: testCaseStarted.Id,
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(len(testStep.StepDefinitions)).To(Equal(1))
 			Expect(testStep.StepDefinitions[0].Pattern.Source).To(Equal("a passed {word}"))
 		})
@@ -245,7 +245,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 				TestStepId:        "test-step-id",
 				TestCaseStartedId: testCaseStarted.Id,
 			}
-			testStep := ProcessTestStepFinished(testStepFinished, lookup)
+			_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 			Expect(testStep.Background).To(BeNil())
 		})
 
@@ -255,7 +255,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 					TestStepId:        "background-step-id",
 					TestCaseStartedId: testCaseStarted.Id,
 				}
-				testStep := ProcessTestStepFinished(testStepFinished, lookup)
+				_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 				Expect(testStep.Background).To(Equal(background))
 			})
 		})
@@ -280,7 +280,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 					TestCaseStartedId: testCaseStarted.Id,
 				}
 
-				testStep := ProcessTestStepFinished(testStepFinished, lookup)
+				_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 				Expect(testStep).To(BeNil())
 			})
 
@@ -290,7 +290,7 @@ var _ = Describe("ProcessTestStepFinished", func() {
 					TestCaseStartedId: testCaseStarted.Id,
 				}
 
-				testStep := ProcessTestStepFinished(testStepFinished, lookup)
+				_, testStep := ProcessTestStepFinished(testStepFinished, lookup)
 				Expect(testStep).To(BeNil())
 			})
 		})


### PR DESCRIPTION
Fix the CCK for `cucumber-json-formatter`. This also replaces defensive programming with fail-fast.