### PR TITLE
demo-formatter: Fix demo-formatter folder name in example script

### DIFF
--- a/demo-formatter/README.md
+++ b/demo-formatter/README.md
@@ -14,8 +14,8 @@ over the `.feature` files used as test data in [gherkin](../gherkin/testdata/goo
 ```
 npm install -g fake-cucumber
 cd ../gherkin
-fake-cucumber --results=random testdata/good/*.feature > ../cucumber-demo-formatter/cucumber-messages.bin
-cd ../cucumber-demo-formatter
+fake-cucumber --results=random testdata/good/*.feature > ../demo-formatter/cucumber-messages.bin
+cd ../demo-formatter
 ls -al
 ```
 


### PR DESCRIPTION
## Summary

Just fix a typo introduced when renaming `cucumber-demo-formatter` to `demo-formatter` in 97123062d.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

