### PR TITLE
Gherkin#fromPaths emits an error if a path can't be read

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,6 +19,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* [JavaScript] `Gherkin#fromPaths` emits an error if a path can't be read (for example if it is a directory)
+
 ## [9.2.0] - 2020-01-22
 
 ### Added

--- a/gherkin/javascript/test/StreamTest.ts
+++ b/gherkin/javascript/test/StreamTest.ts
@@ -19,6 +19,12 @@ describe('gherkin', () => {
     assert.strictEqual(envelopes.length, 3)
   })
 
+  it('throws an error when the path is a directory', async () => {
+    assert.rejects(async () =>
+      streamToArray(Gherkin.fromPaths(['testdata/good'], defaultOptions))
+    )
+  })
+
   it('parses gherkin from STDIN', async () => {
     const source = makeSourceEnvelope(
       `Feature: Minimal


### PR DESCRIPTION
Users of the Gherkin library may pass a directory to `Gherkin#fromPaths`, assuming it will recurse into directories (it will not). This change causes it to emit an error if a path cannot be read.