### PR TITLE
Support up to 10MB NDJSON messages

### DIFF
--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* [Go] Increase max size of a JSON message to 10Mb
+  ([#901](https://github.com/cucumber/cucumber/issues/901)
+   []()
+   [aslakhellesoy])
+
 ## [10.0.1] - 2020-02-13
 
 ### Fixed

--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * [Go] Increase max size of a JSON message to 10Mb
   ([#901](https://github.com/cucumber/cucumber/issues/901)
-   []()
+   [#903](https://github.com/cucumber/cucumber/pull/903)
    [aslakhellesoy])
 
 ## [10.0.1] - 2020-02-13

--- a/messages/go/io/ndjson.go
+++ b/messages/go/io/ndjson.go
@@ -55,6 +55,9 @@ func NewNdjsonReader(r io.Reader) gio.ReadCloser {
 		closer = c
 	}
 	scanner := bufio.NewScanner(r)
+	const maxCapacity = 10 * 1024 * 1024 // 10Mb
+	buf := make([]byte, maxCapacity)
+	scanner.Buffer(buf, maxCapacity)
 	return &ndjsonReader{bufio.NewReader(r), scanner, closer}
 }
 

--- a/messages/go/messages_test.go
+++ b/messages/go/messages_test.go
@@ -69,8 +69,8 @@ func TestMessages(t *testing.T) {
 		require.Equal(t, "Hello", decoded.GetText())
 	})
 
-	t.Run("reads an attachment with a 70k string as NDJSON", func(t *testing.T) {
-		ba := make([]byte, 70000)
+	t.Run("reads an attachment with a 9Mb string as NDJSON", func(t *testing.T) {
+		ba := make([]byte, 9*1024*1024)
 		for i := range ba {
 			ba[i] = "x"[0]
 		}


### PR DESCRIPTION
Increase limit of NDJSON messages from 64Kb to 10Mb. Closes #901.

I chose 10Mb because it should be sufficient for most image attachments. If larger attachments are needed (movie attachments probably) we need to rethink the strategy. Maybe make the max size configurable, and/or try to detect if messages are too big.