### PR TITLE
gherkin/javascript: make Dialect available on main export

### DIFF
--- a/gherkin/javascript/src/index.ts
+++ b/gherkin/javascript/src/index.ts
@@ -1,6 +1,7 @@
 import Gherkin from './Gherkin'
 import IGherkinOptions from './IGherkinOptions'
 import Query from './Query'
+import Dialect from './Dialect'
 
 export default Gherkin
-export { IGherkinOptions, Query }
+export { IGherkinOptions, Query, Dialect }


### PR DESCRIPTION
See https://github.com/cucumber/cucumber-js/pull/1286#discussion_r387779311

`Dialect` is not currently on the main export from gherkin, so in consuming projects we are having to reach into dist directly; this adds it.