### PR TITLE
html-formatter/javascript: Remove npm-link-shared hack

### DIFF
--- a/html-formatter/javascript/Makefile
+++ b/html-formatter/javascript/Makefile
@@ -2,7 +2,7 @@ include default.mk
 
 .tested: acceptance/cucumber.html
 
-acceptance/cucumber.html: .built-npm-link-shared
+acceptance/cucumber.html:
 	mkdir -p $(@D)
 	../../fake-cucumber/javascript/bin/fake-cucumber \
 	  --format ndjson \
@@ -10,6 +10,3 @@ acceptance/cucumber.html: .built-npm-link-shared
 		./bin/cucumber-html-formatter.js --format ndjson > \
 		$@
 
-.built-npm-link-shared:
-	./node_modules/.bin/npm-link-shared ./node_modules/@cucumber/react/node_modules . react
-	touch $@

--- a/html-formatter/javascript/webpack.config.js
+++ b/html-formatter/javascript/webpack.config.js
@@ -3,6 +3,9 @@ const path = require('path')
 module.exports = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
+    alias: {
+      react: path.resolve('./node_modules/react')
+    }
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
## Summary

The `npm-link-shared` hack didn't work because it runs after Make ran npm
install. So at this point `dist/src/main.js` was already created with the
duplicate react include.

By aliasing react inside webpack we can avoid this problem. All versions of
react will be resolved to the direct dependency.