### PR TITLE
Dockerfile: add dependencies for Ruby build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN apk add --no-cache \
   g++ \
   jq \
   libc-dev \
+  libxml2-dev \
+  libxslt-dev \
   make \
   maven \
   nodejs \


### PR DESCRIPTION
To enable to build of `Nokogiri`, we need `libxml2-dev` and `libxslt-dev` on the image.

Previously, we were simply running `apk add libxml2-dev libxslt-dev` during the Ruby build but we do not have the possibility to do so anymore as we run the image as `cukebot` (and `sudo` is not available))