### PR TITLE
html-formatter: stream messages rather than buffering

### DIFF
--- a/.templates/javascript/default.mk
+++ b/.templates/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/c21e/javascript/default.mk
+++ b/c21e/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/compatibility-kit/javascript/default.mk
+++ b/compatibility-kit/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/cucumber-expressions/javascript/default.mk
+++ b/cucumber-expressions/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/fake-cucumber/javascript/default.mk
+++ b/fake-cucumber/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/gherkin/javascript/default.mk
+++ b/gherkin/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/html-formatter/CHANGELOG.md
+++ b/html-formatter/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* [JavaScript] Lower memory footprint - messages are no longer buffered during HTML generation
+
 ## [4.1.0] - 2020-03-02
 
 ### Added

--- a/html-formatter/Makefile
+++ b/html-formatter/Makefile
@@ -1,1 +1,2 @@
+LANGUAGES ?= javascript
 include default.mk

--- a/html-formatter/javascript/Makefile
+++ b/html-formatter/javascript/Makefile
@@ -2,7 +2,7 @@ include default.mk
 
 .tested: acceptance/cucumber.html
 
-acceptance/cucumber.html:
+acceptance/cucumber.html: .built
 	mkdir -p $(@D)
 	../../fake-cucumber/javascript/bin/fake-cucumber \
 	  --format ndjson \

--- a/html-formatter/javascript/default.mk
+++ b/html-formatter/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/html-formatter/javascript/package.json
+++ b/html-formatter/javascript/package.json
@@ -18,7 +18,7 @@
     "test": "mocha",
     "lint": "eslint --ext ts,tsx --max-warnings 0 src test",
     "lint-fix": "eslint --ext ts,tsx --max-warnings 0 --fix src test",
-    "build": "tsc && webpack-cli src/main.tsx"
+    "build": "tsc && webpack-cli src/main.tsx && cp src/index.mustache.html dist/src"
   },
   "dependencies": {
     "@cucumber/messages": "file:../../messages/javascript",

--- a/html-formatter/javascript/src/CucumberHtmlStream.ts
+++ b/html-formatter/javascript/src/CucumberHtmlStream.ts
@@ -1,0 +1,122 @@
+import fs from 'fs'
+import { Readable, Transform, TransformCallback } from 'stream'
+import { messages } from '@cucumber/messages'
+
+export default class CucumberHtmlStream extends Transform {
+  private template: string | null = null
+  private preMessageWritten = false
+  private postMessageWritten = false
+  private firstMessageWritten = false
+  /**
+   * @param cssPath
+   * @param jsPath
+   */
+  constructor(cssPath: string, jsPath: string) {
+    super({ objectMode: true })
+    this.cssPath = cssPath
+    this.jsPath = jsPath
+  }
+
+  public _transform(
+    envelope: messages.Envelope,
+    encoding: string,
+    callback: TransformCallback
+  ): void {
+    if (this.postMessageWritten) {
+      return callback(new Error('Stream closed'))
+    }
+
+    this.writePreMessageUnlessAlreadyWritten(err => {
+      if (err) return callback(err)
+      this.writeMessage(envelope)
+      callback()
+    })
+  }
+
+  public _flush(callback: TransformCallback): void {
+    this.writePostMessage(callback)
+  }
+
+  private cssPath: string
+
+  private writePreMessageUnlessAlreadyWritten(callback: TransformCallback) {
+    if (this.preMessageWritten) {
+      return callback()
+    }
+    this.preMessageWritten = true
+    this.writeTemplateBetween(null, '{{css}}', err => {
+      if (err) return callback(err)
+      this.writeFile(this.cssPath, err => {
+        if (err) return callback(err)
+        this.writeTemplateBetween('{{css}}', '{{messages}}', err => {
+          if (err) return callback(err)
+          // this.writeResource("cucumber-react.css", callback);
+          callback()
+        })
+      })
+    })
+  }
+
+  private jsPath: string
+
+  private writePostMessage(callback: TransformCallback) {
+    this.writePreMessageUnlessAlreadyWritten(err => {
+      if (err) return callback(err)
+      this.writeTemplateBetween('{{messages}}', '{{script}}', err => {
+        if (err) return callback(err)
+        this.writeFile(this.jsPath, err => {
+          if (err) return callback(err)
+          this.writeTemplateBetween('{{script}}', null, callback)
+        })
+      })
+    })
+  }
+
+  private writeFile(path: string, callback: (error?: Error | null) => void) {
+    const cssStream: Readable = fs.createReadStream(path, { encoding: 'utf-8' })
+    cssStream.on('data', chunk => this.push(chunk))
+    cssStream.on('error', err => callback(err))
+    cssStream.on('end', callback)
+  }
+
+  private writeTemplateBetween(
+    begin: string | null,
+    end: string | null,
+    callback: (err?: Error | null) => void
+  ) {
+    this.readTemplate((err, template) => {
+      if (err) return callback(err)
+      const beginIndex =
+        begin == null ? 0 : template.indexOf(begin) + begin.length
+      const endIndex = end == null ? template.length : template.indexOf(end)
+      this.push(template.substring(beginIndex, endIndex))
+      callback()
+    })
+  }
+
+  private readTemplate(
+    callback: (error?: Error | null, data?: string) => void
+  ) {
+    if (this.template !== null) {
+      return callback(null, this.template)
+    }
+    fs.readFile(
+      __dirname + '/index.mustache.html',
+      { encoding: 'utf-8' },
+      (err, template) => {
+        if (err) return callback(err)
+        this.template = template
+        return callback(null, template)
+      }
+    )
+  }
+
+  private writeMessage(envelope: messages.Envelope) {
+    if (!this.firstMessageWritten) {
+      this.firstMessageWritten = true
+    } else {
+      this.push(',')
+    }
+    this.push(JSON.stringify(envelope.toJSON()))
+  }
+}

--- a/html-formatter/javascript/src/cli-main.ts
+++ b/html-formatter/javascript/src/cli-main.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'fs'
 import {
   BinaryToMessageStream,
   messages,
@@ -6,66 +5,8 @@ import {
 } from '@cucumber/messages'
 import program from 'commander'
 import p from '../package.json'
-import { pipeline, Transform, TransformCallback } from 'stream'
-
-class CucumberHtmlStream extends Transform {
-  private readonly envelopes: messages.IEnvelope[] = []
-
-  constructor() {
-    super({ objectMode: true })
-  }
-
-  public _transform(
-    envelope: messages.IEnvelope,
-    encoding: string,
-    callback: TransformCallback
-  ): void {
-    this.envelopes.push(envelope)
-    callback()
-  }
-
-  public _flush(callback: TransformCallback): void {
-    readFile(
-      __dirname + '/../main.js',
-      { encoding: 'utf-8' },
-      (err: Error, js: string) => {
-        if (err) return callback(err)
-
-        readFile(
-          __dirname +
-            '/../../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css',
-          { encoding: 'utf-8' },
-          (err: Error, css: string) => {
-            if (err) return callback(err)
-
-            this.push(`<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Cucumber</title>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-    <style>
-${css}
-    </style>
-  </head>
-  <body>
-    <div id="content">
-    </div>
-    <script>
-      window.CUCUMBER_MESSAGES = ${JSON.stringify(this.envelopes)}
-    </script>
-    <script>
-${js}
-    </script>
-  </body>
-</html>
-`)
-            callback()
-          }
-        )
-      }
-    )
-  }
-}
+import { pipeline } from 'stream'
+import CucumberHtmlStream from './CucumberHtmlStream'
 
 program.version(p.version)
 program.option(
@@ -87,7 +28,11 @@ const toMessageStream =
 pipeline(
   process.stdin,
   toMessageStream,
-  new CucumberHtmlStream(),
+  new CucumberHtmlStream(
+    __dirname +
+      '/../../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css',
+    __dirname + '/../../dist/main.js'
+  ),
   process.stdout,
   (err: any) => {
     // tslint:disable-next-line:no-console

--- a/html-formatter/javascript/src/index.mustache.html
+++ b/html-formatter/javascript/src/index.mustache.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Cucumber</title>
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<style>
+{{css}}
+	</style>
+</head>
+<body>
+<div id="content">
+</div>
+<script>
+window.CUCUMBER_MESSAGES = [{{messages}}];
+</script>
+<script>
+{{script}}
+</script>
+</body>
+</html>

--- a/html-formatter/javascript/test/CucumberHtmlStreamTest.ts
+++ b/html-formatter/javascript/test/CucumberHtmlStreamTest.ts
@@ -1,0 +1,70 @@
+import { messages } from '@cucumber/messages'
+import CucumberHtmlStream from '../src/CucumberHtmlStream'
+import { Writable } from 'stream'
+import assert from 'assert'
+
+async function renderAsHtml(
+  ...envelopes: messages.IEnvelope[]
+): Promise<string> {
+  return new Promise(resolve => {
+    let html = ''
+    const sink: Writable = new Writable({
+      write(
+        chunk: any,
+        encoding: string,
+        callback: (error?: Error | null) => void
+      ): void {
+        html += chunk
+        callback()
+      },
+    })
+    sink.on('finish', () => resolve(html))
+    const cucumberHtmlStream = new CucumberHtmlStream(
+      __dirname +
+        '/../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css',
+      __dirname + '/../dist/main.js'
+    )
+    cucumberHtmlStream.pipe(sink)
+
+    for (const envelope of envelopes) {
+      cucumberHtmlStream.write(envelope)
+    }
+    cucumberHtmlStream.end()
+  })
+}
+
+describe('CucumberHtmlStream', () => {
+  it('writes zero messages to html', async () => {
+    const html = await renderAsHtml()
+    assert(html.indexOf('window.CUCUMBER_MESSAGES = []') >= 0)
+  })
+
+  it('writes one message to html', async () => {
+    const e1 = messages.Envelope.create({
+      testRunStarted: messages.TestRunStarted.create({}),
+    })
+    const html = await renderAsHtml(e1)
+    assert(
+      html.indexOf(
+        `window.CUCUMBER_MESSAGES = [${JSON.stringify(e1.toJSON())}]`
+      ) >= 0
+    )
+  })
+
+  it('writes one message to html', async () => {
+    const e1 = messages.Envelope.create({
+      testRunStarted: messages.TestRunStarted.create({}),
+    })
+    const e2 = messages.Envelope.create({
+      testRunFinished: messages.TestRunFinished.create({}),
+    })
+    const html = await renderAsHtml(e1, e2)
+    assert(
+      html.indexOf(
+        `window.CUCUMBER_MESSAGES = [${JSON.stringify(
+          e1.toJSON()
+        )},${JSON.stringify(e2.toJSON())}]`
+      ) >= 0
+    )
+  })
+})

--- a/json-formatter/javascript/default.mk
+++ b/json-formatter/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/messages/javascript/default.mk
+++ b/messages/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/query/javascript/default.mk
+++ b/query/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/react/javascript/default.mk
+++ b/react/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 

--- a/tag-expressions/javascript/default.mk
+++ b/tag-expressions/javascript/default.mk
@@ -24,7 +24,9 @@ default: .tested .built .linted
 	$(NPM) run build
 	touch $@
 
-.tested: .built $(TYPESCRIPT_SOURCE_FILES)
+.tested: .tested-npm
+
+.tested-npm: .built $(TYPESCRIPT_SOURCE_FILES)
 	TS_NODE_TRANSPILE_ONLY=1 $(NPM) run test
 	touch $@
 


### PR DESCRIPTION
## Summary

Reduce memory footprint for HTML formatter

## Details

Stream the HTML as messages are received

## Motivation and Context

Prior to this change we'd buffer all messages in memory and only flush the HTML when the stream is flushed. This consumes too much memory when there are big messages (screenshots)


