### PR TITLE
TypeScript: Use ReadOnlyArray

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [JavaScript] All array return values and function parameters are now declared as TypeScript `ReadOnlyArray`
+
 ### Deprecated
 
 ### Removed

--- a/cucumber-expressions/javascript/src/Argument.ts
+++ b/cucumber-expressions/javascript/src/Argument.ts
@@ -7,8 +7,8 @@ export default class Argument<T> {
   public static build(
     treeRegexp: TreeRegexp,
     text: string,
-    parameterTypes: Array<ParameterType<any>>
-  ): Array<Argument<any>> {
+    parameterTypes: ReadonlyArray<ParameterType<any>>
+  ): ReadonlyArray<Argument<any>> {
     const group = treeRegexp.match(text)
     if (!group) {
       return null

--- a/cucumber-expressions/javascript/src/CombinatorialGeneratedExpressionFactory.ts
+++ b/cucumber-expressions/javascript/src/CombinatorialGeneratedExpressionFactory.ts
@@ -12,7 +12,7 @@ export default class CombinatorialGeneratedExpressionFactory {
     this.expressionTemplate = expressionTemplate
   }
 
-  public generateExpressions() {
+  public generateExpressions(): ReadonlyArray<GeneratedExpression> {
     const generatedExpressions: GeneratedExpression[] = []
     this.generatePermutations(generatedExpressions, 0, [])
     return generatedExpressions

--- a/cucumber-expressions/javascript/src/CucumberExpression.ts
+++ b/cucumber-expressions/javascript/src/CucumberExpression.ts
@@ -98,7 +98,7 @@ export default class CucumberExpression implements Expression {
     })
   }
 
-  public match(text: string): Array<Argument<any>> {
+  public match(text: string): ReadonlyArray<Argument<any>> {
     return Argument.build(this.treeRegexp, text, this.parameterTypes)
   }
 
@@ -106,7 +106,7 @@ export default class CucumberExpression implements Expression {
     return this.treeRegexp.regexp
   }
 
-  get source() {
+  get source(): string {
     return this.expression
   }
 
@@ -117,7 +117,7 @@ export default class CucumberExpression implements Expression {
   }
 }
 
-function buildCaptureRegexp(regexps: string[]) {
+function buildCaptureRegexp(regexps: ReadonlyArray<string>) {
   if (regexps.length === 1) {
     return `(${regexps[0]})`
   }

--- a/cucumber-expressions/javascript/src/CucumberExpressionGenerator.ts
+++ b/cucumber-expressions/javascript/src/CucumberExpressionGenerator.ts
@@ -9,7 +9,7 @@ import GeneratedExpression from './GeneratedExpression'
 export default class CucumberExpressionGenerator {
   constructor(private readonly parameterTypeRegistry: ParameterTypeRegistry) {}
 
-  public generateExpressions(text: string): GeneratedExpression[] {
+  public generateExpressions(text: string): ReadonlyArray<GeneratedExpression> {
     const parameterTypeCombinations: Array<Array<ParameterType<any>>> = []
     const parameterTypeMatchers = this.createParameterTypeMatchers(text)
     let expressionTemplate = ''

--- a/cucumber-expressions/javascript/src/Errors.ts
+++ b/cucumber-expressions/javascript/src/Errors.ts
@@ -7,8 +7,8 @@ class AmbiguousParameterTypeError extends CucumberExpressionError {
   public static forConstructor(
     keyName: string,
     keyValue: string,
-    parameterTypes: Array<ParameterType<any>>,
-    generatedExpressions: GeneratedExpression[]
+    parameterTypes: ReadonlyArray<ParameterType<any>>,
+    generatedExpressions: ReadonlyArray<GeneratedExpression>
   ) {
     return new this(
       `parameter type with ${keyName}=${keyValue} is used by several parameter types: ${parameterTypes}, ${generatedExpressions}`
@@ -18,8 +18,8 @@ class AmbiguousParameterTypeError extends CucumberExpressionError {
   public static forRegExp(
     parameterTypeRegexp: string,
     expressionRegexp: RegExp,
-    parameterTypes: Array<ParameterType<any>>,
-    generatedExpressions: GeneratedExpression[]
+    parameterTypes: ReadonlyArray<ParameterType<any>>,
+    generatedExpressions: ReadonlyArray<GeneratedExpression>
   ) {
     return new this(
       `Your Regular Expression ${expressionRegexp}
@@ -36,11 +36,15 @@ I couldn't decide which one to use. You have two options:
     )
   }
 
-  public static _parameterTypeNames(parameterTypes: Array<ParameterType<any>>) {
+  public static _parameterTypeNames(
+    parameterTypes: ReadonlyArray<ParameterType<any>>
+  ) {
     return parameterTypes.map(p => `{${p.name}}`).join('\n   ')
   }
 
-  public static _expressions(generatedExpressions: GeneratedExpression[]) {
+  public static _expressions(
+    generatedExpressions: ReadonlyArray<GeneratedExpression>
+  ) {
     return generatedExpressions.map(e => e.source).join('\n   ')
   }
 }

--- a/cucumber-expressions/javascript/src/Expression.ts
+++ b/cucumber-expressions/javascript/src/Expression.ts
@@ -2,5 +2,5 @@ import Argument from './Argument'
 
 export default interface Expression {
   readonly source: string
-  match(text: string): Array<Argument<any>>
+  match(text: string): ReadonlyArray<Argument<any>>
 }

--- a/cucumber-expressions/javascript/src/GeneratedExpression.ts
+++ b/cucumber-expressions/javascript/src/GeneratedExpression.ts
@@ -4,7 +4,7 @@ import ParameterType from './ParameterType'
 export default class GeneratedExpression {
   constructor(
     private readonly expressionTemplate: string,
-    public readonly parameterTypes: Array<ParameterType<any>>
+    public readonly parameterTypes: ReadonlyArray<ParameterType<any>>
   ) {}
 
   get source() {
@@ -17,9 +17,9 @@ export default class GeneratedExpression {
   /**
    * Returns an array of parameter names to use in generated function/method signatures
    *
-   * @returns {Array.<String>}
+   * @returns {ReadonlyArray.<String>}
    */
-  get parameterNames() {
+  get parameterNames(): ReadonlyArray<string> {
     const usageByTypeName: { [key: string]: number } = {}
     return this.parameterTypes.map(t =>
       getParameterName(t.name, usageByTypeName)

--- a/cucumber-expressions/javascript/src/Group.ts
+++ b/cucumber-expressions/javascript/src/Group.ts
@@ -3,7 +3,7 @@ export default class Group {
     public readonly value: string | null,
     public readonly start: number,
     public readonly end: number,
-    public readonly children: Group[]
+    public readonly children: ReadonlyArray<Group>
   ) {}
 
   get values(): string[] {

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -4,7 +4,7 @@ import RegexExecArray from './RegexExecArray'
 export default class GroupBuilder {
   public source: string
   public capturing = true
-  private groupBuilders: GroupBuilder[] = []
+  private readonly groupBuilders: GroupBuilder[] = []
 
   public add(groupBuilder: GroupBuilder) {
     this.groupBuilders.push(groupBuilder)

--- a/cucumber-expressions/javascript/src/ParameterType.ts
+++ b/cucumber-expressions/javascript/src/ParameterType.ts
@@ -4,7 +4,7 @@ const ILLEGAL_PARAMETER_NAME_PATTERN = /([[\]()$.|?*+])/
 const UNESCAPE_PATTERN = () => /(\\([[$.|?*+\]]))/g
 
 export default class ParameterType<T> {
-  private transformFn: (...match: string[]) => T
+  private transformFn: (...match: ReadonlyArray<string>) => T
 
   public static compare(pt1: ParameterType<any>, pt2: ParameterType<any>) {
     if (pt1.preferForRegexpMatch && !pt2.preferForRegexpMatch) {
@@ -26,7 +26,7 @@ export default class ParameterType<T> {
     }
   }
 
-  public regexpStrings: string[]
+  public regexpStrings: ReadonlyArray<string>
 
   /**
    * @param name {String} the name of the type
@@ -38,7 +38,7 @@ export default class ParameterType<T> {
    */
   constructor(
     public readonly name: string,
-    regexps: RegExp[] | string[] | RegExp | string,
+    regexps: ReadonlyArray<RegExp> | ReadonlyArray<string> | RegExp | string,
     private readonly type: any,
     transform: (...match: string[]) => T,
     public readonly useForSnippets: boolean,
@@ -67,7 +67,9 @@ export default class ParameterType<T> {
   }
 }
 
-function stringArray(regexps: RegExp[] | string[] | RegExp | string): string[] {
+function stringArray(
+  regexps: ReadonlyArray<RegExp> | ReadonlyArray<string> | RegExp | string
+): string[] {
   const array = Array.isArray(regexps) ? regexps : [regexps]
   return array.map((r: RegExp | string) =>
     r instanceof RegExp ? regexpSource(r) : r

--- a/cucumber-expressions/javascript/src/RegexExecArray.ts
+++ b/cucumber-expressions/javascript/src/RegexExecArray.ts
@@ -1,4 +1,4 @@
-export default interface RegexExecArray extends Array<string> {
-  index: number[]
+export default interface RegexExecArray extends ReadonlyArray<string> {
+  index: ReadonlyArray<number>
   input: string
 }

--- a/cucumber-expressions/javascript/src/RegularExpression.ts
+++ b/cucumber-expressions/javascript/src/RegularExpression.ts
@@ -14,7 +14,7 @@ export default class RegularExpression implements Expression {
     this.treeRegexp = new TreeRegexp(regexp)
   }
 
-  public match(text: string) {
+  public match(text: string): ReadonlyArray<Argument<any>> {
     const parameterTypes = this.treeRegexp.groupBuilder.children.map(
       groupBuilder => {
         const parameterTypeRegexp = groupBuilder.source
@@ -40,7 +40,7 @@ export default class RegularExpression implements Expression {
     return Argument.build(this.treeRegexp, text, parameterTypes)
   }
 
-  get source() {
+  get source(): string {
     return this.regexp.source
   }
 }

--- a/cucumber-expressions/javascript/src/TreeRegexp.ts
+++ b/cucumber-expressions/javascript/src/TreeRegexp.ts
@@ -2,6 +2,7 @@ import GroupBuilder from './GroupBuilder'
 // @ts-ignore
 import Regex from 'becke-ch--regex--s0-0-v1--base--pl--lib'
 import RegexExecArray from './RegexExecArray'
+import Group from './Group'
 
 export default class TreeRegexp {
   public regexp: RegExp
@@ -52,7 +53,7 @@ export default class TreeRegexp {
     this.groupBuilder = stack.pop()
   }
 
-  public match(s: string) {
+  public match(s: string): Group | null {
     const match: RegexExecArray = this.regex.exec(s)
     if (!match) {
       return null

--- a/fake-cucumber/CHANGELOG.md
+++ b/fake-cucumber/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [JavaScript] All array return values and function parameters are now declared as TypeScript `ReadOnlyArray`
+
 ### Deprecated
 
 ### Removed

--- a/fake-cucumber/javascript/src/ErrorMessageGenerator.ts
+++ b/fake-cucumber/javascript/src/ErrorMessageGenerator.ts
@@ -1,6 +1,9 @@
 import StackUtils from 'stack-utils'
 
-export type MakeErrorMessage = (error: Error, sourceFrames: string[]) => string
+export type MakeErrorMessage = (
+  error: Error,
+  sourceFrames: ReadonlyArray<string>
+) => string
 
 export function withFullStackTrace(): MakeErrorMessage {
   const stack = new StackUtils({

--- a/fake-cucumber/javascript/src/ExpressionStepDefinition.ts
+++ b/fake-cucumber/javascript/src/ExpressionStepDefinition.ts
@@ -32,7 +32,7 @@ export default class ExpressionStepDefinition implements IStepDefinition {
         )
   }
 
-  public getArguments(text: string): Array<Argument<any>> {
+  public getArguments(text: string): ReadonlyArray<Argument<any>> {
     return this.expression.match(text)
   }
 

--- a/fake-cucumber/javascript/src/IParameterTypeDefinition.ts
+++ b/fake-cucumber/javascript/src/IParameterTypeDefinition.ts
@@ -1,8 +1,8 @@
 export default interface IParameterTypeDefinition {
   name: string
-  regexp: RegExp | RegExp[] | string | string[]
+  regexp: RegExp | ReadonlyArray<RegExp> | string | ReadonlyArray<string>
   type?: any
-  transformer?: (...args: string[]) => any
+  transformer?: (...args: ReadonlyArray<string>) => any
   preferForRegexpMatch?: boolean
   useForSnippets?: boolean
 }

--- a/fake-cucumber/javascript/src/IStepDefinition.ts
+++ b/fake-cucumber/javascript/src/IStepDefinition.ts
@@ -5,7 +5,7 @@ import { messages } from '@cucumber/messages'
 export default interface IStepDefinition {
   match(pickleStep: messages.Pickle.IPickleStep): SupportCodeExecutor | null
 
-  getArguments(text: string): Array<Argument<any>>
+  getArguments(text: string): ReadonlyArray<Argument<any>>
 
   toMessage(): messages.IEnvelope
 }

--- a/fake-cucumber/javascript/src/PickleTestStep.ts
+++ b/fake-cucumber/javascript/src/PickleTestStep.ts
@@ -12,7 +12,7 @@ export default class PickleTestStep extends TestStep {
       stepMatchArgumentsLists: this.supportCodeExecutors.map(
         e =>
           new messages.TestCase.TestStep.StepMatchArgumentsList({
-            stepMatchArguments: e.argsToMessages(),
+            stepMatchArguments: e.argsToMessages().slice(),
           })
       ),
     })

--- a/fake-cucumber/javascript/src/SupportCodeExecutor.ts
+++ b/fake-cucumber/javascript/src/SupportCodeExecutor.ts
@@ -8,7 +8,7 @@ export default class SupportCodeExecutor {
   constructor(
     public readonly stepDefinitionId: string,
     private readonly body: AnyBody,
-    private readonly args: Array<Argument<any>>,
+    private readonly args: ReadonlyArray<Argument<any>>,
     private readonly docString: messages.PickleStepArgument.IPickleDocString,
     private readonly dataTable: messages.PickleStepArgument.IPickleTable
   ) {}

--- a/fake-cucumber/javascript/src/TestPlan.ts
+++ b/fake-cucumber/javascript/src/TestPlan.ts
@@ -62,7 +62,7 @@ function parameterTypeToMessage(
   return new messages.Envelope({
     parameterType: new messages.ParameterType({
       name: parameterType.name,
-      regularExpressions: parameterType.regexpStrings,
+      regularExpressions: parameterType.regexpStrings.slice(),
       preferForRegularExpressionMatch: parameterType.preferForRegexpMatch,
       useForSnippets: parameterType.useForSnippets,
     }),

--- a/fake-cucumber/javascript/src/TestStep.ts
+++ b/fake-cucumber/javascript/src/TestStep.ts
@@ -17,8 +17,8 @@ export default abstract class TestStep implements ITestStep {
     public readonly id: string,
     public readonly sourceId: string,
     public readonly alwaysExecute: boolean,
-    protected readonly supportCodeExecutors: SupportCodeExecutor[],
-    private readonly sourceFrames: string[],
+    protected readonly supportCodeExecutors: ReadonlyArray<SupportCodeExecutor>,
+    private readonly sourceFrames: ReadonlyArray<string>,
     private readonly clock: IClock,
     private readonly makeErrorMessage: MakeErrorMessage
   ) {}

--- a/fake-cucumber/javascript/src/makePickleTestStep.ts
+++ b/fake-cucumber/javascript/src/makePickleTestStep.ts
@@ -8,8 +8,8 @@ import { MakeErrorMessage } from './ErrorMessageGenerator'
 export default function makePickleTestStep(
   testStepId: string,
   pickleStep: messages.Pickle.IPickleStep,
-  stepDefinitions: IStepDefinition[],
-  sourceFrames: string[],
+  stepDefinitions: ReadonlyArray<IStepDefinition>,
+  sourceFrames: ReadonlyArray<string>,
   clock: IClock,
   makeErrorMessage: MakeErrorMessage
 ): ITestStep {

--- a/fake-cucumber/javascript/src/makeTestCase.ts
+++ b/fake-cucumber/javascript/src/makeTestCase.ts
@@ -12,9 +12,9 @@ import EmptyPickleTestStep from './EmptyPickleTestStep'
 
 export default function makeTestCase(
   pickle: messages.IPickle,
-  stepDefinitions: IStepDefinition[],
-  beforeHooks: IHook[],
-  afterHooks: IHook[],
+  stepDefinitions: ReadonlyArray<IStepDefinition>,
+  beforeHooks: ReadonlyArray<IHook>,
+  afterHooks: ReadonlyArray<IHook>,
   gherkinQuery: Query,
   newId: IdGenerator.NewId,
   clock: IClock,
@@ -75,7 +75,7 @@ export default function makeTestCase(
 
 function makeHookSteps(
   pickle: messages.IPickle,
-  hooks: IHook[],
+  hooks: ReadonlyArray<IHook>,
   alwaysExecute: boolean,
   gherkinQuery: Query,
   newId: IdGenerator.NewId,

--- a/fake-cucumber/javascript/src/types.ts
+++ b/fake-cucumber/javascript/src/types.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream'
 import { messages } from '@cucumber/messages'
 
 export type EnvelopeListener = (envelope: messages.IEnvelope) => void
-export type AnyBody = (...args: any) => any
+export type AnyBody = (...args: ReadonlyArray<any>) => any
 export type Attach = (
   data: string | Buffer | Readable,
   mediaType: string


### PR DESCRIPTION
Declare functions parameters and return types as ReadonlyArray. This is to avoid accidental mutation of arrays when they shouldn't be.