### PR TITLE
datatable/java: Improve error messages

### DIFF
--- a/datatable/CHANGELOG.md
+++ b/datatable/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ * [Java] Improve error messages
+    ([#944](https://github.com/cucumber/cucumber/pull/944)
+      [mpkorstanje])     
+      - `table.asList(String.class)` throw an exception rather then return an empty list   
 
 ## [3.3.0] - 2020-02-06
 

--- a/datatable/java/datatable/src/main/java/io/cucumber/datatable/CucumberDataTableException.java
+++ b/datatable/java/datatable/src/main/java/io/cucumber/datatable/CucumberDataTableException.java
@@ -25,7 +25,7 @@ public class CucumberDataTableException extends RuntimeException {
 
     private static CucumberDataTableException cantConvertToMap(Type keyType, Type valueType, String message) {
         return new CucumberDataTableException(
-                format("Can't convert DataTable to Map<%s, %s>. %s", typeName(keyType), typeName(valueType), message)
+                format("Can't convert DataTable to Map<%s, %s>.\n%s", typeName(keyType), typeName(valueType), message)
         );
     }
 

--- a/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
+++ b/datatable/java/datatable/src/test/java/io/cucumber/datatable/DataTableTest.java
@@ -509,7 +509,7 @@ class DataTableTest {
         );
 
         assertThat(exception.getMessage(), is(format("" +
-                        "Can't convert DataTable to Map<%s, %s>. " +
+                        "Can't convert DataTable to Map<%s, %s>.\n" +
                         "Encountered duplicate key 1 with values 4 and 5",
                 typeName(String.class), typeName(String.class))));
     }
@@ -526,7 +526,7 @@ class DataTableTest {
                 table::asMaps
         );
         assertThat(exception.getMessage(), is(format("" +
-                        "Can't convert DataTable to Map<%s, %s>. " +
+                        "Can't convert DataTable to Map<%s, %s>.\n" +
                         "Encountered duplicate key null with values 1 and 2",
                 typeName(String.class), typeName(String.class))));
     }


### PR DESCRIPTION
As reported in https://github.com/cucumber/cucumber-jvm/issues/1928:

```
Given table1
  | aaa | bbb | ccc |

List<String> result1 = table1.asList(String.class);
```

As part of cucumber/cucumber#540 this should have thrown an exception
but no exception was thrown. After fixing this, reviewing the
exceptions revealed that they were rather lacking in clarify. By
including all potential causes rather then a best guess we'll ensure
that all possible fixes have been suggested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [X] I've added tests for my code.
- [X] I have updated the CHANGELOG accordingly.

