### PR TITLE
build: Disable html-formatter/ruby and fix build order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PACKAGES ?= c21e \
 	query \
 	json-formatter \
 	react \
-	html-formatter \
 	compatibility-kit \
+	html-formatter \
 	datatable \
 	config \
 	demo-formatter \

--- a/html-formatter/Makefile
+++ b/html-formatter/Makefile
@@ -1,2 +1,2 @@
-LANGUAGES ?= javascript java ruby
+LANGUAGES ?= javascript java
 include default.mk

--- a/html-formatter/ruby/Makefile
+++ b/html-formatter/ruby/Makefile
@@ -22,6 +22,7 @@ acceptance/cucumber.html: .deps $(FEATURES)
 		bundle exec bin/cucumber-html-formatter --format ndjson > \
 		$@
 
+# TOOD: Replace this with .rsync
 features/%.feature: ../javascript/features/%.feature
 	cp $^ $@
 


### PR DESCRIPTION
The `html-formatter` depends on the `compatibility-kit`.

Disabled `html-formatter/ruby` because `compatibility-kit/ruby` is
also disabled

