### PR TITLE
html-formatter/java Use version range for messages dependency

### DIFF
--- a/html-formatter/CHANGELOG.md
+++ b/html-formatter/CHANGELOG.md
@@ -20,7 +20,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
+* [Java] Use version range for messages dependency 
+  ([#986](https://github.com/cucumber/cucumber/pull/986)
+   [mpkorstanje])
+* [Java] Make writer idempotent when failing to close underlying writer 
+  ([#986](https://github.com/cucumber/cucumber/pull/986)
+   [mpkorstanje])
+   
 ## [6.0.1] - 2020-04-15
 
 ### Fixed

--- a/html-formatter/java/pom.xml
+++ b/html-formatter/java/pom.xml
@@ -26,12 +26,11 @@
         <url>git://github.com/cucumber/html-formatter-java.git</url>
     </scm>
 
-
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>messages</artifactId>
-            <version>12.0.0</version>
+            <version>[12.0.0,13.0.0)</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/html-formatter/java/src/main/java/io/cucumber/htmlformatter/MessagesToHtmlWriter.java
+++ b/html-formatter/java/src/main/java/io/cucumber/htmlformatter/MessagesToHtmlWriter.java
@@ -29,6 +29,7 @@ public class MessagesToHtmlWriter implements AutoCloseable {
     private boolean preMessageWritten = false;
     private boolean postMessageWritten = false;
     private boolean firstMessageWritten = false;
+    private boolean streamClosed = false;
 
     public MessagesToHtmlWriter(Writer writer) throws IOException {
         this.writer = writer;
@@ -54,7 +55,7 @@ public class MessagesToHtmlWriter implements AutoCloseable {
      * @throws IOException if an IO error occurs
      */
     public void write(Messages.Envelope envelope) throws IOException {
-        if (postMessageWritten) {
+        if (streamClosed) {
             throw new IOException("Stream closed");
         }
 
@@ -81,7 +82,7 @@ public class MessagesToHtmlWriter implements AutoCloseable {
      */
     @Override
     public void close() throws IOException {
-        if (postMessageWritten) {
+        if(streamClosed){
             return;
         }
 
@@ -89,10 +90,14 @@ public class MessagesToHtmlWriter implements AutoCloseable {
             writePreMessage();
             preMessageWritten = true;
         }
-
-        writePostMessage();
+        // writer.close may fail
+        // this conditional keeps the writer idempotent
+        if (!postMessageWritten) {
+            writePostMessage();
+            postMessageWritten = true;
+        }
         writer.close();
-        postMessageWritten = true;
+        streamClosed = true;
     }
 
     private static void writeTemplateBetween(Writer writer, String template, String begin, String end) throws IOException {


### PR DESCRIPTION
## Types of changes

The html formatter has minimal interactions with the messages library so using a version range here is probably safe and avoids issues with build system configurations that do not allow conflicts between dependencies.

The alternative would be using the `messages` dependency as a `provided` dependency but this results in the main not working without explicitly including a dependency on messages on the classpath.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1963

@aslakhellesoy you can find an explanation of how version ranges work in maven here:

http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html

Note that this won't pick up snapshot versions.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [X] I've added tests for my code.
- [X] I have updated the CHANGELOG accordingly.

