### PR TITLE
Add json-schema everywhere to get the build pass again

### DIFF
--- a/c21e/javascript/package.json
+++ b/c21e/javascript/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
     "prettier": "^2.0.2",

--- a/compatibility-kit/javascript/package.json
+++ b/compatibility-kit/javascript/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
     "fake-cucumber": "^3.0.2",
+    "json-schema": "^0.2.5",
     "prettier": "^2.0.2",
     "stream-buffers": "^3.0.2",
     "typescript": "^3.8.3"

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",

--- a/fake-cucumber/javascript/package.json
+++ b/fake-cucumber/javascript/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",

--- a/gherkin/javascript/package.json
+++ b/gherkin/javascript/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",

--- a/html-formatter/javascript/package.json
+++ b/html-formatter/javascript/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
     "gherkin": "^9.0.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.2",
     "npm-link-shared": "^0.5.6",
     "nyc": "^15.0.1",

--- a/json-to-messages/javascript-json/package.json
+++ b/json-to-messages/javascript-json/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "prettier": "^2.0.5",
     "typescript": "^3.8.3"
   }

--- a/json-to-messages/javascript/package.json
+++ b/json-to-messages/javascript/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.2",
     "nyc": "^15.0.1",
     "prettier": "^2.0.5",

--- a/messages/javascript/package.json
+++ b/messages/javascript/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",

--- a/query/javascript/package.json
+++ b/query/javascript/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.4",

--- a/react/javascript/package.json
+++ b/react/javascript/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
     "jsdom": "^16.2.2",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "node-sass": "4.13.1",
     "nyc": "^15.0.1",

--- a/tag-expressions/javascript/package.json
+++ b/tag-expressions/javascript/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
+    "json-schema": "^0.2.5",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
     "prettier": "^2.0.2",


### PR DESCRIPTION
The build is [currently failing](https://app.circleci.com/pipelines/github/cucumber/cucumber/2304/workflows/4d6f9882-673f-474f-b16c-1540a86e631b) when trying to run `eslint` in the javascript packages. This is linked to this issue: https://github.com/typescript-eslint/typescript-eslint/issues/2012

In the meantime, this adds the `json-schema` dev dependencies to all the Javascript modules so the build should pass again.