### PR TITLE
Tag expressions: Tag exception message

### DIFF
--- a/tag-expressions/CHANGELOG.md
+++ b/tag-expressions/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * [Java] Updated `TagExpressionParser` to use a static method to parse a tag expression and return an `Expression` object to the user.
+* [Java] Reduced public API to the bare minimum required.
 * [Java] Added more informative error messages for `TagExpressionParser` through the `TagExpressionException`. 
   ([#1005](https://github.com/cucumber/cucumber/pull/1005)
   [cyocum])

--- a/tag-expressions/CHANGELOG.md
+++ b/tag-expressions/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* [Java] Updated `TagExpressionParser` to use a static method to parse a tag expression and return an `Expression` object to the user.
+* [Java] Added more informative error messages for `TagExpressionParser` through the `TagExpressionException`. 
+  ([#1005](https://github.com/cucumber/cucumber/pull/1005)
+  [cyocum])
+
 ### Deprecated
 
 ### Removed

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
@@ -1,7 +1,8 @@
 package io.cucumber.tagexpressions;
 
 public class TagExpressionException extends RuntimeException {
-    public TagExpressionException(String message, Object... args) {
-        super(String.format(message, args));
+    public TagExpressionException(final String message, final Object... args) {
+		super(String.format(message, args));
+
     }
 }

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
@@ -1,7 +1,7 @@
 package io.cucumber.tagexpressions;
 
 public class TagExpressionException extends RuntimeException {
-    public TagExpressionException(final String message, final Object... args) {
+    public TagExpressionException(String message, Object... args) {
 		super(String.format(message, args));
 
     }

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionException.java
@@ -1,8 +1,7 @@
 package io.cucumber.tagexpressions;
 
-public class TagExpressionException extends RuntimeException {
-    public TagExpressionException(String message, Object... args) {
+public final class TagExpressionException extends RuntimeException {
+    TagExpressionException(String message, Object... args) {
 		super(String.format(message, args));
-
     }
 }

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -184,7 +184,7 @@ public class TagExpressionParser {
     }
 
     private class Literal implements Expression {
-        private String value;
+        private final String value;
 
         Literal(String value) {
             this.value = value;
@@ -202,8 +202,8 @@ public class TagExpressionParser {
     }
 
     private class Or implements Expression {
-        private Expression left;
-        private Expression right;
+        private final Expression left;
+        private final Expression right;
 
         Or(Expression left, Expression right) {
             this.left = left;
@@ -222,8 +222,8 @@ public class TagExpressionParser {
     }
 
     private class And implements Expression {
-        private Expression left;
-        private Expression right;
+        private final Expression left;
+        private final Expression right;
 
         And(Expression left, Expression right) {
             this.left = left;
@@ -242,7 +242,7 @@ public class TagExpressionParser {
     }
 
     private class Not implements Expression {
-        private Expression expr;
+        private final Expression expr;
 
         Not(Expression expr) {
             this.expr = expr;

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -7,13 +7,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class TagExpressionParser {
-    private static Map<String, Assoc> ASSOC = new HashMap<String, Assoc>() {{
+public final class TagExpressionParser {
+    private static final Map<String, Assoc> ASSOC = new HashMap<String, Assoc>() {{
         put("or", Assoc.LEFT);
         put("and", Assoc.LEFT);
         put("not", Assoc.RIGHT);
     }};
-    private static Map<String, Integer> PREC = new HashMap<String, Integer>() {{
+    private static final Map<String, Integer> PREC = new HashMap<String, Integer>() {{
         put("(", -2);
         put(")", -1);
         put("or", 0);

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -21,17 +21,22 @@ public class TagExpressionParser {
         put("not", 2);
     }};
     private static final char ESCAPING_CHAR = '\\';
-    private String infix;
+    private final String infix;
 
-    
-    public Expression parse(final String infix) {
+    public static Expression parse(String infix) {
+	return new TagExpressionParser(infix).parse();
+    }
+
+    private TagExpressionParser(String infix) {
 	this.infix = infix;
-	
-        final List<String> tokens = tokenize(infix);
+    }
+    
+    private Expression parse() {	
+        List<String> tokens = tokenize(infix);
         if(tokens.isEmpty()) return new True();
 
-        final Deque<String> operators = new ArrayDeque<>();
-        final Deque<Expression> expressions = new ArrayDeque<>();
+        Deque<String> operators = new ArrayDeque<>();
+        Deque<Expression> expressions = new ArrayDeque<>();
         TokenType expectedTokenType = TokenType.OPERAND;
         for (String token : tokens) {
             if (isUnary(token)) {
@@ -74,7 +79,7 @@ public class TagExpressionParser {
 
         while (operators.size() > 0) {
             if ("(".equals(operators.peek())) {
-                throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: unmatched (", this.infix);
+                throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: unmatched (", infix);
             }
             pushExpr(pop(operators), expressions);
         }
@@ -82,7 +87,7 @@ public class TagExpressionParser {
         return expressions.pop();
     }
 
-    private static List<String> tokenize(final String expr) {
+    private static List<String> tokenize(String expr) {
         List<String> tokens = new ArrayList<>();
 
         boolean isEscaped = false;
@@ -128,23 +133,23 @@ public class TagExpressionParser {
 
     private void check(TokenType expectedTokenType, TokenType tokenType) {
         if (expectedTokenType != tokenType) {
-            throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: expected %s", this.infix, expectedTokenType.toString().toLowerCase());
+            throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: expected %s", infix, expectedTokenType.toString().toLowerCase());
         }
     }
 
-    private <T> T pop(final Deque<T> stack) {
-        if (stack.isEmpty()) throw new TagExpressionException("Tag expression '%s' could not be parsed because of an empty stack", this.infix);
+    private <T> T pop(Deque<T> stack) {
+        if (stack.isEmpty()) throw new TagExpressionException("Tag expression '%s' could not be parsed because of an empty stack", infix);
         return stack.pop();
     }
 
     private void pushExpr(String token, Deque<Expression> stack) {
         switch (token) {
             case "and":
-                final Expression rightAndExpr = pop(stack);
+                Expression rightAndExpr = pop(stack);
                 stack.push(new And(pop(stack), rightAndExpr));
                 break;
             case "or":
-                final Expression rightOrExpr = pop(stack);
+                Expression rightOrExpr = pop(stack);
                 stack.push(new Or(pop(stack), rightOrExpr));
                 break;
             case "not":
@@ -197,8 +202,8 @@ public class TagExpressionParser {
     }
 
     private class Or implements Expression {
-        private final Expression left;
-        private final Expression right;
+        private Expression left;
+        private Expression right;
 
         Or(Expression left, Expression right) {
             this.left = left;
@@ -217,8 +222,8 @@ public class TagExpressionParser {
     }
 
     private class And implements Expression {
-        private final Expression left;
-        private final Expression right;
+        private Expression left;
+        private Expression right;
 
         And(Expression left, Expression right) {
             this.left = left;

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -21,15 +21,19 @@ public class TagExpressionParser {
         put("not", 2);
     }};
     private static final char ESCAPING_CHAR = '\\';
+    private String infix;
 
-    public Expression parse(String infix) {
+    
+    public Expression parse(final String infix) {
+	this.infix = infix;
+	
         final List<String> tokens = tokenize(infix);
         if(tokens.isEmpty()) return new True();
 
         final Deque<String> operators = new ArrayDeque<>();
         final Deque<Expression> expressions = new ArrayDeque<>();
         TokenType expectedTokenType = TokenType.OPERAND;
-        for (String token : tokens) {
+        for (final String token : tokens) {
             if (isUnary(token)) {
                 check(expectedTokenType, TokenType.OPERAND);
                 operators.push(token);
@@ -55,7 +59,7 @@ public class TagExpressionParser {
                     pushExpr(pop(operators), expressions);
                 }
                 if (operators.size() == 0) {
-                    throw new TagExpressionException("Syntax error. Unmatched )");
+                    throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: unmatched )", this.infix);
                 }
                 if ("(".equals(operators.peek())) {
                     pop(operators);
@@ -70,7 +74,7 @@ public class TagExpressionParser {
 
         while (operators.size() > 0) {
             if ("(".equals(operators.peek())) {
-                throw new TagExpressionException("Syntax error. Unmatched (");
+                throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: unmatched (", this.infix);
             }
             pushExpr(pop(operators), expressions);
         }
@@ -78,13 +82,13 @@ public class TagExpressionParser {
         return expressions.pop();
     }
 
-    private static List<String> tokenize(String expr) {
-        List<String> tokens = new ArrayList<>();
+    private static List<String> tokenize(final String expr) {
+        final List<String> tokens = new ArrayList<>();
 
         boolean isEscaped = false;
         StringBuilder token = null;
         for (int i = 0; i < expr.length(); i++) {
-            char c = expr.charAt(i);
+            final char c = expr.charAt(i);
             if (ESCAPING_CHAR == c) {
                 isEscaped = true;
             } else {
@@ -122,25 +126,25 @@ public class TagExpressionParser {
         return tokens;
     }
 
-    private void check(TokenType expectedTokenType, TokenType tokenType) {
+    private void check(final TokenType expectedTokenType, final TokenType tokenType) {
         if (expectedTokenType != tokenType) {
-            throw new TagExpressionException("Syntax error. Expected %s", expectedTokenType.toString().toLowerCase());
+            throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: expected %s", this.infix, expectedTokenType.toString().toLowerCase());
         }
     }
 
-    private <T> T pop(Deque<T> stack) {
-        if (stack.isEmpty()) throw new TagExpressionException("empty stack");
+    private <T> T pop(final Deque<T> stack) {
+        if (stack.isEmpty()) throw new TagExpressionException("Tag expression '%s' could not be parsed because of an empty stack", this.infix);
         return stack.pop();
     }
 
-    private void pushExpr(String token, Deque<Expression> stack) {
+    private void pushExpr(final String token, final Deque<Expression> stack) {
         switch (token) {
             case "and":
-                Expression rightAndExpr = pop(stack);
+                final Expression rightAndExpr = pop(stack);
                 stack.push(new And(pop(stack), rightAndExpr));
                 break;
             case "or":
-                Expression rightOrExpr = pop(stack);
+                final Expression rightOrExpr = pop(stack);
                 stack.push(new Or(pop(stack), rightOrExpr));
                 break;
             case "not":
@@ -152,15 +156,15 @@ public class TagExpressionParser {
         }
     }
 
-    private boolean isUnary(String token) {
+    private boolean isUnary(final String token) {
         return "not".equals(token);
     }
 
-    private boolean isBinary(String token) {
+    private boolean isBinary(final String token) {
         return "or".equals(token) || "and".equals(token);
     }
 
-    private boolean isOperator(String token) {
+    private boolean isOperator(final String token) {
         return ASSOC.get(token) != null;
     }
 
@@ -177,12 +181,12 @@ public class TagExpressionParser {
     private class Literal implements Expression {
         private final String value;
 
-        Literal(String value) {
+        Literal(final String value) {
             this.value = value;
         }
 
         @Override
-        public boolean evaluate(List<String> variables) {
+        public boolean evaluate(final List<String> variables) {
             return variables.contains(value);
         }
 
@@ -196,13 +200,13 @@ public class TagExpressionParser {
         private final Expression left;
         private final Expression right;
 
-        Or(Expression left, Expression right) {
+        Or(final Expression left, final Expression right) {
             this.left = left;
             this.right = right;
         }
 
         @Override
-        public boolean evaluate(List<String> variables) {
+        public boolean evaluate(final List<String> variables) {
             return left.evaluate(variables) || right.evaluate(variables);
         }
 
@@ -216,13 +220,13 @@ public class TagExpressionParser {
         private final Expression left;
         private final Expression right;
 
-        And(Expression left, Expression right) {
+        And(final Expression left, final Expression right) {
             this.left = left;
             this.right = right;
         }
 
         @Override
-        public boolean evaluate(List<String> variables) {
+        public boolean evaluate(final List<String> variables) {
             return left.evaluate(variables) && right.evaluate(variables);
         }
 
@@ -235,12 +239,12 @@ public class TagExpressionParser {
     private class Not implements Expression {
         private final Expression expr;
 
-        Not(Expression expr) {
+        Not(final Expression expr) {
             this.expr = expr;
         }
 
         @Override
-        public boolean evaluate(List<String> variables) {
+        public boolean evaluate(final List<String> variables) {
             return !expr.evaluate(variables);
         }
 
@@ -252,7 +256,7 @@ public class TagExpressionParser {
 
     private class True implements Expression {
         @Override
-        public boolean evaluate(List<String> variables) {
+        public boolean evaluate(final List<String> variables) {
             return true;
         }
     }

--- a/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/tag-expressions/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -33,7 +33,7 @@ public class TagExpressionParser {
         final Deque<String> operators = new ArrayDeque<>();
         final Deque<Expression> expressions = new ArrayDeque<>();
         TokenType expectedTokenType = TokenType.OPERAND;
-        for (final String token : tokens) {
+        for (String token : tokens) {
             if (isUnary(token)) {
                 check(expectedTokenType, TokenType.OPERAND);
                 operators.push(token);
@@ -83,12 +83,12 @@ public class TagExpressionParser {
     }
 
     private static List<String> tokenize(final String expr) {
-        final List<String> tokens = new ArrayList<>();
+        List<String> tokens = new ArrayList<>();
 
         boolean isEscaped = false;
         StringBuilder token = null;
         for (int i = 0; i < expr.length(); i++) {
-            final char c = expr.charAt(i);
+            char c = expr.charAt(i);
             if (ESCAPING_CHAR == c) {
                 isEscaped = true;
             } else {
@@ -126,7 +126,7 @@ public class TagExpressionParser {
         return tokens;
     }
 
-    private void check(final TokenType expectedTokenType, final TokenType tokenType) {
+    private void check(TokenType expectedTokenType, TokenType tokenType) {
         if (expectedTokenType != tokenType) {
             throw new TagExpressionException("Tag expression '%s' could not be parsed because of syntax error: expected %s", this.infix, expectedTokenType.toString().toLowerCase());
         }
@@ -137,7 +137,7 @@ public class TagExpressionParser {
         return stack.pop();
     }
 
-    private void pushExpr(final String token, final Deque<Expression> stack) {
+    private void pushExpr(String token, Deque<Expression> stack) {
         switch (token) {
             case "and":
                 final Expression rightAndExpr = pop(stack);
@@ -156,15 +156,15 @@ public class TagExpressionParser {
         }
     }
 
-    private boolean isUnary(final String token) {
+    private boolean isUnary(String token) {
         return "not".equals(token);
     }
 
-    private boolean isBinary(final String token) {
+    private boolean isBinary(String token) {
         return "or".equals(token) || "and".equals(token);
     }
 
-    private boolean isOperator(final String token) {
+    private boolean isOperator(String token) {
         return ASSOC.get(token) != null;
     }
 
@@ -179,14 +179,14 @@ public class TagExpressionParser {
     }
 
     private class Literal implements Expression {
-        private final String value;
+        private String value;
 
-        Literal(final String value) {
+        Literal(String value) {
             this.value = value;
         }
 
         @Override
-        public boolean evaluate(final List<String> variables) {
+        public boolean evaluate(List<String> variables) {
             return variables.contains(value);
         }
 
@@ -200,13 +200,13 @@ public class TagExpressionParser {
         private final Expression left;
         private final Expression right;
 
-        Or(final Expression left, final Expression right) {
+        Or(Expression left, Expression right) {
             this.left = left;
             this.right = right;
         }
 
         @Override
-        public boolean evaluate(final List<String> variables) {
+        public boolean evaluate(List<String> variables) {
             return left.evaluate(variables) || right.evaluate(variables);
         }
 
@@ -220,13 +220,13 @@ public class TagExpressionParser {
         private final Expression left;
         private final Expression right;
 
-        And(final Expression left, final Expression right) {
+        And(Expression left, Expression right) {
             this.left = left;
             this.right = right;
         }
 
         @Override
-        public boolean evaluate(final List<String> variables) {
+        public boolean evaluate(List<String> variables) {
             return left.evaluate(variables) && right.evaluate(variables);
         }
 
@@ -237,14 +237,14 @@ public class TagExpressionParser {
     }
 
     private class Not implements Expression {
-        private final Expression expr;
+        private Expression expr;
 
-        Not(final Expression expr) {
+        Not(Expression expr) {
             this.expr = expr;
         }
 
         @Override
-        public boolean evaluate(final List<String> variables) {
+        public boolean evaluate(List<String> variables) {
             return !expr.evaluate(variables);
         }
 
@@ -256,7 +256,7 @@ public class TagExpressionParser {
 
     private class True implements Expression {
         @Override
-        public boolean evaluate(final List<String> variables) {
+        public boolean evaluate(List<String> variables) {
             return true;
         }
     }

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TagExpressionParserParameterizedTest {
-    private final TagExpressionParser parser = new TagExpressionParser();
 
     static Stream<Arguments> data() {
         return Stream.of(
@@ -26,7 +25,7 @@ public class TagExpressionParserParameterizedTest {
     @ParameterizedTest
     @MethodSource("data")
     public void parser_expression(String infix, String expected) {
-        Expression expr = parser.parse(infix);
+        Expression expr = TagExpressionParser.parse(infix);
         assertEquals(expected, expr.toString());
     }
 

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class TagExpressionParserParameterizedTest {
+class TagExpressionParserParameterizedTest {
 
     static Stream<Arguments> data() {
         return Stream.of(

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserParameterizedTest.java
@@ -25,7 +25,7 @@ public class TagExpressionParserParameterizedTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void parser_expression(final String infix, final String expected) {
+    public void parser_expression(String infix, String expected) {
         Expression expr = parser.parse(infix);
         assertEquals(expected, expr.toString());
     }

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
@@ -18,7 +18,7 @@ public class TagExpressionParserSyntaxErrorTest {
         return Stream.of(
                 arguments("@a @b or", "Tag expression '@a @b or' could not be parsed because of syntax error: expected operator"),
                 arguments("@a and (@b not)", "Tag expression '@a and (@b not)' could not be parsed because of syntax error: expected operator"),
-                arguments("Tag expression '@a and (@b @c) or' could not be parsed because of syntax error: expected operator"),
+                arguments("@a and (@b @c) or", "Tag expression '@a and (@b @c) or' could not be parsed because of syntax error: expected operator"),
                 arguments("@a and or", "Tag expression '@a and or' could not be parsed because of syntax error: expected operand"),
                 arguments("or or", "Tag expression 'or or' could not be parsed because of syntax error: expected operand"),
                 arguments("a b", "Tag expression 'a b' could not be parsed because of syntax error: expected operator"),

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TagExpressionParserSyntaxErrorTest {
 
-    private final TagExpressionParser parser = new TagExpressionParser();
-
     static Stream<Arguments> data() {
         return Stream.of(
                 arguments("@a @b or", "Tag expression '@a @b or' could not be parsed because of syntax error: expected operator"),
@@ -31,7 +29,7 @@ public class TagExpressionParserSyntaxErrorTest {
     @MethodSource("data")
     public void parser_expression(String infix, String expectedError) {
 	TagExpressionException e = assertThrows(TagExpressionException.class,
-			() -> parser.parse(infix));
+			() -> TagExpressionParser.parse(infix));
 
             assertEquals(expectedError, e.getMessage());
     }

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
@@ -29,7 +29,7 @@ public class TagExpressionParserSyntaxErrorTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void parser_expression(final String infix, final String expectedError) {
+    public void parser_expression(String infix, String expectedError) {
 	TagExpressionException e = assertThrows(TagExpressionException.class,
 			() -> parser.parse(infix));
 

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class TagExpressionParserSyntaxErrorTest {
+class TagExpressionParserSyntaxErrorTest {
 
     static Stream<Arguments> data() {
         return Stream.of(

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserSyntaxErrorTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TagExpressionParserSyntaxErrorTest {
@@ -16,26 +16,24 @@ public class TagExpressionParserSyntaxErrorTest {
 
     static Stream<Arguments> data() {
         return Stream.of(
-                arguments("@a @b or", "Syntax error. Expected operator"),
-                arguments("@a and (@b not)", "Syntax error. Expected operator"),
-                arguments("@a and (@b @c) or", "Syntax error. Expected operator"),
-                arguments("@a and or", "Syntax error. Expected operand"),
-                arguments("or or", "Syntax error. Expected operand"),
-                arguments("a b", "Syntax error. Expected operator"),
-                arguments("( a and b ) )", "Syntax error. Unmatched )"),
-                arguments("( ( a and b )", "Syntax error. Unmatched (")
+                arguments("@a @b or", "Tag expression '@a @b or' could not be parsed because of syntax error: expected operator"),
+                arguments("@a and (@b not)", "Tag expression '@a and (@b not)' could not be parsed because of syntax error: expected operator"),
+                arguments("Tag expression '@a and (@b @c) or' could not be parsed because of syntax error: expected operator"),
+                arguments("@a and or", "Tag expression '@a and or' could not be parsed because of syntax error: expected operand"),
+                arguments("or or", "Tag expression 'or or' could not be parsed because of syntax error: expected operand"),
+                arguments("a b", "Tag expression 'a b' could not be parsed because of syntax error: expected operator"),
+                arguments("( a and b ) )", "Tag expression '( a and b ) )' could not be parsed because of syntax error: unmatched )"),
+                arguments("( ( a and b )", "Tag expression '( ( a and b )' could not be parsed because of syntax error: unmatched (")
         );
     }
 
     @ParameterizedTest
     @MethodSource("data")
     public void parser_expression(final String infix, final String expectedError) {
-        try {
-            parser.parse(infix);
-            fail();
-        } catch (TagExpressionException e) {
+	TagExpressionException e = assertThrows(TagExpressionException.class,
+			() -> parser.parse(infix));
+
             assertEquals(expectedError, e.getMessage());
-        }
     }
 
 }

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
@@ -15,30 +15,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TagExpressionParserTest {
 
-    private TagExpressionParser parser = new TagExpressionParser();
-
     @Test
     public void evaluates_empty_expression_to_true() {
-        Expression expr = parser.parse("");
+        Expression expr = TagExpressionParser.parse("");
         assertTrue(expr.evaluate(asList("@a @c @d".split(" "))));
     }
 
     @Test
     public void evaluates_not() {
-        Expression expr = parser.parse("not   x");
+        Expression expr = TagExpressionParser.parse("not   x");
         assertEquals(false, expr.evaluate(singletonList("x")));
         assertEquals(true, expr.evaluate(singletonList("y")));
     }
 
     @Test
     public void evaluates_example() {
-        Expression expr = parser.parse("not @a or @b and not @c or not @d or @e and @f");
+        Expression expr = TagExpressionParser.parse("not @a or @b and not @c or not @d or @e and @f");
         assertFalse(expr.evaluate(asList("@a @c @d".split(" "))));
     }
 
     @Test
     public void evaluates_expr_with_escaped_chars() {
-        Expression expr = parser.parse("((not @a\\(1\\) or @b\\(2\\)) and not @c\\(3\\) or not @d\\(4\\) or @e\\(5\\) and @f\\(6\\))");
+        Expression expr = TagExpressionParser.parse("((not @a\\(1\\) or @b\\(2\\)) and not @c\\(3\\) or not @d\\(4\\) or @e\\(5\\) and @f\\(6\\))");
         assertFalse(expr.evaluate(asList("@a(1) @c(3) @d(4)".split(" "))));
         assertTrue(expr.evaluate(asList("@b(2) @e(5) @f(6)".split(" "))));
     }
@@ -46,7 +44,7 @@ public class TagExpressionParserTest {
     @Test
     public void errors_when_there_are_only_operators() {
 
-        Executable testMethod = () -> parser.parse("or or");
+        Executable testMethod = () -> TagExpressionParser.parse("or or");
 
         TagExpressionException thrownException = assertThrows(TagExpressionException.class, testMethod);
         assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Tag expression 'or or' could not be parsed because of syntax error: expected operand")));

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
@@ -49,7 +49,7 @@ public class TagExpressionParserTest {
         final Executable testMethod = () -> parser.parse("or or");
 
         final TagExpressionException thrownException = assertThrows(TagExpressionException.class, testMethod);
-        assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Syntax error. Expected operand")));
+        assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Tag expression 'or or' could not be parsed because of syntax error: expected operand")));
     }
 
 }

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
@@ -46,9 +46,9 @@ public class TagExpressionParserTest {
     @Test
     public void errors_when_there_are_only_operators() {
 
-        final Executable testMethod = () -> parser.parse("or or");
+        Executable testMethod = () -> parser.parse("or or");
 
-        final TagExpressionException thrownException = assertThrows(TagExpressionException.class, testMethod);
+        TagExpressionException thrownException = assertThrows(TagExpressionException.class, testMethod);
         assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Tag expression 'or or' could not be parsed because of syntax error: expected operand")));
     }
 

--- a/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
+++ b/tag-expressions/java/src/test/java/io/cucumber/tagexpressions/TagExpressionParserTest.java
@@ -13,39 +13,37 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TagExpressionParserTest {
+class TagExpressionParserTest {
 
     @Test
-    public void evaluates_empty_expression_to_true() {
+    void evaluates_empty_expression_to_true() {
         Expression expr = TagExpressionParser.parse("");
         assertTrue(expr.evaluate(asList("@a @c @d".split(" "))));
     }
 
     @Test
-    public void evaluates_not() {
+    void evaluates_not() {
         Expression expr = TagExpressionParser.parse("not   x");
         assertEquals(false, expr.evaluate(singletonList("x")));
         assertEquals(true, expr.evaluate(singletonList("y")));
     }
 
     @Test
-    public void evaluates_example() {
+    void evaluates_example() {
         Expression expr = TagExpressionParser.parse("not @a or @b and not @c or not @d or @e and @f");
         assertFalse(expr.evaluate(asList("@a @c @d".split(" "))));
     }
 
     @Test
-    public void evaluates_expr_with_escaped_chars() {
+    void evaluates_expr_with_escaped_chars() {
         Expression expr = TagExpressionParser.parse("((not @a\\(1\\) or @b\\(2\\)) and not @c\\(3\\) or not @d\\(4\\) or @e\\(5\\) and @f\\(6\\))");
         assertFalse(expr.evaluate(asList("@a(1) @c(3) @d(4)".split(" "))));
         assertTrue(expr.evaluate(asList("@b(2) @e(5) @f(6)".split(" "))));
     }
 
     @Test
-    public void errors_when_there_are_only_operators() {
-
+    void errors_when_there_are_only_operators() {
         Executable testMethod = () -> TagExpressionParser.parse("or or");
-
         TagExpressionException thrownException = assertThrows(TagExpressionException.class, testMethod);
         assertThat("Unexpected message", thrownException.getMessage(), is(equalTo("Tag expression 'or or' could not be parsed because of syntax error: expected operand")));
     }


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This change makes the original tag expression with the error viable to the user via the exception message.

## Details

This change saves the infix string in an object instance variable.  This is then used to create the TagExpressionException object so that the tag expression is visible to the user when an error occurs.

## Motivation and Context

This is required facilitate the fixing of cucumber-jvm bug cucumber/cucumber-jvm#1976.

## How Has This Been Tested?

The tests have been updated to reflect the new exception message.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

