### PR TITLE
cucumber-expressions: Support for Optional

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+* [Java]  Support for Optional
+  ([#1006](https://github.com/cucumber/cucumber/pull/1006)
+   [gaeljw], [mpkorstanje])
 
 * [Java] Enable consumers to find our version at runtime using `clazz.getPackage().getImplementationVersion()` by upgrading to `cucumber-parent:2.1.0`
   ([#976](https://github.com/cucumber/cucumber/pull/976)
@@ -735,6 +738,7 @@ N/A
 [charlierudolph]:   https://github.com/charlierudolph
 [davidjgoss]:       https://github.com/davidjgoss
 [dmeehan1968]:      https://github.com/dmeehan1968
+[gaeljw]:          https://github.com/gaeljw
 [gpichot]:          https://github.com/gpichot
 [jamis]:            https://github.com/jamis
 [jaysonesmith]:     https://github.com/jaysonesmith

--- a/cucumber-expressions/java/pom.xml
+++ b/cucumber-expressions/java/pom.xml
@@ -62,6 +62,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.11.0.rc1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.6.2</version>

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
@@ -22,15 +22,15 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
         return doTransform(fromValue, toValueType, toValueType);
     }
 
-    private Object doTransform(String fromValue, Type toValueType, Type originalValueType) {
+    private Object doTransform(String fromValue, Type toValueType, Type originalToValueType) {
         Type optionalValueType;
         if ((optionalValueType = getOptionalGenericType(toValueType)) != null) {
-            Object wrappedValue = doTransform(fromValue, optionalValueType, originalValueType);
+            Object wrappedValue = doTransform(fromValue, optionalValueType, originalToValueType);
             return Optional.ofNullable(wrappedValue);
         }
 
         if (!(toValueType instanceof Class)) {
-            throw createIllegalArgumentException(fromValue, originalValueType);
+            throw createIllegalArgumentException(fromValue, originalToValueType);
         }
 
         Class<?> toValueClass = (Class<?>) requireNonNull(toValueType);
@@ -86,11 +86,11 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
                     return enumConstant;
                 }
             }
-            throw new CucumberExpressionException("Can't transform '" + fromValue + "' to " + originalValueType + ". " +
+            throw new CucumberExpressionException("Can't transform '" + fromValue + "' to " + originalToValueType + ". " +
                     "Not an enum constant");
         }
 
-        throw createIllegalArgumentException(fromValue, originalValueType);
+        throw createIllegalArgumentException(fromValue, originalToValueType);
     }
 
     private Type getOptionalGenericType(Type type) {

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformer.java
@@ -23,8 +23,9 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
     }
 
     private Object doTransform(String fromValue, Type toValueType, Type originalValueType) {
-        if (isOptionalType(toValueType)) {
-            Object wrappedValue = doTransform(fromValue, getOptionalGenericType(toValueType), originalValueType);
+        Type optionalValueType;
+        if ((optionalValueType = getOptionalGenericType(toValueType)) != null) {
+            Object wrappedValue = doTransform(fromValue, optionalValueType, originalValueType);
             return Optional.ofNullable(wrappedValue);
         }
 
@@ -92,20 +93,21 @@ final class BuiltInParameterTransformer implements ParameterByTypeTransformer {
         throw createIllegalArgumentException(fromValue, originalValueType);
     }
 
-    private boolean isOptionalType(Type type) {
-        if (type instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-            return Optional.class.equals(parameterizedType.getRawType());
+    private Type getOptionalGenericType(Type type) {
+        if (Optional.class.equals(type)) {
+            return Object.class;
         }
-        return Optional.class.equals(type);
-    }
 
-    private Type getOptionalGenericType(Type optionalGenericType) {
-        if (optionalGenericType instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) optionalGenericType;
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        if (Optional.class.equals(parameterizedType.getRawType())) {
             return parameterizedType.getActualTypeArguments()[0];
         }
-        return Object.class;
+
+        return null;
     }
 
     private IllegalArgumentException createIllegalArgumentException(String fromValue, Type toValueType) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
@@ -3,10 +3,12 @@ package io.cucumber.cucumberexpressions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Optional;
 
 import static java.util.Locale.ENGLISH;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -63,6 +65,60 @@ public class BuiltInParameterTransformerTest {
         for (String value : Arrays.asList("true", "True", "false", "False")) {
             objectMapper.transform(value, Boolean.class);
         }
+    }
+
+    @Test
+    public void should_transform_optional() {
+        assertThat(objectMapper.transform("abc", Optional.class), is(equalTo(Optional.of("abc"))));
+        assertThat(objectMapper.transform("", Optional.class), is(equalTo(Optional.of(""))));
+        assertThat(objectMapper.transform(null, Optional.class), is(equalTo(Optional.empty())));
+    }
+
+    @Test
+    public void should_transform_optional_generic_string() {
+        ParameterizedType optionalStringType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { String.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return Optional.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        assertThat(objectMapper.transform("abc", optionalStringType), is(equalTo(Optional.<String>of("abc"))));
+        assertThat(objectMapper.transform("", optionalStringType), is(equalTo(Optional.<String>of(""))));
+        assertThat(objectMapper.transform(null, optionalStringType), is(equalTo(Optional.<String>empty())));
+    }
+
+    @Test
+    public void should_transform_optional_generic_integer() {
+        ParameterizedType optionalIntType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { Integer.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return Optional.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        assertThat(objectMapper.transform("42", optionalIntType), is(equalTo(Optional.<Integer>of(42))));
+        assertThat(objectMapper.transform(null, optionalIntType), is(equalTo(Optional.<Integer>empty())));
     }
 
     private enum TestEnum {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Locale.ENGLISH;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,6 +59,20 @@ public class BuiltInParameterTransformerTest {
                 "Can't transform 'something' to java.util.Optional<java.util.Date>\n" +
                         "BuiltInParameterTransformer only supports a limited number of class types\n" +
                         "Consider using a different object mapper or register a parameter type for java.util.Optional<java.util.Date>"
+        )));
+    }
+
+    @Test
+    public void simple_object_mapper_only_supports_some_generic_types() {
+        Type optionalDate = new TypeReference<Supplier<String>>() {}.getType();
+
+        final Executable testMethod = () -> objectMapper.transform("something", optionalDate);
+
+        final IllegalArgumentException thrownException = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected message", thrownException.getMessage(), is(equalTo(
+                "Can't transform 'something' to java.util.function.Supplier<java.lang.String>\n" +
+                        "BuiltInParameterTransformer only supports a limited number of class types\n" +
+                        "Consider using a different object mapper or register a parameter type for java.util.function.Supplier<java.lang.String>"
         )));
     }
 

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/BuiltInParameterTransformerTest.java
@@ -3,7 +3,6 @@ package io.cucumber.cucumberexpressions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BuiltInParameterTransformerTest {
 
-    private BuiltInParameterTransformer objectMapper = new BuiltInParameterTransformer(ENGLISH);
+    private final BuiltInParameterTransformer objectMapper = new BuiltInParameterTransformer(ENGLISH);
 
     @Test
     public void simple_object_mapper_only_supports_class_types() {
@@ -45,6 +44,20 @@ public class BuiltInParameterTransformerTest {
                 "Can't transform 'something' to class java.util.Date\n" +
                         "BuiltInParameterTransformer only supports a limited number of class types\n" +
                         "Consider using a different object mapper or register a parameter type for class java.util.Date"
+        )));
+    }
+
+    @Test
+    public void simple_object_mapper_only_supports_some_optional_types() {
+        Type optionalDate = new TypeReference<Optional<Date>>() {}.getType();
+
+        final Executable testMethod = () -> objectMapper.transform("something", optionalDate);
+
+        final IllegalArgumentException thrownException = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected message", thrownException.getMessage(), is(equalTo(
+                "Can't transform 'something' to java.util.Optional<java.util.Date>\n" +
+                        "BuiltInParameterTransformer only supports a limited number of class types\n" +
+                        "Consider using a different object mapper or register a parameter type for java.util.Optional<java.util.Date>"
         )));
     }
 
@@ -76,22 +89,7 @@ public class BuiltInParameterTransformerTest {
 
     @Test
     public void should_transform_optional_generic_string() {
-        ParameterizedType optionalStringType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[] { String.class };
-            }
-
-            @Override
-            public Type getRawType() {
-                return Optional.class;
-            }
-
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+        Type optionalStringType = new TypeReference<Optional<String>>() {}.getType();
 
         assertThat(objectMapper.transform("abc", optionalStringType), is(equalTo(Optional.<String>of("abc"))));
         assertThat(objectMapper.transform("", optionalStringType), is(equalTo(Optional.<String>of(""))));
@@ -100,22 +98,7 @@ public class BuiltInParameterTransformerTest {
 
     @Test
     public void should_transform_optional_generic_integer() {
-        ParameterizedType optionalIntType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[] { Integer.class };
-            }
-
-            @Override
-            public Type getRawType() {
-                return Optional.class;
-            }
-
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+        Type optionalIntType = new TypeReference<Optional<Integer>>() {}.getType();
 
         assertThat(objectMapper.transform("42", optionalIntType), is(equalTo(Optional.<Integer>of(42))));
         assertThat(objectMapper.transform(null, optionalIntType), is(equalTo(Optional.<Integer>empty())));

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterByTypeTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterByTypeTransformerTest.java
@@ -4,9 +4,14 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import static java.util.Locale.ENGLISH;
@@ -30,9 +35,61 @@ public class ParameterByTypeTransformerTest {
 
     @ParameterizedTest
     @MethodSource("objectMapperImplementations")
+    public void should_convert_null_to_optional(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
+        assertEquals(Optional.empty(), defaultTransformer.transform(null, Optional.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMapperImplementations")
+    public void should_convert_null_to_optional_generic(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
+        ParameterizedType optionalIntType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { Integer.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return Optional.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        assertEquals(Optional.empty(), defaultTransformer.transform(null, optionalIntType));
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMapperImplementations")
     public void should_convert_to_string(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
         assertEquals("Barbara Liskov",
                 defaultTransformer.transform("Barbara Liskov", String.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMapperImplementations")
+    public void should_convert_to_optional_string(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
+        ParameterizedType optionalStringType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { String.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return Optional.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        assertEquals(Optional.of("Barbara Liskov"), defaultTransformer.transform("Barbara Liskov", optionalStringType));
     }
 
     @ParameterizedTest
@@ -79,6 +136,29 @@ public class ParameterByTypeTransformerTest {
 
     @ParameterizedTest
     @MethodSource("objectMapperImplementations")
+    public void should_convert_to_optional_integer(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
+        ParameterizedType optionalIntType = new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { Integer.class };
+            }
+
+            @Override
+            public Type getRawType() {
+                return Optional.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+
+        assertEquals(Optional.of(Integer.decode("42")), defaultTransformer.transform("42", optionalIntType));
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMapperImplementations")
     public void should_convert_to_long(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
         assertEquals(Long.decode("42"), defaultTransformer.transform("42", Long.class));
         assertEquals(Long.decode("42"), defaultTransformer.transform("42", long.class));
@@ -105,8 +185,13 @@ public class ParameterByTypeTransformerTest {
     }
 
     private static class TestJacksonDefaultTransformer implements ParameterByTypeTransformer {
-        com.fasterxml.jackson.databind.ObjectMapper delegate =
-                new com.fasterxml.jackson.databind.ObjectMapper();
+        com.fasterxml.jackson.databind.ObjectMapper delegate = initMapper();
+
+        private static com.fasterxml.jackson.databind.ObjectMapper initMapper() {
+            com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            objectMapper.registerModule(new com.fasterxml.jackson.datatype.jdk8.Jdk8Module());
+            return objectMapper;
+        }
 
         @Override
         public Object transform(String fromValue, Type toValueType) {

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterByTypeTransformerTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/ParameterByTypeTransformerTest.java
@@ -42,22 +42,7 @@ public class ParameterByTypeTransformerTest {
     @ParameterizedTest
     @MethodSource("objectMapperImplementations")
     public void should_convert_null_to_optional_generic(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
-        ParameterizedType optionalIntType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[] { Integer.class };
-            }
-
-            @Override
-            public Type getRawType() {
-                return Optional.class;
-            }
-
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+        Type optionalIntType = new TypeReference<Optional<Integer>>(){}.getType();
 
         assertEquals(Optional.empty(), defaultTransformer.transform(null, optionalIntType));
     }
@@ -72,22 +57,7 @@ public class ParameterByTypeTransformerTest {
     @ParameterizedTest
     @MethodSource("objectMapperImplementations")
     public void should_convert_to_optional_string(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
-        ParameterizedType optionalStringType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[] { String.class };
-            }
-
-            @Override
-            public Type getRawType() {
-                return Optional.class;
-            }
-
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+        Type optionalStringType = new TypeReference<Optional<String>>(){}.getType();
 
         assertEquals(Optional.of("Barbara Liskov"), defaultTransformer.transform("Barbara Liskov", optionalStringType));
     }
@@ -137,22 +107,7 @@ public class ParameterByTypeTransformerTest {
     @ParameterizedTest
     @MethodSource("objectMapperImplementations")
     public void should_convert_to_optional_integer(final ParameterByTypeTransformer defaultTransformer) throws Throwable {
-        ParameterizedType optionalIntType = new ParameterizedType() {
-            @Override
-            public Type[] getActualTypeArguments() {
-                return new Type[] { Integer.class };
-            }
-
-            @Override
-            public Type getRawType() {
-                return Optional.class;
-            }
-
-            @Override
-            public Type getOwnerType() {
-                return null;
-            }
-        };
+        Type optionalIntType = new TypeReference<Optional<Integer>>(){}.getType();
 
         assertEquals(Optional.of(Integer.decode("42")), defaultTransformer.transform("42", optionalIntType));
     }


### PR DESCRIPTION
## Summary

This PR aims to support `Optional` types out of the box in Expressions.

## Details

Add support for `Optional<T>` in the (default) `BuiltInParameterTransformer`.

## Motivation and Context

The main goal is to be able to describe a step definition with optional capture groups. For instance: `"^I am logged in(?: as (.+))?$"`.

`Optional` as method parameters are generally considered a bad practice in Java and you would usually expect a `String` parameter with a `null` value in this case.
But on the other hand, other JVM languages (like Scala) consider `null` as forbidden and would benefit from mapping this as an `Optional<String>`.

(Related to https://github.com/cucumber/cucumber-jvm-scala/issues/3)

## How Has This Been Tested?

Tests added in `BuiltInParameterTransformerTest` and `ParameterByTypeTransformerTest` (with Jackson JDK8 Module).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

## Open questions

I'm just starting to learn how Cucumber "Core" is working, thus I would really appreciate any feedback.

As a start, I have two questions:
- Is this is something we want to document considering that `Optional` is not recommended as parameter in Java?
- Should we add default parameter types in `ParameterTypeRegistry`?
