### PR TITLE
gherkin: Prefer `require_relative` for internal requires

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -35,6 +35,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* [Ruby] Use `require_relative` for internal requires ([#1010](https://github.com/cucumber/cucumber/pull/1010) [deivid-rodriguez])
+
 ## [13.0.0] - 2020-04-14
 
 ### Changed
@@ -782,6 +784,7 @@ to Gherkin 2.
 [cyocum]:           https://github.com/cyocum
 [danilat]:          https://github.com/danilat
 [davidjgoss]:       https://github.com/davidjgoss
+[deivid-rodriguez]  https://github.com/deivid-rodriguez
 [dobiedad]:         https://github.com/dobiedad
 [ehpc]:             https://github.com/ehpc
 [enkessler]:        https://github.com/enkessler

--- a/gherkin/ruby/gherkin-ruby.razor
+++ b/gherkin/ruby/gherkin-ruby.razor
@@ -26,10 +26,10 @@
 @helper MatchToken(TokenType tokenType)
 {<text>match_@(tokenType)(context, token)</text>}
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
-require 'gherkin/ast_builder'
-require 'gherkin/token_matcher'
-require 'gherkin/token_scanner'
-require 'gherkin/errors'
+require_relative 'ast_builder'
+require_relative 'token_matcher'
+require_relative 'token_scanner'
+require_relative 'errors'
 
 module Gherkin
 

--- a/gherkin/ruby/lib/gherkin.rb
+++ b/gherkin/ruby/lib/gherkin.rb
@@ -1,4 +1,4 @@
-require 'gherkin/stream/parser_message_stream'
+require_relative 'gherkin/stream/parser_message_stream'
 
 module Gherkin
   DEFAULT_OPTIONS = {

--- a/gherkin/ruby/lib/gherkin/ast_builder.rb
+++ b/gherkin/ruby/lib/gherkin/ast_builder.rb
@@ -1,5 +1,5 @@
 require 'cucumber/messages'
-require 'gherkin/ast_node'
+require_relative 'ast_node'
 
 module Gherkin
   class AstBuilder

--- a/gherkin/ruby/lib/gherkin/parser.rb
+++ b/gherkin/ruby/lib/gherkin/parser.rb
@@ -1,8 +1,8 @@
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
-require 'gherkin/ast_builder'
-require 'gherkin/token_matcher'
-require 'gherkin/token_scanner'
-require 'gherkin/errors'
+require_relative 'ast_builder'
+require_relative 'token_matcher'
+require_relative 'token_scanner'
+require_relative 'errors'
 
 module Gherkin
 

--- a/gherkin/ruby/lib/gherkin/stream/parser_message_stream.rb
+++ b/gherkin/ruby/lib/gherkin/stream/parser_message_stream.rb
@@ -1,7 +1,7 @@
 require 'cucumber/messages'
-require 'gherkin/parser'
-require 'gherkin/token_matcher'
-require 'gherkin/pickles/compiler'
+require_relative '../parser'
+require_relative '../token_matcher'
+require_relative '../pickles/compiler'
 
 module Gherkin
   module Stream

--- a/gherkin/ruby/lib/gherkin/token_matcher.rb
+++ b/gherkin/ruby/lib/gherkin/token_matcher.rb
@@ -1,5 +1,5 @@
-require 'gherkin/dialect'
-require 'gherkin/errors'
+require_relative 'dialect'
+require_relative 'errors'
 
 module Gherkin
   class TokenMatcher

--- a/gherkin/ruby/lib/gherkin/token_scanner.rb
+++ b/gherkin/ruby/lib/gherkin/token_scanner.rb
@@ -1,6 +1,6 @@
 require 'stringio'
-require 'gherkin/token'
-require 'gherkin/gherkin_line'
+require_relative 'token'
+require_relative 'gherkin_line'
 
 module Gherkin
   # The scanner reads a gherkin doc (typically read from a .feature file) and

--- a/json-formatter/ruby/Gemfile
+++ b/json-formatter/ruby/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "cucumber"
+gem "cucumber", "~> 3.2.0"
 gem "json"
 gem "rspec"


### PR DESCRIPTION
## Summary

This PR changes internal requires inside the `gherkin-ruby` gem to use `require_relative`. 

## Details

`require_relative` is faster because it doesn't search the `$LOAD_PATH`, it's more clear, because it makes it more explicit where the code is being loaded from, and it can avoid actually requiring the wrong code.

Normally this doesn't make a difference, but in this case, since the same files are also present in the old defunct `gherkin` gem (if I have understood the migration alright), it can prevent errors.

In my case, I was upgrading `cucumber`, but some dependencies still were pinned to the old `gherkin` gem. This was causing some requires to actually load code from the old project, causing weird errors like:

```
1 processes for 1 features, ~ 1 features per process
wrong number of arguments (given 1, expected 0) (ArgumentError)
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gherkin-5.1.0/lib/gherkin/ast_builder.rb:5:in `initialize'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-gherkin-13.0.0/lib/gherkin/stream/parser_message_stream.rb:15:in `new'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-gherkin-13.0.0/lib/gherkin/stream/parser_message_stream.rb:15:in `initialize'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-gherkin-13.0.0/lib/gherkin.rb:19:in `new'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-gherkin-13.0.0/lib/gherkin.rb:19:in `from_sources'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-gherkin-13.0.0/lib/gherkin.rb:27:in `from_source'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-core-7.0.0/lib/cucumber/core/gherkin/parser.rb:20:in `document'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-core-7.0.0/lib/cucumber/core.rb:33:in `block in parse'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-core-7.0.0/lib/cucumber/core.rb:32:in `each'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-core-7.0.0/lib/cucumber/core.rb:32:in `parse'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-core-7.0.0/lib/cucumber/core.rb:24:in `compile'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-4.0.0/lib/cucumber/runtime.rb:78:in `run!'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-4.0.0/lib/cucumber/cli/main.rb:29:in `execute!'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cucumber-4.0.0/bin/cucumber:9:in `<top (required)>'
/home/deivid/.rbenv/versions/2.7.1/bin/cucumber:23:in `load'
/home/deivid/.rbenv/versions/2.7.1/bin/cucumber:23:in `<top (required)>'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:481:in `exec'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:24:in `start'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.dev/exe/bundle:49:in `block in <top (required)>'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/home/deivid/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.0.dev/exe/bundle:37:in `<top (required)>'
/home/deivid/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
/home/deivid/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
Tests Failed
```

## How Has This Been Tested?

I made the edits in place and confirmed that my issue was gone.
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.