### PR TITLE
html-formatter/java: Always use UFT_8 encoding

### DIFF
--- a/html-formatter/CHANGELOG.md
+++ b/html-formatter/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
 * [JavaScript] Fixed a bug where the command-line interface would always exit with 1
-  even if there were no errors. 
+  even if there were no errors.
+* [Java] Always use UFT_8 encoding
 
 ## [6.0.2] - 2020-05-01
 

--- a/html-formatter/java/src/main/java/io/cucumber/htmlformatter/MessagesToHtmlWriter.java
+++ b/html-formatter/java/src/main/java/io/cucumber/htmlformatter/MessagesToHtmlWriter.java
@@ -118,7 +118,7 @@ public class MessagesToHtmlWriter implements AutoCloseable {
 
     private static String readResource(String name) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(baos))) {
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(baos, UTF_8))) {
             writeResource(writer, name);
         }
         return new String(baos.toByteArray(), UTF_8);


### PR DESCRIPTION
Fixes: https://github.com/cucumber/cucumber/issues/1045

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG accordingly.

