### PR TITLE
html-formatter: Ruby gem metadata

### DIFF
--- a/html-formatter/ruby/cucumber-html-formatter.gemspec
+++ b/html-formatter/ruby/cucumber-html-formatter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.metadata    = {
                     'bug_tracker_uri'   => 'https://github.com/cucumber/cucumber/issues',
-                    'changelog_uri'     => 'https://github.com/cucumber/cucumber/blob/master/gherkin/CHANGELOG.md',
+                    'changelog_uri'     => 'https://github.com/cucumber/cucumber/blob/master/html-formatter/CHANGELOG.md',
                     'documentation_uri' => 'https://cucumber.io/docs/gherkin/',
                     'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/cukes',
                     'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/gherkin/ruby',

--- a/html-formatter/ruby/cucumber-html-formatter.gemspec
+++ b/html-formatter/ruby/cucumber-html-formatter.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |s|
                     'bug_tracker_uri'   => 'https://github.com/cucumber/cucumber/issues',
                     'changelog_uri'     => 'https://github.com/cucumber/cucumber/blob/master/html-formatter/CHANGELOG.md',
                     'documentation_uri' => 'https://cucumber.io/docs/gherkin/',
+                    'homepage_uri'      => s.homepage,
                     'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/cukes',
-                    'source_code_uri'   => 'https://github.com/cucumber/cucumber/blob/master/gherkin/ruby',
+                    'source_code_uri'   => 'https://github.com/cucumber/cucumber/tree/master/html-formatter/ruby'
                   }
 
   s.add_dependency 'cucumber-messages', '~> 12.1', '>= 12.1.1'


### PR DESCRIPTION
## Summary

Updated gemspec metadata for the `html-formatter` sub-project.

## Details

As per [metadata specification](https://guides.rubygems.org/specification-reference/#metadata), add missing metadata to the gemspec file and update its changelog URI.

## Motivation and Context

This'll allow people to more easily access docs and source code, raise issues and read the changelog.

These links will appear on the [cucumber-html-formatter Rubygems page](https://rubygems.org/gems/cucumber-html-formatter) at and will also be available via the Rubygems API after the next release.

My team uses an automated bundle update process that annotates pull-requests and it makes it easier for reviewers when there is a changelog link.

## How Has This Been Tested?

I believe tests don't apply here.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

Since there is no code change, I believe none of these apply.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

