### PR TITLE
cucumber-expressions/java: Allow parameter types in optional groups

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -215,6 +215,14 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
     }
 
     T transform(List<String> groupValues) {
+        // This only happens when a parameter type is used in an optional group
+        // This can not happen with Cucumber expressions which do not allow
+        // parameter types in an optional group, but it can happen when a
+        // parameter type is matched to a regex in an optional group.
+        if (groupValues.isEmpty()) {
+            return null;
+        }
+
         if (transformer instanceof TransformerAdaptor) {
             if (groupValues.size() > 1) {
                 if (isAnonymous()) {
@@ -265,8 +273,7 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
 
         @Override
         public T transform(String[] args) throws Throwable {
-            String arg = args.length == 0 ? null : args[0];
-            return transformer.transform(arg);
+            return transformer.transform(args[0]);
         }
     }
 }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -187,6 +187,23 @@ public class RegularExpressionTest {
         assertEquals(singletonList(null), match(pattern, "", Boolean.class));
     }
 
+    @Test
+    public void parameter_types_can_be_optional_when_used_in_regex() {
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                "test",
+                ".+",
+                String.class,
+                new Transformer<String>() {
+                    @Override
+                    public String transform(String s) {
+                        return s.toUpperCase();
+                    }
+                }
+        ));
+        List<?> match = match(compile("^text(?: (.+))? text2$"), "text text2", String.class);
+        assertEquals(singletonList(null), match);
+    }
+
     private List<?> match(Pattern pattern, String text, Type... types) {
         RegularExpression regularExpression = new RegularExpression(pattern, parameterTypeRegistry);
         List<Argument<?>> arguments = regularExpression.match(text, types);


### PR DESCRIPTION
This only happens when a parameter type is used in an optional group. This can
not happen with Cucumber expressions which do not allow parameter types in an
optional group, but it can happen when a parameter type is matched to a regex
in an optional group.

Fixes: #952

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

