### PR TITLE
cucumber-expressions: Retain position of optional groups

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -16,11 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+* [All] Retain position of optional groups
+  ([#1076](https://github.com/cucumber/cucumber/pull/1076)
+   [mpkorstanje])
+
 
 ## [10.2.0] - 2020-05-28
 
 ### Added
-* [Java]  Support for Optional
+* [Java] Add support for Optional
   ([#1006](https://github.com/cucumber/cucumber/pull/1006)
    [gaeljw], [mpkorstanje])
 

--- a/cucumber-expressions/examples.txt
+++ b/cucumber-expressions/examples.txt
@@ -29,3 +29,7 @@ I have 22 cukes in my belly now
 I have {} cuke(s) in my {} now
 I have 22 cukes in my belly now
 ["22","belly"]
+---
+/^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
+a purchase for $33
+[null,33]

--- a/cucumber-expressions/go/examples.txt
+++ b/cucumber-expressions/go/examples.txt
@@ -29,3 +29,7 @@ I have 22 cukes in my belly now
 I have {} cuke(s) in my {} now
 I have 22 cukes in my belly now
 ["22","belly"]
+---
+/^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
+a purchase for $33
+[null,33]

--- a/cucumber-expressions/java/examples.txt
+++ b/cucumber-expressions/java/examples.txt
@@ -29,3 +29,7 @@ I have 22 cukes in my belly now
 I have {} cuke(s) in my {} now
 I have 22 cukes in my belly now
 ["22","belly"]
+---
+/^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
+a purchase for $33
+[null,33]

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Group.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Group.java
@@ -2,8 +2,8 @@ package io.cucumber.cucumberexpressions;
 
 import org.apiguardian.api.API;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 
@@ -38,13 +38,9 @@ public class Group {
     }
 
     public List<String> getValues() {
-        List<String> list = new ArrayList<>();
-        for (Group group : (getChildren().isEmpty() ? singletonList(this) : getChildren())) {
-            String groupValue = group.getValue();
-            if (groupValue != null) {
-                list.add(groupValue);
-            }
-        }
-        return list;
+        List<Group> groups = getChildren().isEmpty() ? singletonList(this) : getChildren();
+        return groups.stream()
+                .map(Group::getValue)
+                .collect(Collectors.toList());
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 
 final class GroupBuilder {
-    private List<GroupBuilder> groupBuilders = new ArrayList<>();
+    private final List<GroupBuilder> groupBuilders = new ArrayList<>();
     private boolean capturing = true;
     private String source;
 

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterType.java
@@ -265,8 +265,7 @@ public final class ParameterType<T> implements Comparable<ParameterType<?>> {
 
         @Override
         public T transform(String[] args) throws Throwable {
-            String arg = args.length == 0 ? null : args[0];
-            return transformer.transform(arg);
+            return transformer.transform(args[0]);
         }
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -120,10 +120,11 @@ public final class ParameterTypeRegistry {
                 return (String) internalParameterTransformer.transform(arg, String.class);
             }
         }, false, false, false));
-        defineParameterType(new ParameterType<>("string", STRING_REGEXPS, String.class, new Transformer<String>() {
+        defineParameterType(new ParameterType<>("string", STRING_REGEXPS, String.class, new CaptureGroupTransformer<String>() {
             @Override
-            public String transform(String arg) throws Throwable {
-                return arg == null ? null : (String) internalParameterTransformer.transform(arg
+            public String transform(String... args) throws Throwable {
+                String arg = args[0] != null ? args[0] : args[1];
+                return (String) internalParameterTransformer.transform(arg
                                 .replaceAll("\\\\\"", "\"")
                                 .replaceAll("\\\\'", "'"),
                         String.class);

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/RegularExpressionTest.java
@@ -84,7 +84,8 @@ public class RegularExpressionTest {
     @Test
     public void exposes_source_and_regexp() {
         String regexp = "I have (\\d+) cukes? in my (.+) now";
-        RegularExpression expression = new RegularExpression(Pattern.compile(regexp), new ParameterTypeRegistry(Locale.ENGLISH));
+        RegularExpression expression = new RegularExpression(Pattern.compile(regexp),
+                new ParameterTypeRegistry(Locale.ENGLISH));
         assertEquals(regexp, expression.getSource());
         assertEquals(regexp, expression.getRegexp().pattern());
     }
@@ -185,6 +186,23 @@ public class RegularExpressionTest {
         assertEquals(singletonList(true), match(pattern, "true", Boolean.class));
         assertEquals(singletonList(false), match(pattern, "false", Boolean.class));
         assertEquals(singletonList(null), match(pattern, "", Boolean.class));
+    }
+
+    @Test
+    public void parameter_types_can_be_optional_when_used_in_regex() {
+        parameterTypeRegistry.defineParameterType(new ParameterType<>(
+                "test",
+                ".+",
+                String.class,
+                new Transformer<String>() {
+                    @Override
+                    public String transform(String s) {
+                        return s;
+                    }
+                }
+        ));
+        List<?> match = match(compile("^text(?: (.+))? text2$"), "text text2", String.class);
+        assertEquals(singletonList(null), match);
     }
 
     private List<?> match(Pattern pattern, String text, Type... types) {

--- a/cucumber-expressions/javascript/examples.txt
+++ b/cucumber-expressions/javascript/examples.txt
@@ -29,3 +29,7 @@ I have 22 cukes in my belly now
 I have {} cuke(s) in my {} now
 I have 22 cukes in my belly now
 ["22","belly"]
+---
+/^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
+a purchase for $33
+[null,33]

--- a/cucumber-expressions/javascript/src/Group.ts
+++ b/cucumber-expressions/javascript/src/Group.ts
@@ -1,14 +1,14 @@
 export default class Group {
   constructor(
-    public readonly value: string | null,
+    public readonly value: string | undefined,
     public readonly start: number,
     public readonly end: number,
     public readonly children: ReadonlyArray<Group>
   ) {}
 
   get values(): string[] {
-    return (this.children.length === 0 ? [this] : this.children)
-      .filter((g) => typeof g.start !== 'undefined')
-      .map((g) => g.value)
+    return (this.children.length === 0 ? [this] : this.children).map(
+      (g) => g.value
+    )
   }
 }

--- a/cucumber-expressions/javascript/src/GroupBuilder.ts
+++ b/cucumber-expressions/javascript/src/GroupBuilder.ts
@@ -16,7 +16,7 @@ export default class GroupBuilder {
       gb.build(match, nextGroupIndex)
     )
     return new Group(
-      match[groupIndex] || null,
+      match[groupIndex] || undefined,
       match.index[groupIndex],
       match.index[groupIndex] + (match[groupIndex] || '').length,
       children

--- a/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeRegistry.ts
@@ -52,7 +52,7 @@ export default class ParameterTypeRegistry {
         'string',
         ParameterTypeRegistry.STRING_REGEXP,
         String,
-        (s) => (s || '').replace(/\\"/g, '"').replace(/\\'/g, "'"),
+        (s1, s2) => (s1 || s2 || '').replace(/\\"/g, '"').replace(/\\'/g, "'"),
         true,
         false
       )

--- a/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
+++ b/cucumber-expressions/javascript/test/CucumberExpressionTest.ts
@@ -253,6 +253,37 @@ describe('CucumberExpression', () => {
     )
   })
 
+  it('unmatched optional groups have undefined values', () => {
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    parameterTypeRegistry.defineParameterType(
+      new ParameterType(
+        'textAndOrNumber',
+        /([A-Z]+)?(?: )?([0-9]+)?/,
+        null,
+        function (s1, s2) {
+          return [s1, s2]
+        },
+        false,
+        true
+      )
+    )
+    const expression = new CucumberExpression(
+      '{textAndOrNumber}',
+      parameterTypeRegistry
+    )
+
+    const world = {}
+
+    assert.deepStrictEqual(expression.match(`TLA`)[0].getValue(world), [
+      'TLA',
+      undefined,
+    ])
+    assert.deepStrictEqual(expression.match(`123`)[0].getValue(world), [
+      undefined,
+      '123',
+    ])
+  })
+
   // JavaScript-specific
 
   it('delegates transform to custom object', () => {

--- a/cucumber-expressions/javascript/test/TreeRegexpTest.ts
+++ b/cucumber-expressions/javascript/test/TreeRegexpTest.ts
@@ -60,7 +60,7 @@ describe('TreeRegexp', () => {
   it('matches optional group', () => {
     const tr = new TreeRegexp(/^Something( with an optional argument)?/)
     const group = tr.match('Something')
-    assert.strictEqual(group.children[0].value, null)
+    assert.strictEqual(group.children[0].value, undefined)
   })
 
   it('matches nested groups', () => {
@@ -108,7 +108,7 @@ describe('TreeRegexp', () => {
     const tr = new TreeRegexp('the stdout(?: from "(.*?)")?')
     const group = tr.match('the stdout')
     assert.strictEqual(group.value, 'the stdout')
-    assert.strictEqual(group.children[0].value, null)
+    assert.strictEqual(group.children[0].value, undefined)
     assert.strictEqual(group.children.length, 1)
   })
 

--- a/cucumber-expressions/ruby/examples.txt
+++ b/cucumber-expressions/ruby/examples.txt
@@ -29,3 +29,7 @@ I have 22 cukes in my belly now
 I have {} cuke(s) in my {} now
 I have 22 cukes in my belly now
 ["22","belly"]
+---
+/^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
+a purchase for $33
+[null,33]

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/group.rb
@@ -11,7 +11,7 @@ module Cucumber
       end
 
       def values
-        (children.empty? ? [self] : children).map(&:value).compact
+        (children.empty? ? [self] : children).map(&:value)
       end
     end
   end

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -18,7 +18,7 @@ module Cucumber
         define_parameter_type(ParameterType.new('int', INTEGER_REGEXPS, Integer, lambda {|s = nil| s && s.to_i}, true, true))
         define_parameter_type(ParameterType.new('float', FLOAT_REGEXP, Float, lambda {|s = nil| s && s.to_f}, true, false))
         define_parameter_type(ParameterType.new('word', WORD_REGEXP, String, lambda {|s = nil| s}, false, false))
-        define_parameter_type(ParameterType.new('string', STRING_REGEXP, String, lambda {|s = nil| s && s.gsub(/\\"/, '"').gsub(/\\'/, "'")}, true, false))
+        define_parameter_type(ParameterType.new('string', STRING_REGEXP, String, lambda { |s1, s2| arg = s1 != nil ? s1 : s2; arg.gsub(/\\"/, '"').gsub(/\\'/, "'")}, true, false))
         define_parameter_type(ParameterType.new('', ANONYMOUS_REGEXP, String, lambda {|s = nil| s}, false, true))
       end
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -201,6 +201,33 @@ module Cucumber
         end
       end
 
+
+      it "unmatched optional groups have undefined values" do
+        parameter_type_registry = ParameterTypeRegistry.new
+        parameter_type_registry.define_parameter_type(
+            ParameterType.new(
+                'textAndOrNumber',
+                /([A-Z]+)?(?: )?([0-9]+)?/,
+                Object,
+                -> (s1, s2) {
+                  [s1, s2]
+                },
+                false,
+                true
+            )
+        )
+        expression = CucumberExpression.new(
+            '{textAndOrNumber}',
+            parameter_type_registry
+        )
+
+        class World
+        end
+
+        expect(expression.match("TLA")[0].value(World.new)).to eq(["TLA", nil])
+        expect(expression.match("123")[0].value(World.new)).to eq([nil, "123"])
+      end
+
       def match(expression, text)
         cucumber_expression = CucumberExpression.new(expression, ParameterTypeRegistry.new)
         args = cucumber_expression.match(text)


### PR DESCRIPTION
When using a regular expression with multiple optional capturing groups. Absent
groups (i.e. a null value) were filtered out. This makes optional
capture groups hard to use:

For example given a parameter type with optional capturing groups:

```java
   parameterTypeRegistry.defineParameterType(new ParameterType<>(
                "textAndOrNumber",
                singletonList("([A-Z]+)?(?: )?([0-9]+)?"),
                new TypeReference<List<String>>() {
                }.getType(),
                new CaptureGroupTransformer<List<String>>() {
                    @Override
                    public List<String> transform(String... args) {
                        return ...;
                    }
                },
                false,
                false)
        );
```

Now the intuition would be that `args[0]` always contains letters and `args[1]`
always contains numbers.

So when we match the expression `{textAndOrNumber}` against `TLA 123`. Then
`args = ["TLA", "123"]`. However when matched `TLA` or `123`
then `args = ["TLA"]` or `args = ["123"]`. This makes it hard to
distinguish between the two.

By not removing the null values we resolve this problem. So when matching
`123` we end up with `args = [null, "123"]`.

However. This will break instances where people were depend on the strict
either-or behaviour. As we did, for example our build in `{string}` type.

Fixes: #511
Fixes: #952

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

