### PR TITLE
gherkin-query ruby: do not try to lookup feature attributes if nil

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -23,7 +23,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
   ([#769](https://github.com/cucumber/cucumber/pull/769)
    [mpkorstanje]
    [vincent-psarga])
-
+* [Ruby] gherkin-query: if a feature file is empty, do not update anything.
+  ([cucumber-ruby#1427](https://github.com/cucumber/cucumber-ruby/issues/1427)
+   [vincent-psarga])
 
 ### Changed
 

--- a/gherkin/ruby/lib/gherkin/query.rb
+++ b/gherkin/ruby/lib/gherkin/query.rb
@@ -16,6 +16,7 @@ module Gherkin
     private
 
     def update_feature(feature)
+      return if feature.nil?
       store_nodes_location(feature.tags)
 
       feature.children.each do |child|

--- a/gherkin/ruby/spec/gherkin/query_spec.rb
+++ b/gherkin/ruby/spec/gherkin/query_spec.rb
@@ -59,13 +59,27 @@ describe Gherkin::Query do
       """
   }
 
-  before do
-    messages.each { |message|
-      subject.update(message)
-    }
+  context '#update' do
+    context 'when the feature file is empty' do
+      let(:feature_content) { '' }
+
+      it 'does not fail' do
+        expect {
+          messages.each { |message|
+            subject.update(message)
+          }
+        }.not_to raise_exception
+      end
+    end
   end
 
   context '#location' do
+    before do
+      messages.each { |message|
+        subject.update(message)
+      }
+    end
+
     let(:background) { find_message_by_attribute(gherkin_document.feature.children, :background) }
     let(:scenarios) { filter_messages_by_attribute(gherkin_document.feature.children, :scenario) }
     let(:scenario) { scenarios.first }


### PR DESCRIPTION
This is a fix for [cucumber-ruby#1427](https://github.com/cucumber/cucumber-ruby/issues/1427)

It can occur when there is an empty `.feature` file in the features directory. Surprisingly (or not), the error is only raised when trying to filter the scenarios by tags.