### PR TITLE
cucumber-expressions: Use Unicode symbols as a parameter boundary in snippets

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -16,19 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
-## [0.0.0] - 2020-07-03
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
+* Use Unicode symbols as a parameter boundary in snippets 
+    ([#1108](https://github.com/cucumber/cucumber/pull/1108)
+ [mpkorstanje])  
+ 
 ## [10.2.1] - 2020-06-23
 
 ### Fixed

--- a/cucumber-expressions/examples.txt
+++ b/cucumber-expressions/examples.txt
@@ -33,3 +33,7 @@ I have 22 cukes in my belly now
 /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
 a purchase for $33
 [null,33]
+---
+Some ${float} of cukes at {int}° Celsius
+Some $3.50 of cukes at 42° Celsius
+[3.5,42]

--- a/cucumber-expressions/go/cucumber_expression_generator_test.go
+++ b/cucumber-expressions/go/cucumber_expression_generator_test.go
@@ -55,6 +55,24 @@ func TestCucumberExpressionGeneratory(t *testing.T) {
 		)
 	})
 
+	t.Run("generates expression for numbers with symbol and currency", func(t *testing.T) {
+		assertExpression(
+			t,
+			"Some ${float} of cukes at {int}° Celsius",
+			[]string{"float", "int"},
+			"Some $3.50 of cukes at 42° Celsius",
+		)
+	})
+
+	t.Run("generates expression for numbers with text on both sides", func(t *testing.T) {
+		assertExpression(
+			t,
+			"i18n",
+			[]string{},
+			"i18n",
+		)
+	})
+
 	t.Run("generates expression for strings", func(t *testing.T) {
 		assertExpression(
 			t,

--- a/cucumber-expressions/go/examples.txt
+++ b/cucumber-expressions/go/examples.txt
@@ -33,3 +33,7 @@ I have 22 cukes in my belly now
 /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
 a purchase for $33
 [null,33]
+---
+Some ${float} of cukes at {int}° Celsius
+Some $3.50 of cukes at 42° Celsius
+[3.5,42]

--- a/cucumber-expressions/go/parameter_type_matcher.go
+++ b/cucumber-expressions/go/parameter_type_matcher.go
@@ -55,7 +55,7 @@ func (p *ParameterTypeMatcher) MatchEndWord() bool {
 }
 
 func (p *ParameterTypeMatcher) CharacterIsWordDelimiter(index int) bool {
-	matched, _ := regexp.MatchString(`\s|\p{P}`, p.text[index:index+1])
+	matched, _ := regexp.MatchString(`\p{Z}|\p{P}|\p{S}`, p.text[index:index+1])
 	return matched
 }
 

--- a/cucumber-expressions/java/examples.txt
+++ b/cucumber-expressions/java/examples.txt
@@ -33,3 +33,7 @@ I have 22 cukes in my belly now
 /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
 a purchase for $33
 [null,33]
+---
+Some ${float} of cukes at {int}° Celsius
+Some $3.50 of cukes at 42° Celsius
+[3.5,42]

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeMatcher.java
@@ -14,8 +14,8 @@ final class ParameterTypeMatcher implements Comparable<ParameterTypeMatcher> {
         this.text = text;
     }
 
-    private static boolean isWhitespaceOrPunctuation(char c) {
-        return Pattern.matches("[\\s\\p{P}]", new String(new char[]{c}));
+    private static boolean isWhitespaceOrPunctuationOrSymbol(char c) {
+        return Pattern.matches("[\\p{Z}\\p{P}\\p{S}]", new String(new char[] { c }));
     }
 
     boolean advanceToAndFind(int newMatchPos) {
@@ -23,24 +23,32 @@ final class ParameterTypeMatcher implements Comparable<ParameterTypeMatcher> {
         // so we can't use the immutable semantics.
         matcher.region(newMatchPos, text.length());
         while (matcher.find()) {
-            if (!group().isEmpty() && groupMatchesFullWord()) {
+            if (group().isEmpty()) {
+                continue;
+            }
+            if (groupHasWordBoundaryOnBothSides()) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean groupMatchesFullWord() {
+    private boolean groupHasWordBoundaryOnBothSides() {
+        return groupHasLeftWordBoundary() && groupHasRightWordBoundary();
+    }
+
+    private boolean groupHasLeftWordBoundary() {
         if (matcher.start() > 0) {
             char before = text.charAt(matcher.start() - 1);
-            if (!isWhitespaceOrPunctuation(before)) {
-                return false;
-            }
+            return isWhitespaceOrPunctuationOrSymbol(before);
         }
+        return true;
+    }
 
+    private boolean groupHasRightWordBoundary() {
         if (matcher.end() < text.length()) {
             char after = text.charAt(matcher.end());
-            return isWhitespaceOrPunctuation(after);
+            return isWhitespaceOrPunctuationOrSymbol(after);
         }
         return true;
     }

--- a/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
+++ b/cucumber-expressions/java/src/test/java/io/cucumber/cucumberexpressions/CucumberExpressionGeneratorTest.java
@@ -65,6 +65,20 @@ public class CucumberExpressionGeneratorTest {
     }
 
     @Test
+    public void generates_expression_for_numbers_with_symbols_and_currency() {
+        assertExpression(
+                "Some ${double} of cukes at {int}° Celsius", asList("double1", "int1"),
+                "Some $5000.00 of cukes at 42° Celsius");
+    }
+
+    @Test
+    public void generates_expression_for_numbers_with_text_on_both_sides() {
+        assertExpression(
+                "i18n", asList(),
+                "i18n");
+    }
+
+    @Test
     public void generates_expression_for_strings() {
         assertExpression(
                 "I like {string} and {string}", asList("string", "string2"),

--- a/cucumber-expressions/javascript/examples.txt
+++ b/cucumber-expressions/javascript/examples.txt
@@ -33,3 +33,7 @@ I have 22 cukes in my belly now
 /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
 a purchase for $33
 [null,33]
+---
+Some ${float} of cukes at {int}° Celsius
+Some $3.50 of cukes at 42° Celsius
+[3.5,42]

--- a/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
+++ b/cucumber-expressions/javascript/src/ParameterTypeMatcher.ts
@@ -52,14 +52,16 @@ export default class ParameterTypeMatcher {
   }
 
   get matchStartWord() {
-    return this.start === 0 || this.text[this.start - 1].match(/\s|\p{P}/u)
+    return (
+      this.start === 0 || this.text[this.start - 1].match(/\p{Z}|\p{P}|\p{S}/u)
+    )
   }
 
   get matchEndWord() {
     const nextCharacterIndex = this.start + this.group.length
     return (
       nextCharacterIndex === this.text.length ||
-      this.text[nextCharacterIndex].match(/\s|\p{P}/u)
+      this.text[nextCharacterIndex].match(/\p{Z}|\p{P}|\p{S}/u)
     )
   }
 

--- a/cucumber-expressions/ruby/examples.txt
+++ b/cucumber-expressions/ruby/examples.txt
@@ -33,3 +33,7 @@ I have 22 cukes in my belly now
 /^a (pre-commercial transaction |pre buyer fee model )?purchase(?: for \$(\d+))?$/
 a purchase for $33
 [null,33]
+---
+Some ${float} of cukes at {int}° Celsius
+Some $3.50 of cukes at 42° Celsius
+[3.5,42]

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/parameter_type_matcher.rb
@@ -47,12 +47,12 @@ module Cucumber
 
       def space_before_match_or_sentence_start?
         match_begin = @match.begin(0)
-        match_begin == 0 || @text[match_begin - 1].match(/\s|\p{P}/)
+        match_begin == 0 || @text[match_begin - 1].match(/\p{Z}|\p{P}|\p{S}/)
       end
 
       def space_after_match_or_sentence_end?
         match_end = @match.end(0)
-        match_end == @text.length || @text[match_end].match(/\s|\p{P}/)
+        match_end == @text.length || @text[match_end].match(/\p{Z}|\p{P}|\p{S}/)
       end
     end
   end


### PR DESCRIPTION
Numerical parameters should be bounded by whitespace, punctuation or symbols
on both sides.

```
$1.50 -> ${double}
15° Celsius -> {int}° Celcius
i18n -> i18n
$15m -> $15m
```
Fixes: https://github.com/cucumber/cucumber/issues/844

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [x] The change has been ported to Ruby.
- [x] The change has been ported to JavaScript.
- [x] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

