### PR TITLE
/gherkin/go: fix Gherkin link

### DIFF
--- a/gherkin/go/README.md
+++ b/gherkin/go/README.md
@@ -2,7 +2,7 @@
 
  [![GoDoc](https://godoc.org/github.com/cucumber/gherkin-go?status.svg)](http://godoc.org/github.com/cucumber/gherkin-go) [![Go Report Card](https://goreportcard.com/badge/github.com/cucumber/gherkin-go)](https://goreportcard.com/report/github.com/cucumber/gherkin-go)
 
-Gherkin parser/compiler for Go. Please see [Gherkin](https://github.com/cucumber/gherkin) for details.
+Gherkin parser/compiler for Go. Please see [Gherkin](https://github.com/cucumber/cucumber/tree/master/gherkin) for details.
 
 ## Building
 


### PR DESCRIPTION
## Summary

I've just fixed the link


