### PR TITLE
Fix linking error during serial build

### DIFF
--- a/messages/javascript/test/verifyStreamContract.ts
+++ b/messages/javascript/test/verifyStreamContract.ts
@@ -3,7 +3,7 @@ import { Transform } from 'stream'
 import toArray from './toArray'
 import assert = require('assert')
 
-export default function (
+export default function verifyStreamContract(
   makeFromMessageStream: () => Transform,
   makeToMessageStream: () => Transform
 ) {


### PR DESCRIPTION
Add name for function verifyStreamContract (the linter was failing as it could not find a name apparently)

Example of failed build: https://app.circleci.com/pipelines/github/cucumber/cucumber/3062/workflows/d42c1f7b-0606-4e32-94d2-46fc6877fe8c/jobs/97765

That does not really explains why it works in the parallel build that said.