### PR TITLE
messages: Use resource bundle to determine message protocol version

### DIFF
--- a/create-meta/java/pom.xml
+++ b/create-meta/java/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>messages</artifactId>
-            <version>12.3.2</version>
+            <version>12.3.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/create-meta/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
+++ b/create-meta/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
@@ -3,6 +3,7 @@ package io.cucumber.createmeta;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import io.cucumber.messages.Messages;
+import io.cucumber.messages.ProtocolVersion;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -33,7 +34,6 @@ public class CreateMeta {
             Map<String, String> env
     ) {
         Messages.Meta.Builder metaBuilder = Messages.Meta.newBuilder()
-                .setProtocolVersion(Messages.class.getPackage().getImplementationVersion())
                 .setRuntime(Messages.Meta.Product.newBuilder()
                         .setName(System.getProperty("java.vendor"))
                         .setVersion(System.getProperty("java.version")))
@@ -44,6 +44,10 @@ public class CreateMeta {
                         .setName(System.getProperty("os.name")))
                 .setCpu(Messages.Meta.Product.newBuilder()
                         .setName(System.getProperty("os.arch")));
+
+        ProtocolVersion.getVersion()
+                .ifPresent(metaBuilder::setProtocolVersion);
+
         Messages.Meta.CI ci = detectCI(env);
         if (ci != null) {
             metaBuilder.setCi(ci);

--- a/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
+++ b/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
@@ -1,28 +1,35 @@
 package io.cucumber.createmeta;
 
 import io.cucumber.messages.Messages;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CreateMetaTest {
+class CreateMetaTest {
     @Test
-    public void it_provides_the_correct_tool_name() {
+    void it_provides_the_correct_tool_name() {
         Messages.Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertEquals("cucumber-jvm", meta.getImplementation().getName());
     }
 
     @Test
-    public void it_provides_the_correct_tool_version() {
+    void it_provides_the_correct_tool_version() {
         Messages.Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
         assertEquals("3.2.1", meta.getImplementation().getVersion());
     }
 
     @Test
-    public void it_detects_github_actions() {
+    void it_provides_the_correct_protocol_version() {
+        Messages.Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", new HashMap<>());
+        assertThat(meta.getProtocolVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?"));
+    }
+
+    @Test
+    void it_detects_github_actions() {
         HashMap<String, String> env = new HashMap<String, String>() {{
             put("GITHUB_REPOSITORY", "cucumber/cucumber-ruby");
             put("GITHUB_RUN_ID", "140170388");
@@ -41,4 +48,5 @@ public class CreateMetaTest {
                         .build(),
                 meta.getCi());
     }
+
 }

--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+* Added ProtocolVersion to access messages version reliably ([#1127](https://github.com/cucumber/cucumber/pull/1127) [mpkorstanje])
 
 ### Changed
 

--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -36,12 +36,14 @@
             <artifactId>protobuf-java-util</artifactId>
             <version>3.12.4</version>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -44,9 +44,22 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
+++ b/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
@@ -1,13 +1,11 @@
 package io.cucumber.messages;
 
-import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 

--- a/messages/java/src/main/java/io/cucumber/messages/ProtocolVersion.java
+++ b/messages/java/src/main/java/io/cucumber/messages/ProtocolVersion.java
@@ -1,0 +1,15 @@
+package io.cucumber.messages;
+
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+public final class ProtocolVersion {
+
+    public static Optional<String> getVersion(){
+        try {
+            return Optional.of(ResourceBundle.getBundle("io.cucumber.messages.version").getString("messages.version"));
+        } catch (Exception ignored){
+            return Optional.empty();
+        }
+    }
+}

--- a/messages/java/src/main/resources/io/cucumber/messages/version.properties
+++ b/messages/java/src/main/resources/io/cucumber/messages/version.properties
@@ -1,0 +1,1 @@
+messages.version=${project.version}

--- a/messages/java/src/test/java/io/cucumber/messages/MessageSerializationContract.java
+++ b/messages/java/src/test/java/io/cucumber/messages/MessageSerializationContract.java
@@ -1,6 +1,6 @@
 package io.cucumber.messages;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -10,11 +10,12 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public abstract class MessageSerializationContract {
+abstract class MessageSerializationContract {
+
     @Test
-    public void can_serialise_messages_over_a_stream() throws IOException {
+    void can_serialise_messages_over_a_stream() throws IOException {
         List<Messages.Envelope> outgoingMessages = createOutgoingMessages();
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -42,7 +43,8 @@ public abstract class MessageSerializationContract {
         return outgoingMessages;
     }
 
-    private void writeOutgoingMessages(List<Messages.Envelope> messages, MessageWriter messageWriter) throws IOException {
+    private void writeOutgoingMessages(List<Messages.Envelope> messages, MessageWriter messageWriter)
+            throws IOException {
         for (Messages.Envelope writtenMessage : messages) {
             messageWriter.write(writtenMessage);
         }
@@ -55,4 +57,5 @@ public abstract class MessageSerializationContract {
         }
         return result;
     }
+
 }

--- a/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
@@ -1,6 +1,6 @@
 package io.cucumber.messages;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -8,11 +8,11 @@ import java.io.OutputStream;
 import java.util.Iterator;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NdjsonSerializationTest extends MessageSerializationContract {
+class NdjsonSerializationTest extends MessageSerializationContract {
     @Override
     protected MessageWriter makeMessageWriter(OutputStream output) {
         return new MessageToNdjsonWriter(output);
@@ -24,7 +24,7 @@ public class NdjsonSerializationTest extends MessageSerializationContract {
     }
 
     @Test
-    public void ignores_missing_fields() {
+    void ignores_missing_fields() {
         InputStream input = new ByteArrayInputStream("{\"unused\": 99}\n".getBytes(UTF_8));
         Iterable<Messages.Envelope> incomingMessages = makeMessageIterable(input);
         Iterator<Messages.Envelope> iterator = incomingMessages.iterator();

--- a/messages/java/src/test/java/io/cucumber/messages/ProtobufSerializationTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/ProtobufSerializationTest.java
@@ -3,7 +3,7 @@ package io.cucumber.messages;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class ProtobufSerializationTest extends MessageSerializationContract {
+class ProtobufSerializationTest extends MessageSerializationContract {
     @Override
     protected MessageWriter makeMessageWriter(OutputStream output) {
         return new MessageToBinaryWriter(output);

--- a/messages/java/src/test/java/io/cucumber/messages/ProtocolVersionTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/ProtocolVersionTest.java
@@ -1,0 +1,16 @@
+package io.cucumber.messages;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ProtocolVersionTest {
+
+    @Test
+    void should_have_a_resource_bundle_version() {
+        String version = ProtocolVersion.getVersion().get();
+        assertThat(version, Matchers.matchesPattern("\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?"));
+    }
+
+}

--- a/messages/java/src/test/java/io/cucumber/messages/TimeConversionTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/TimeConversionTest.java
@@ -1,6 +1,6 @@
 package io.cucumber.messages;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -9,11 +9,12 @@ import static io.cucumber.messages.TimeConversion.durationToJavaDuration;
 import static io.cucumber.messages.TimeConversion.javaDurationToDuration;
 import static io.cucumber.messages.TimeConversion.javaInstantToTimestamp;
 import static io.cucumber.messages.TimeConversion.timestampToJavaInstant;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TimeConversionTest {
+class TimeConversionTest {
+
     @Test
-    public void convertsToAndFromTimestamp() {
+    void convertsToAndFromTimestamp() {
         Instant javaInstant = Instant.now();
         Messages.Timestamp timestamp = javaInstantToTimestamp(javaInstant);
         Instant javaInstantAgain = timestampToJavaInstant(timestamp);
@@ -22,11 +23,12 @@ public class TimeConversionTest {
     }
 
     @Test
-    public void convertsToAndFromDuration() {
+    void convertsToAndFromDuration() {
         Duration javaDuration = Duration.ofSeconds(3, 161000);
         Messages.Duration duration = javaDurationToDuration(javaDuration);
         Duration javaDurationAgain = durationToJavaDuration(duration);
 
         assertEquals(javaDuration, javaDurationAgain);
     }
+
 }


### PR DESCRIPTION
Because `Messages.class.getPackage().getImplementationVersion()` can not reliably determine the implementation version of the messages jar (e.g. when the jar is shaded). we should determine the message protocol version in a different way. By adding a resource bundle with the version of messages included we can avoid this problem. 

Fixes: https://github.com/cucumber/cucumber/issues/1127

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

