### PR TITLE
Expose filterByStatus and fix signature

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* expose `filterByStatus` method
+
 ### Changed
+
+* fix `filterByStatus` signature
 
 ### Deprecated
 
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Updated `messages` to v12.4.0 
+* Updated `messages` to v12.4.0
 
 ## [8.1.0] - 2020-07-30
 

--- a/react/javascript/src/filter/filterByStatus.ts
+++ b/react/javascript/src/filter/filterByStatus.ts
@@ -11,7 +11,7 @@ export default function filterByStatus(
   gherkinQuery: GherkinQuery,
   cucumberQuery: CucumberQuery,
   statuses: messages.TestStepFinished.TestStepResult.Status[]
-): messages.IGherkinDocument {
+): messages.IGherkinDocument | null {
   const filters = {
     acceptScenario: (scenario: messages.GherkinDocument.Feature.IScenario) => {
       const pickleIds = gherkinQuery.getPickleIds(

--- a/react/javascript/src/index.ts
+++ b/react/javascript/src/index.ts
@@ -2,5 +2,12 @@ import GherkinDocumentList from './components/app/GherkinDocumentList'
 import FilteredResults from './components/app/FilteredResults'
 import QueriesWrapper from './components/app/QueriesWrapper'
 import { EnvelopesQuery } from './EnvelopesQueryContext'
+import filterByStatus from './filter/filterByStatus'
 
-export { GherkinDocumentList, QueriesWrapper, EnvelopesQuery, FilteredResults }
+export {
+  GherkinDocumentList,
+  QueriesWrapper,
+  EnvelopesQuery,
+  FilteredResults,
+  filterByStatus,
+}


### PR DESCRIPTION
## Summary

Expose `filterByStatus` to enable custom filtering of displayed `GherkinDocuments`.
Also update the signature so it's clear it can also return `null`.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

