### PR TITLE
Add semantic CSS classes to React

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* semantic CSS classes on elements.
+
 ### Changed
 
 ### Deprecated
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Updated `messages` to v12.4.0 
+* Updated `messages` to v12.4.0
 
 ## [8.1.0] - 2020-07-30
 

--- a/react/javascript/CSS_map.md
+++ b/react/javascript/CSS_map.md
@@ -1,0 +1,34 @@
+# CSS map
+
+Overview of the semantic CSS classes. They sshould all be prefixed with `cucumberReact-` to avoid conflicts in integration.
+
+## Gherkin document
+
+Here are the classes used when rendering a `GherkinDocument`.
+
+### Generic elements
+
+Some CSS classes can be applied to multiple places:
+
+ * `cucumberReact-title`: title for a `Feature`, `Scenario`, `Background` or `Rule`
+ * `cucumberReact-descrition`: description for the same elements
+ * `cucumberReact-tags`: list of element tags
+ * `cucumberReact-tag`: single tag
+ * `cucumberReact-steps`: list of steps
+ * `cucumberReact-step`: single step
+ * `cucumberReact-table`: a Table rendered by cucumber-react. Can be either `Examples` or `datatable`
+ * `cucumberReact-code`: code rendered (either `docstring` or attachment logs)
+ * `cucumberReact-attachments`: container for the step attachments
+ * `cucumberReact-attachment`: a single attachment
+ * `cucumberReact-status`: the status of a step or a Feature
+
+### Specific class by element in the AST
+
+ * `cucumberReact-feature`: container for a Feature
+ * `cucumberReact-background`: container for a Background
+ * `cucumberReact-scenario`: container for a Scenario
+ * `cucumberReact-rule`: container for a Rule
+ * `cucumberReact-examples`: apply for an `Example` table
+ * `cucumberReact-datatable`: apply for a datatable argument
+ * `cucumberReact-docstring`: apply for a docstring argument
+

--- a/react/javascript/CSS_map.md
+++ b/react/javascript/CSS_map.md
@@ -19,12 +19,15 @@ Some CSS classes can be applied to multiple places:
  * `cucumber-children`: list of childrens for a `Feature` or a `Rule`
  * `cucumber-steps`: list of steps
  * `cucumber-step`: single step
+ * `cucumber-step__status`: the status of the step
+ * `cucumber-step__content`: the content of the step (keyword, text, parameters, attachments ...)
  * `cucumber-step__keyword`: the keyword of a step
  * `cucumber-step__param`: a parameter of a step
  * `cucumber-step__text`: the text of a step
  * `cucumber-table`: a Table rendered by cucumber-react. Can be either `Examples` or `datatable`
  * `cucumber-code`: code rendered (either `docstring` or attachment logs)
  * `cucumber-status`: the status of a step or a Feature
+ * `cucumber-status-<status name>`: a specific status
 
 ### Specific class by element in the AST
 
@@ -44,3 +47,7 @@ Some CSS classes can be applied to multiple places:
  * `cucumber-attachment__text`: a text attachment
  * `cucumber-attachment__image`: an image attachment
  * `cucumber-error`: an error message
+ * `cucumber-anchor`: anchor + link to easily point to a specific part of the document
+ * `cucumber-anchor__link`: the link to the anchor
+ * `cucumber-anchor__icon`: the icon used to find the link
+ * `cucumber-no-documents`: a text displayed when no document can be displayed

--- a/react/javascript/CSS_map.md
+++ b/react/javascript/CSS_map.md
@@ -1,6 +1,6 @@
 # CSS map
 
-Overview of the semantic CSS classes. They sshould all be prefixed with `cucumberReact-` to avoid conflicts in integration.
+Overview of the semantic CSS classes. They should all be prefixed with `cucumber-` to avoid conflicts in integration.
 
 ## Gherkin document
 
@@ -10,25 +10,37 @@ Here are the classes used when rendering a `GherkinDocument`.
 
 Some CSS classes can be applied to multiple places:
 
- * `cucumberReact-title`: title for a `Feature`, `Scenario`, `Background` or `Rule`
- * `cucumberReact-descrition`: description for the same elements
- * `cucumberReact-tags`: list of element tags
- * `cucumberReact-tag`: single tag
- * `cucumberReact-steps`: list of steps
- * `cucumberReact-step`: single step
- * `cucumberReact-table`: a Table rendered by cucumber-react. Can be either `Examples` or `datatable`
- * `cucumberReact-code`: code rendered (either `docstring` or attachment logs)
- * `cucumberReact-attachments`: container for the step attachments
- * `cucumberReact-attachment`: a single attachment
- * `cucumberReact-status`: the status of a step or a Feature
+ * `cucumber-title`: title for a `Feature`, `Scenario`, `Background` or `Rule`
+ * `cucumber-title__keyword`: the keyword of a title
+ * `cucumber-title__text`: the text of a title
+ * `cucumber-descrition`: description for the same elements
+ * `cucumber-tags`: list of element tags
+ * `cucumber-tag`: single tag
+ * `cucumber-children`: list of childrens for a `Feature` or a `Rule`
+ * `cucumber-steps`: list of steps
+ * `cucumber-step`: single step
+ * `cucumber-step__keyword`: the keyword of a step
+ * `cucumber-step__param`: a parameter of a step
+ * `cucumber-step__text`: the text of a step
+ * `cucumber-table`: a Table rendered by cucumber-react. Can be either `Examples` or `datatable`
+ * `cucumber-code`: code rendered (either `docstring` or attachment logs)
+ * `cucumber-status`: the status of a step or a Feature
 
 ### Specific class by element in the AST
 
- * `cucumberReact-feature`: container for a Feature
- * `cucumberReact-background`: container for a Background
- * `cucumberReact-scenario`: container for a Scenario
- * `cucumberReact-rule`: container for a Rule
- * `cucumberReact-examples`: apply for an `Example` table
- * `cucumberReact-datatable`: apply for a datatable argument
- * `cucumberReact-docstring`: apply for a docstring argument
+ * `cucumber-feature`: container for a `Feature`
+ * `cucumber-background`: container for a `Background`
+ * `cucumber-scenario`: container for a `Scenario`
+ * `cucumber-rule`: container for a `Rule`
+ * `cucumber-examples`: containers for lisst of `Examples`
+ * `cucumber-examples-table`: apply for an `Examples` table
+ * `cucumber-datatable`: apply for a datatable argument
+ * `cucumber-docstring`: apply for a docstring argument
 
+### Other specific elements
+
+ * `cucumber-attachments`: container for the step attachments
+ * `cucumber-attachment`: a single attachment
+ * `cucumber-attachment__text`: a text attachment
+ * `cucumber-attachment__image`: an image attachment
+ * `cucumber-error`: an error message

--- a/react/javascript/src/components/app/GherkinDocumentList.tsx
+++ b/react/javascript/src/components/app/GherkinDocumentList.tsx
@@ -65,7 +65,7 @@ const GherkinDocumentList: React.FunctionComponent<IProps> = ({
             <AccordionItem key={doc.uri} uuid={doc.uri}>
               <AccordionItemHeading>
                 <AccordionItemButton>
-                  <span className="text_status_icon_container">
+                  <span className="cucumber-feature__icon">
                     <StatusIcon status={gherkinDocumentStatus} />
                   </span>
                   <span>{doc.uri}</span>

--- a/react/javascript/src/components/app/HighLight.tsx
+++ b/react/javascript/src/components/app/HighLight.tsx
@@ -5,7 +5,7 @@ import elasticlunr from 'elasticlunr'
 
 interface IProps {
   text: string
-  htmlText?: boolean,
+  htmlText?: boolean
   className?: string
 }
 
@@ -48,7 +48,7 @@ const highlightElements = (text: string, chunks: Chunk[]): JSX.Element[] => {
 const HighLight: React.FunctionComponent<IProps> = ({
   text,
   htmlText = false,
-  className = ''
+  className = '',
 }) => {
   const searchQueryContext = React.useContext(SearchQueryContext)
   const queryWords = allQueryWords(
@@ -71,7 +71,9 @@ const HighLight: React.FunctionComponent<IProps> = ({
     )
   }
 
-  return <span className={appliedClassName}>{highlightElements(text, chunks)}</span>
+  return (
+    <span className={appliedClassName}>{highlightElements(text, chunks)}</span>
+  )
 }
 
 export default HighLight

--- a/react/javascript/src/components/app/HighLight.tsx
+++ b/react/javascript/src/components/app/HighLight.tsx
@@ -5,7 +5,8 @@ import elasticlunr from 'elasticlunr'
 
 interface IProps {
   text: string
-  htmlText?: boolean
+  htmlText?: boolean,
+  className?: string
 }
 
 const allQueryWords = (queryWords: string[]): string[] => {
@@ -47,6 +48,7 @@ const highlightElements = (text: string, chunks: Chunk[]): JSX.Element[] => {
 const HighLight: React.FunctionComponent<IProps> = ({
   text,
   htmlText = false,
+  className = ''
 }) => {
   const searchQueryContext = React.useContext(SearchQueryContext)
   const queryWords = allQueryWords(
@@ -58,16 +60,18 @@ const HighLight: React.FunctionComponent<IProps> = ({
     htmlText,
   })
 
+  const appliedClassName = className ? `highlight ${className}` : 'highlight'
+
   if (htmlText) {
     return (
-      <span
-        className="highlight"
+      <div
+        className={appliedClassName}
         dangerouslySetInnerHTML={{ __html: highlightText(text, chunks) }}
       />
     )
   }
 
-  return <span className="highlight">{highlightElements(text, chunks)}</span>
+  return <span className={appliedClassName}>{highlightElements(text, chunks)}</span>
 }
 
 export default HighLight

--- a/react/javascript/src/components/app/NoMatchResult.tsx
+++ b/react/javascript/src/components/app/NoMatchResult.tsx
@@ -10,7 +10,7 @@ const NoMatchResult: React.FunctionComponent<IProps> = ({ query, matches }) => {
   const showNoMatchMessage = query !== '' && matches.length === 0
 
   return (
-    <p className="cucumber-no-results">
+    <p className="cucumber-no-documents">
       {showNoMatchMessage && `No match found for: "${query}"`}
     </p>
   )

--- a/react/javascript/src/components/gherkin/Attachment.tsx
+++ b/react/javascript/src/components/gherkin/Attachment.tsx
@@ -36,6 +36,7 @@ function image(attachment: messages.IAttachment) {
   ) {
     return (
       <ErrorMessage
+        className="cucumber-attachment"
         message={`Couldn't display ${attachment.mediaType} image because it wasn't base64 encoded`}
       />
     )
@@ -44,7 +45,7 @@ function image(attachment: messages.IAttachment) {
     <img
       alt="Embedded Image"
       src={`data:${attachment.mediaType};base64,${attachment.body}`}
-      className="attachment-image"
+      className="cucumber-attachment cucumber-attachment__image"
     />
   )
 }
@@ -55,6 +56,7 @@ function video(attachment: messages.IAttachment) {
   ) {
     return (
       <ErrorMessage
+        className="cucumber-attachment"
         message={`Couldn't display ${attachment.mediaType} video because it wasn't base64 encoded`}
       />
     )
@@ -91,14 +93,14 @@ function text(
 
   if (dangerouslySetInnerHTML) {
     return (
-      <pre className="attachment">
+      <pre className="cucumber-attachment cucumber-attachment__text">
         <FontAwesomeIcon icon={faPaperclip} className="attachment-icon" />
         <span dangerouslySetInnerHTML={{ __html: prettify(body) }} />
       </pre>
     )
   }
   return (
-    <pre className="attachment">
+    <pre className="cucumber-attachment cucumber-attachment__text">
       <FontAwesomeIcon icon={faPaperclip} className="attachment-icon" />
       {prettify(body)}
     </pre>

--- a/react/javascript/src/components/gherkin/Attachment.tsx
+++ b/react/javascript/src/components/gherkin/Attachment.tsx
@@ -94,14 +94,20 @@ function text(
   if (dangerouslySetInnerHTML) {
     return (
       <pre className="cucumber-attachment cucumber-attachment__text">
-        <FontAwesomeIcon icon={faPaperclip} className="cucumber-attachment__icon" />
+        <FontAwesomeIcon
+          icon={faPaperclip}
+          className="cucumber-attachment__icon"
+        />
         <span dangerouslySetInnerHTML={{ __html: prettify(body) }} />
       </pre>
     )
   }
   return (
     <pre className="cucumber-attachment cucumber-attachment__text">
-      <FontAwesomeIcon icon={faPaperclip} className="cucumber-attachment__icon" />
+      <FontAwesomeIcon
+        icon={faPaperclip}
+        className="cucumber-attachment__icon"
+      />
       {prettify(body)}
     </pre>
   )

--- a/react/javascript/src/components/gherkin/Attachment.tsx
+++ b/react/javascript/src/components/gherkin/Attachment.tsx
@@ -94,14 +94,14 @@ function text(
   if (dangerouslySetInnerHTML) {
     return (
       <pre className="cucumber-attachment cucumber-attachment__text">
-        <FontAwesomeIcon icon={faPaperclip} className="attachment-icon" />
+        <FontAwesomeIcon icon={faPaperclip} className="cucumber-attachment__icon" />
         <span dangerouslySetInnerHTML={{ __html: prettify(body) }} />
       </pre>
     )
   }
   return (
     <pre className="cucumber-attachment cucumber-attachment__text">
-      <FontAwesomeIcon icon={faPaperclip} className="attachment-icon" />
+      <FontAwesomeIcon icon={faPaperclip} className="cucumber-attachment__icon" />
       {prettify(body)}
     </pre>
   )

--- a/react/javascript/src/components/gherkin/Background.tsx
+++ b/react/javascript/src/components/gherkin/Background.tsx
@@ -16,16 +16,14 @@ const Background: React.FunctionComponent<IProps> = ({ background }) => {
   const idGenerated = generator.generate(background.name)
 
   return (
-    <section>
+    <section className="cucumber-background">
       <BackgroundTitle id={idGenerated} background={background} />
-      <div className="indent">
-        <Description description={background.description} />
-        <StepList
-          steps={background.steps || []}
-          renderStepMatchArguments={true}
-          renderMessage={true}
-        />
-      </div>
+      <Description description={background.description} />
+      <StepList
+        steps={background.steps || []}
+        renderStepMatchArguments={true}
+        renderMessage={true}
+      />
     </section>
   )
 }

--- a/react/javascript/src/components/gherkin/BackgroundTitle.tsx
+++ b/react/javascript/src/components/gherkin/BackgroundTitle.tsx
@@ -15,13 +15,15 @@ const BackgroundTitle: React.FunctionComponent<IProps> = ({
   background,
 }) => {
   return (
-    <div className="anchored-link">
+    <div className="anchored-link cucumber-title">
       <a href={'#' + id}>
         <FontAwesomeIcon icon={faLink} className="attachment-icon" />
       </a>
       <h2 id={id}>
-        <Keyword>{background.keyword}:</Keyword>{' '}
-        <span className="step-text">{background.name}</span>
+        <Keyword className="cucumber-title__keyword">
+          {background.keyword}:
+        </Keyword>{' '}
+        <span className="cucumber-title__text">{background.name}</span>
       </h2>
     </div>
   )

--- a/react/javascript/src/components/gherkin/BackgroundTitle.tsx
+++ b/react/javascript/src/components/gherkin/BackgroundTitle.tsx
@@ -15,9 +15,9 @@ const BackgroundTitle: React.FunctionComponent<IProps> = ({
   background,
 }) => {
   return (
-    <div className="anchored-link cucumber-title">
+    <div className="cucumber-anchor cucumber-title">
       <a href={'#' + id}>
-        <FontAwesomeIcon icon={faLink} className="attachment-icon" />
+        <FontAwesomeIcon icon={faLink} className="cucumber-anchor__icon" />
       </a>
       <h2 id={id}>
         <Keyword className="cucumber-title__keyword">

--- a/react/javascript/src/components/gherkin/DataTable.tsx
+++ b/react/javascript/src/components/gherkin/DataTable.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 const DataTable: React.FunctionComponent<IProps> = ({ dataTable }) => {
   return (
-    <table className="data-table">
+    <table className="cucumber-table cucumber-datatable">
       <TableBody rows={dataTable.rows || []} />
     </table>
   )

--- a/react/javascript/src/components/gherkin/Description.tsx
+++ b/react/javascript/src/components/gherkin/Description.tsx
@@ -4,18 +4,20 @@ import sanitizeHtml from 'sanitize-html'
 import HighLight from '../app/HighLight'
 
 interface IProps {
-  description: string,
+  description: string
   className?: string
 }
 
 const Description: React.FunctionComponent<IProps> = ({
   description,
-  className = ''
+  className = '',
 }) => {
   const html = marked(description)
   const sanitizedHtml = sanitizeHtml(html)
 
-  return <HighLight className={className} text={sanitizedHtml} htmlText={true} />
+  return (
+    <HighLight className={className} text={sanitizedHtml} htmlText={true} />
+  )
 }
 
 export default Description

--- a/react/javascript/src/components/gherkin/Description.tsx
+++ b/react/javascript/src/components/gherkin/Description.tsx
@@ -4,14 +4,18 @@ import sanitizeHtml from 'sanitize-html'
 import HighLight from '../app/HighLight'
 
 interface IProps {
-  description: string
+  description: string,
+  className?: string
 }
 
-const Description: React.FunctionComponent<IProps> = ({ description }) => {
+const Description: React.FunctionComponent<IProps> = ({
+  description,
+  className = ''
+}) => {
   const html = marked(description)
   const sanitizedHtml = sanitizeHtml(html)
 
-  return <HighLight text={sanitizedHtml} htmlText={true} />
+  return <HighLight className={className} text={sanitizedHtml} htmlText={true} />
 }
 
 export default Description

--- a/react/javascript/src/components/gherkin/Description.tsx
+++ b/react/javascript/src/components/gherkin/Description.tsx
@@ -5,18 +5,18 @@ import HighLight from '../app/HighLight'
 
 interface IProps {
   description: string
-  className?: string
 }
 
-const Description: React.FunctionComponent<IProps> = ({
-  description,
-  className = '',
-}) => {
+const Description: React.FunctionComponent<IProps> = ({ description }) => {
   const html = marked(description)
   const sanitizedHtml = sanitizeHtml(html)
 
   return (
-    <HighLight className={className} text={sanitizedHtml} htmlText={true} />
+    <HighLight
+      className="cucumber-description"
+      text={sanitizedHtml}
+      htmlText={true}
+    />
   )
 }
 

--- a/react/javascript/src/components/gherkin/DocString.tsx
+++ b/react/javascript/src/components/gherkin/DocString.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 const DocString: React.FunctionComponent<IProps> = ({ docString }) => {
   return (
-    <pre>
+    <pre className="cucumber-code cucumber-docstring">
       <HighLight text={docString.content} />
     </pre>
   )

--- a/react/javascript/src/components/gherkin/ErrorMessage.tsx
+++ b/react/javascript/src/components/gherkin/ErrorMessage.tsx
@@ -2,10 +2,14 @@ import React from 'react'
 
 interface IProps {
   message: string
+  className?: string
 }
 
-const ErrorMessage: React.FunctionComponent<IProps> = ({ message }) => {
-  return <pre className="error-message">{message}</pre>
+const ErrorMessage: React.FunctionComponent<IProps> = ({
+  message,
+  className = '',
+}) => {
+  return <pre className={`cucumber-error ${className}`}>{message}</pre>
 }
 
 export default ErrorMessage

--- a/react/javascript/src/components/gherkin/Examples.tsx
+++ b/react/javascript/src/components/gherkin/Examples.tsx
@@ -12,22 +12,22 @@ interface IExamplesProps {
 
 const Examples: React.FunctionComponent<IExamplesProps> = ({ examples }) => {
   return (
-    <div className="indent">
-      <section>
-        <Tags tags={examples.tags} />
-        <h2>
-          <Keyword>{examples.keyword}:</Keyword>{' '}
-          <span className="step-text">{examples.name}</span>
-        </h2>
-        <Description description={examples.description} />
-        {examples.tableHeader && (
-          <ExamplesTable
-            tableHeader={examples.tableHeader}
-            tableBody={examples.tableBody}
-          />
-        )}
-      </section>
-    </div>
+    <section className="cucumber-examples">
+      <Tags tags={examples.tags} />
+      <h2 className="cucumber-title">
+        <Keyword className="cucumber-title__keyword">
+          {examples.keyword}:
+        </Keyword>{' '}
+        <span className="cucumber-title__text">{examples.name}</span>
+      </h2>
+      <Description description={examples.description} />
+      {examples.tableHeader && (
+        <ExamplesTable
+          tableHeader={examples.tableHeader}
+          tableBody={examples.tableBody}
+        />
+      )}
+    </section>
   )
 }
 

--- a/react/javascript/src/components/gherkin/ExamplesTable.tsx
+++ b/react/javascript/src/components/gherkin/ExamplesTable.tsx
@@ -16,9 +16,9 @@ const ExamplesTable: React.FunctionComponent<IProps> = ({
     <table className="cucumber-table cucumber-examples-table">
       <thead>
         <tr>
-          <th>&nbsp;</th>
+          <th className="cucumber-table__header-cell">&nbsp;</th>
           {tableHeader.cells.map((cell, j) => (
-            <th key={j}>{cell.value}</th>
+            <th className="cucumber-table__header-cell" key={j}>{cell.value}</th>
           ))}
         </tr>
       </thead>

--- a/react/javascript/src/components/gherkin/ExamplesTable.tsx
+++ b/react/javascript/src/components/gherkin/ExamplesTable.tsx
@@ -18,7 +18,9 @@ const ExamplesTable: React.FunctionComponent<IProps> = ({
         <tr>
           <th className="cucumber-table__header-cell">&nbsp;</th>
           {tableHeader.cells.map((cell, j) => (
-            <th className="cucumber-table__header-cell" key={j}>{cell.value}</th>
+            <th className="cucumber-table__header-cell" key={j}>
+              {cell.value}
+            </th>
           ))}
         </tr>
       </thead>

--- a/react/javascript/src/components/gherkin/ExamplesTable.tsx
+++ b/react/javascript/src/components/gherkin/ExamplesTable.tsx
@@ -13,7 +13,7 @@ const ExamplesTable: React.FunctionComponent<IProps> = ({
   tableBody,
 }) => {
   return (
-    <table className="examples-table">
+    <table className="cucumber-table cucumber-examples-table">
       <thead>
         <tr>
           <th>&nbsp;</th>

--- a/react/javascript/src/components/gherkin/ExamplesTableBody.tsx
+++ b/react/javascript/src/components/gherkin/ExamplesTableBody.tsx
@@ -38,12 +38,13 @@ const RowOrRows: React.FunctionComponent<IRowOrRows> = ({ row }) => {
   )
   return (
     <>
-      <tr className={`status-${statusName(testStepResult.status)}`}>
-        <td>
+      <tr className={`cucumber-status--${statusName(testStepResult.status)}`}>
+        <td className="cucumber-table__cell">
           <StatusIcon status={testStepResult.status} />
         </td>
         {row.cells.map((cell, j) => (
           <td
+            className="cucumber-table__cell"
             key={j}
             style={{ textAlign: isNumber(cell.value) ? 'right' : 'left' }}
           >
@@ -71,7 +72,7 @@ const ErrorMessageRow: React.FunctionComponent<IErrorMessageRowProps> = ({
 }) => {
   if (!testStepResult.message) return null
   return (
-    <tr className={`status-${statusName(testStepResult.status)}`}>
+    <tr className={`cucumber-status--${statusName(testStepResult.status)} cucumber-table__cell`}>
       <td>&nbsp;</td>
       <td colSpan={colSpan}>
         <ErrorMessage message={testStepResult.message} />

--- a/react/javascript/src/components/gherkin/ExamplesTableBody.tsx
+++ b/react/javascript/src/components/gherkin/ExamplesTableBody.tsx
@@ -72,7 +72,11 @@ const ErrorMessageRow: React.FunctionComponent<IErrorMessageRowProps> = ({
 }) => {
   if (!testStepResult.message) return null
   return (
-    <tr className={`cucumber-status--${statusName(testStepResult.status)} cucumber-table__cell`}>
+    <tr
+      className={`cucumber-status--${statusName(
+        testStepResult.status
+      )} cucumber-table__cell`}
+    >
       <td>&nbsp;</td>
       <td colSpan={colSpan}>
         <ErrorMessage message={testStepResult.message} />

--- a/react/javascript/src/components/gherkin/Feature.tsx
+++ b/react/javascript/src/components/gherkin/Feature.tsx
@@ -24,7 +24,10 @@ const Feature: React.FunctionComponent<IProps> = ({ feature }) => {
       <FeatureTitle id={idGenerated} feature={feature} />
       <div className="cucumberFeature__indent">
         {feature.description ? (
-          <Description description={feature.description} />
+          <Description
+            description={feature.description}
+            className="cucumberfeature__description"
+          />
         ) : null}
         {(feature.children || []).map((child, index) => {
           if (child.background) {

--- a/react/javascript/src/components/gherkin/Feature.tsx
+++ b/react/javascript/src/components/gherkin/Feature.tsx
@@ -19,16 +19,13 @@ const Feature: React.FunctionComponent<IProps> = ({ feature }) => {
   const idGenerated = generator.generate(feature.name)
 
   return (
-    <section className="cucumberFeature">
+    <section className="cucumber-feature">
       <Tags tags={feature.tags} />
       <FeatureTitle id={idGenerated} feature={feature} />
-      <div className="cucumberFeature__indent">
-        {feature.description ? (
-          <Description
-            description={feature.description}
-            className="cucumberfeature__description"
-          />
-        ) : null}
+      {feature.description ? (
+        <Description description={feature.description} />
+      ) : null}
+      <div className="cucumber-children">
         {(feature.children || []).map((child, index) => {
           if (child.background) {
             return <Background key={index} background={child.background} />

--- a/react/javascript/src/components/gherkin/FeatureTitle.tsx
+++ b/react/javascript/src/components/gherkin/FeatureTitle.tsx
@@ -13,9 +13,9 @@ interface IProps {
 
 const FeatureTitle: React.FunctionComponent<IProps> = ({ id, feature }) => {
   return (
-    <div className="anchored-link cucumber-title">
-      <a href={'#' + id}>
-        <FontAwesomeIcon icon={faLink} className="attachment-icon" />
+    <div className="cucumber-anchor cucumber-title">
+      <a href={'#' + id} className="cucumber-anchor__link">
+        <FontAwesomeIcon icon={faLink} className="cucumber-anchor__icon" />
       </a>
       <h1 id={id}>
         <Keyword className="cucumber-title__keyword">

--- a/react/javascript/src/components/gherkin/FeatureTitle.tsx
+++ b/react/javascript/src/components/gherkin/FeatureTitle.tsx
@@ -13,15 +13,15 @@ interface IProps {
 
 const FeatureTitle: React.FunctionComponent<IProps> = ({ id, feature }) => {
   return (
-    <div className="anchored-link cucumberFeature__title">
+    <div className="anchored-link cucumber-title">
       <a href={'#' + id}>
         <FontAwesomeIcon icon={faLink} className="attachment-icon" />
       </a>
       <h1 id={id}>
-        <Keyword>{feature.keyword}:</Keyword>{' '}
-        <span className="step-text">
-          <HighLight text={feature.name} />
-        </span>
+        <Keyword className="cucumber-title__keyword">
+          {feature.keyword}:
+        </Keyword>{' '}
+        <HighLight className="cucumber-title__text" text={feature.name} />
       </h1>
     </div>
   )

--- a/react/javascript/src/components/gherkin/FeatureTitle.tsx
+++ b/react/javascript/src/components/gherkin/FeatureTitle.tsx
@@ -13,7 +13,7 @@ interface IProps {
 
 const FeatureTitle: React.FunctionComponent<IProps> = ({ id, feature }) => {
   return (
-    <div className="anchored-link">
+    <div className="anchored-link cucumberFeature__title">
       <a href={'#' + id}>
         <FontAwesomeIcon icon={faLink} className="attachment-icon" />
       </a>

--- a/react/javascript/src/components/gherkin/HookList.tsx
+++ b/react/javascript/src/components/gherkin/HookList.tsx
@@ -8,7 +8,7 @@ interface IProps {
 
 const HookList: React.FunctionComponent<IProps> = ({ hookSteps }) => {
   return (
-    <ol>
+    <ol className="cucumber-steps">
       {hookSteps.map((step, index) => (
         <HookStep key={index} step={step} />
       ))}

--- a/react/javascript/src/components/gherkin/Keyword.tsx
+++ b/react/javascript/src/components/gherkin/Keyword.tsx
@@ -2,10 +2,14 @@ import React from 'react'
 
 interface IProps {
   children: any
+  className?: string
 }
 
-const Keyword: React.FunctionComponent<IProps> = ({ children }) => {
-  return <span className="keyword">{children}</span>
+const Keyword: React.FunctionComponent<IProps> = ({
+  children,
+  className = '',
+}) => {
+  return <span className={className}>{children}</span>
 }
 
 export default Keyword

--- a/react/javascript/src/components/gherkin/Rule.tsx
+++ b/react/javascript/src/components/gherkin/Rule.tsx
@@ -17,7 +17,7 @@ const Rule: React.FunctionComponent<IProps> = ({ rule }) => {
   const idGenerated = generator.generate(rule.name)
 
   return (
-    <section>
+    <section className="cucumber-rule">
       <RuleTitle id={idGenerated} rule={rule} />
       <div className="indent">
         <Description description={rule.description} />

--- a/react/javascript/src/components/gherkin/Rule.tsx
+++ b/react/javascript/src/components/gherkin/Rule.tsx
@@ -19,7 +19,7 @@ const Rule: React.FunctionComponent<IProps> = ({ rule }) => {
   return (
     <section className="cucumber-rule">
       <RuleTitle id={idGenerated} rule={rule} />
-      <div className="indent">
+      <div className="cucumber-children">
         <Description description={rule.description} />
         {(rule.children || []).map((child, index) => {
           if (child.background) {

--- a/react/javascript/src/components/gherkin/RuleTitle.tsx
+++ b/react/javascript/src/components/gherkin/RuleTitle.tsx
@@ -13,15 +13,13 @@ interface IProps {
 
 const RuleTitle: React.FunctionComponent<IProps> = ({ id, rule }) => {
   return (
-    <div className="anchored-link">
+    <div className="anchored-link cucumber-title">
       <a href={'#' + id}>
         <FontAwesomeIcon icon={faLink} className="attachment-icon" />
       </a>
       <h2 id={id}>
-        <Keyword>{rule.keyword}:</Keyword>{' '}
-        <span className="step-text">
-          <HighLight text={rule.name} />
-        </span>
+        <Keyword className="cucumber-title__keyword">{rule.keyword}:</Keyword>{' '}
+        <HighLight className="cucumber-title__text" text={rule.name} />
       </h2>
     </div>
   )

--- a/react/javascript/src/components/gherkin/RuleTitle.tsx
+++ b/react/javascript/src/components/gherkin/RuleTitle.tsx
@@ -13,9 +13,9 @@ interface IProps {
 
 const RuleTitle: React.FunctionComponent<IProps> = ({ id, rule }) => {
   return (
-    <div className="anchored-link cucumber-title">
-      <a href={'#' + id}>
-        <FontAwesomeIcon icon={faLink} className="attachment-icon" />
+    <div className="cucumber-anchor cucumber-title">
+      <a href={'#' + id} className="cucumber-anchor__link">
+        <FontAwesomeIcon icon={faLink} className="cucumber-anchor__icon" />
       </a>
       <h2 id={id}>
         <Keyword className="cucumber-title__keyword">{rule.keyword}:</Keyword>{' '}

--- a/react/javascript/src/components/gherkin/Scenario.tsx
+++ b/react/javascript/src/components/gherkin/Scenario.tsx
@@ -30,24 +30,22 @@ const Scenario: React.FunctionComponent<IProps> = ({ scenario }) => {
   const afterHooks = cucumberQuery.getAfterHookSteps(pickleIds[0])
 
   return (
-    <div className="indent">
-      <section>
-        <Tags tags={scenario.tags} />
-        <ScenarioTitle id={idGenerated} scenario={scenario} />
-        <Description description={scenario.description} />
-        <HookList hookSteps={beforeHooks} />
-        <StepList
-          steps={scenario.steps || []}
-          renderStepMatchArguments={!hasExamples}
-          renderMessage={!hasExamples}
-        />
-        <HookList hookSteps={afterHooks} />
+    <section className="cucumber-scenario">
+      <Tags tags={scenario.tags} />
+      <ScenarioTitle id={idGenerated} scenario={scenario} />
+      <Description description={scenario.description} />
+      <HookList hookSteps={beforeHooks} />
+      <StepList
+        steps={scenario.steps || []}
+        renderStepMatchArguments={!hasExamples}
+        renderMessage={!hasExamples}
+      />
+      <HookList hookSteps={afterHooks} />
 
-        {examplesList.map((examples, index) => (
-          <Examples key={index} examples={examples} />
-        ))}
-      </section>
-    </div>
+      {examplesList.map((examples, index) => (
+        <Examples key={index} examples={examples} />
+      ))}
+    </section>
   )
 }
 

--- a/react/javascript/src/components/gherkin/ScenarioTitle.tsx
+++ b/react/javascript/src/components/gherkin/ScenarioTitle.tsx
@@ -13,15 +13,15 @@ interface IProps {
 
 const ScenarioTitle: React.FunctionComponent<IProps> = ({ id, scenario }) => {
   return (
-    <div className="anchored-link">
+    <div className="anchored-link cucumber-title">
       <a href={'#' + id}>
         <FontAwesomeIcon icon={faLink} className="attachment-icon" />
       </a>
       <h2 id={id}>
-        <Keyword>{scenario.keyword}:</Keyword>{' '}
-        <span className="step-text">
-          <HighLight text={scenario.name} />
-        </span>
+        <Keyword className="cucumber-title__keyword">
+          {scenario.keyword}:
+        </Keyword>{' '}
+        <HighLight className="cucumber-title__text" text={scenario.name} />
       </h2>
     </div>
   )

--- a/react/javascript/src/components/gherkin/ScenarioTitle.tsx
+++ b/react/javascript/src/components/gherkin/ScenarioTitle.tsx
@@ -13,9 +13,9 @@ interface IProps {
 
 const ScenarioTitle: React.FunctionComponent<IProps> = ({ id, scenario }) => {
   return (
-    <div className="anchored-link cucumber-title">
-      <a href={'#' + id}>
-        <FontAwesomeIcon icon={faLink} className="attachment-icon" />
+    <div className="cucumber-anchor cucumber-title">
+      <a href={'#' + id} className="cucumber-anchor__link">
+        <FontAwesomeIcon icon={faLink} className="cucumber-anchor__icon" />
       </a>
       <h2 id={id}>
         <Keyword className="cucumber-title__keyword">

--- a/react/javascript/src/components/gherkin/StatusIcon.tsx
+++ b/react/javascript/src/components/gherkin/StatusIcon.tsx
@@ -22,7 +22,7 @@ const StatusIcon: React.FunctionComponent<IProps> = ({ status }) => {
     <FontAwesomeIcon
       icon={statusIcon(status)}
       size="1x"
-      className={`status-${statusName(status)}`}
+      className={`cucumber-status--${statusName(status)}`}
     />
   )
 }

--- a/react/javascript/src/components/gherkin/Step.tsx
+++ b/react/javascript/src/components/gherkin/Step.tsx
@@ -53,7 +53,7 @@ const Step: React.FunctionComponent<IProps> = ({
         plain = step.text.slice(offset, argument.group.start)
         if (plain.length > 0) {
           stepTextElements.push(
-            <span className="step-text" key={`plain-${index}`}>
+            <span className="cucumber-step__text" key={`plain-${index}`}>
               <HighLight text={plain} />
             </span>
           )
@@ -62,7 +62,7 @@ const Step: React.FunctionComponent<IProps> = ({
         if (arg.length > 0) {
           stepTextElements.push(
             <a
-              className="step-param"
+              className="cucumber-step__param"
               key={`bold-${index}`}
               title={argument.parameterTypeName}
             >
@@ -75,7 +75,7 @@ const Step: React.FunctionComponent<IProps> = ({
       plain = step.text.slice(offset)
       if (plain.length > 0) {
         stepTextElements.push(
-          <span className="step-text" key={`plain-rest`}>
+          <span className="cucumber-step__text" key={`plain-rest`}>
             <HighLight text={plain} />
           </span>
         )
@@ -83,14 +83,14 @@ const Step: React.FunctionComponent<IProps> = ({
     } else if (stepMatchArgumentsLists.length >= 2) {
       // Step is ambiguous
       stepTextElements.push(
-        <span className="step-text" key={`plain-ambiguous`}>
+        <span className="cucumber-step__text" key={`plain-ambiguous`}>
           <HighLight text={step.text} />
         </span>
       )
     } else {
       // Step is undefined
       stepTextElements.push(
-        <span className="step-text" key={`plain-undefined`}>
+        <span className="cucumber-step__text" key={`plain-undefined`}>
           <HighLight text={step.text} />
         </span>
       )
@@ -98,17 +98,17 @@ const Step: React.FunctionComponent<IProps> = ({
   } else {
     // Step is from scenario with examples, and has <> placeholders.
     stepTextElements.push(
-      <span className="step-text" key={`plain-placeholders`}>
+      <span className="cucumber-step__text" key={`plain-placeholders`}>
         <HighLight text={step.text} />
       </span>
     )
   }
 
   return (
-    <li className="step">
+    <li className="cucumber-step">
       <StepContainer status={testStepResult.status}>
         <h3>
-          <Keyword>{step.keyword}</Keyword>
+          <Keyword className="cucumber-step__keyword">{step.keyword}</Keyword>
           {stepTextElements}
         </h3>
         {step.dataTable && <DataTable dataTable={step.dataTable} />}
@@ -116,9 +116,11 @@ const Step: React.FunctionComponent<IProps> = ({
         {renderMessage && testStepResult.message && (
           <ErrorMessage message={testStepResult.message} />
         )}
-        {attachments.map((attachment, i) => (
-          <Attachment key={i} attachment={attachment} />
-        ))}
+        <div className="cucumber-attachments">
+          {attachments.map((attachment, i) => (
+            <Attachment key={i} attachment={attachment} />
+          ))}
+        </div>
       </StepContainer>
     </li>
   )

--- a/react/javascript/src/components/gherkin/Step.tsx
+++ b/react/javascript/src/components/gherkin/Step.tsx
@@ -9,7 +9,6 @@ import ErrorMessage from './ErrorMessage'
 import StepContainer from './StepContainer'
 import Attachment from './Attachment'
 import HighLight from '../app/HighLight'
-import StatusIcon from './StatusIcon'
 
 interface IProps {
   step: messages.GherkinDocument.Feature.IStep

--- a/react/javascript/src/components/gherkin/Step.tsx
+++ b/react/javascript/src/components/gherkin/Step.tsx
@@ -9,6 +9,7 @@ import ErrorMessage from './ErrorMessage'
 import StepContainer from './StepContainer'
 import Attachment from './Attachment'
 import HighLight from '../app/HighLight'
+import StatusIcon from './StatusIcon'
 
 interface IProps {
   step: messages.GherkinDocument.Feature.IStep
@@ -105,24 +106,22 @@ const Step: React.FunctionComponent<IProps> = ({
   }
 
   return (
-    <li className="cucumber-step">
-      <StepContainer status={testStepResult.status}>
-        <h3>
-          <Keyword className="cucumber-step__keyword">{step.keyword}</Keyword>
-          {stepTextElements}
-        </h3>
-        {step.dataTable && <DataTable dataTable={step.dataTable} />}
-        {step.docString && <DocString docString={step.docString} />}
-        {renderMessage && testStepResult.message && (
-          <ErrorMessage message={testStepResult.message} />
-        )}
-        <div className="cucumber-attachments">
-          {attachments.map((attachment, i) => (
-            <Attachment key={i} attachment={attachment} />
-          ))}
-        </div>
-      </StepContainer>
-    </li>
+    <StepContainer status={testStepResult.status}>
+      <h3 className="cucumber-step__title">
+        <Keyword className="cucumber-step__keyword">{step.keyword}</Keyword>
+        {stepTextElements}
+      </h3>
+      {step.dataTable && <DataTable dataTable={step.dataTable} />}
+      {step.docString && <DocString docString={step.docString} />}
+      {renderMessage && testStepResult.message && (
+        <ErrorMessage message={testStepResult.message} />
+      )}
+      <div className="cucumber-attachments">
+        {attachments.map((attachment, i) => (
+          <Attachment key={i} attachment={attachment} />
+        ))}
+      </div>
+    </StepContainer>
   )
 }
 

--- a/react/javascript/src/components/gherkin/StepContainer.tsx
+++ b/react/javascript/src/components/gherkin/StepContainer.tsx
@@ -13,12 +13,12 @@ const StepContainer: React.FunctionComponent<IProps> = ({
 }) => {
   // @ts-ignore
   return (
-    <div className="step-container">
-      <span className="text_status_icon_container">
+    <li className="cucumber-step">
+      <span className="cucumber-step__status">
         <StatusIcon status={status} />
       </span>
-      <div className="step-container__step">{children}</div>
-    </div>
+      <div className="cucumber-step__content">{children}</div>
+    </li>
   )
 }
 

--- a/react/javascript/src/components/gherkin/StepList.tsx
+++ b/react/javascript/src/components/gherkin/StepList.tsx
@@ -14,7 +14,7 @@ const StepList: React.FunctionComponent<IProps> = ({
   renderMessage,
 }) => {
   return (
-    <ol>
+    <ol className="cucumber-steps">
       {steps.map((step, index) => (
         <Step
           key={index}

--- a/react/javascript/src/components/gherkin/TableBody.tsx
+++ b/react/javascript/src/components/gherkin/TableBody.tsx
@@ -14,6 +14,7 @@ const TableBody: React.FunctionComponent<IProps> = ({ rows }) => {
         <tr key={i}>
           {(row.cells || []).map((cell, j) => (
             <td
+              className="cucumber-table__cell"
               key={j}
               style={{ textAlign: isNumber(cell.value) ? 'right' : 'left' }}
             >

--- a/react/javascript/src/components/gherkin/Tags.tsx
+++ b/react/javascript/src/components/gherkin/Tags.tsx
@@ -12,9 +12,9 @@ const Tags: React.FunctionComponent<IProps> = ({ tags }) => {
     return null
   }
   return (
-    <ul className="tag-list">
+    <ul className="cucumber-tags">
       {tags.map((tag, index) => (
-        <li className="tag" key={index}>
+        <li className="cucumber-tag" key={index}>
           <HighLight text={tag.name} />
         </li>
       ))}

--- a/react/javascript/src/styles/styles.scss
+++ b/react/javascript/src/styles/styles.scss
@@ -112,6 +112,11 @@ $statusColors:
       &__text {
         font-weight: normal;
       }
+
+      &__param {
+        font-weight: normal;
+        font-style: italic;
+      }
     }
   }
 

--- a/react/javascript/src/styles/styles.scss
+++ b/react/javascript/src/styles/styles.scss
@@ -144,6 +144,11 @@ $statusColors:
     }
   }
 
+  .cucumber-code {
+    padding: 0.25em;
+    background-color: rgb(235, 235, 235);
+  }
+
   .cucumber-error {
     padding: 0.5em;
     margin: 0;

--- a/react/javascript/src/styles/styles.scss
+++ b/react/javascript/src/styles/styles.scss
@@ -20,41 +20,112 @@ $statusColors:
 }
 
 .cucumber-react {
-  h1, h2, h3 {
-    padding: 0;
-    margin-top: 0.3em;
-    margin-bottom: 0;
-    display: inline-block;
-  }
-
-  a { color: inherit; }
-
-  ol {
-    list-style-type: none;
-    padding-left: 10px;
-  }
-
-  section {
-    margin-bottom: 1em;
-  }
-
   @each $name, $color in $statusColors {
-    .status-#{$name} {
+    .cucumber-status--#{$name} {
       color: $color
     }
   }
 
-  .data-table {
+  // Reset browser defaults.
+  h1, h2, h3 {
+    padding: 0;
+    margin: 0;
+  }
+  a { color: inherit; }
+
+
+  .gherkin-document-list {
+    font: 14px 'Open Sans', sans-serif;
+    color: #161C24;
+    background: #fff;
+    overflow-x: hidden;
+  }
+
+  .cucumber-title {
+    margin-top: 0.3em;
+    margin-bottom: 0;
+    display: inline-block;
+
+    &__keyword {
+      font-weight: bold;
+    }
+
+    &__text {
+      font-weight: normal;
+    }
+  }
+
+
+  .cucumber-tags {
+    padding: 0;
+    margin-bottom: 0;
+
+    .cucumber-tag {
+      display: inline;
+      list-style-type: none;
+      padding: 4px 8px 4px 8px;
+      margin-right: 6px;
+      background-color: #FFFFFF;
+      border-radius: 6px;
+    }
+  }
+
+  .cucumber-feature__icon {
+    padding-top: 0.35em;
+    padding-right: 0.5em;
+  }
+
+  // Indentation inside feature and rules
+  .cucumber-description,
+  .cucumber-children {
+    margin-left: 1em;
+  }
+
+  // Spacing between elements
+  .cucumber-feature,
+  .cucumber-rule,
+  .cucumber-scenario,
+  .cucumber-background {
+    margin-bottom: 1em;
+  }
+
+  .cucumber-steps {
+    list-style-type: none;
+    padding-left: 10px;
+
+    & .cucumber-step {
+      display: flex;
+
+      &__status {
+        padding-top: 0.35em;
+        padding-right: 0.5em;
+      }
+
+      &__content {
+        flex-grow: 1;
+      }
+
+      &__keyword {
+        font-weight: bold;
+      }
+
+      &__text {
+        font-weight: normal;
+      }
+    }
+  }
+
+  .cucumber-table {
     border-collapse: collapse;
     margin-top: .5em;
     margin-bottom: .5em;
 
-    th {
+    &__header-cell {
       @include border-table-cell;
       @include padding-table-cell;
     }
 
-    td {
+    &__cell {
       @include border-table-cell;
       @include padding-table-cell;
 
@@ -68,153 +139,61 @@ $statusColors:
     }
   }
 
-  .examples-table {
-    border-collapse: collapse;
-    margin-top: .5em;
-    margin-bottom: .5em;
-
-    th {
-      @include padding-table-cell;
-    }
-
-    th + th {
-      @include border-table-cell;
-    }
-
-    td {
-      @include padding-table-cell;
-    }
-
-    td + td {
-      @include border-table-cell;
-
-      &__status {
-          padding: 0.5em 3px 3px 3px;
-      }
-
-      &__step {
-        flex-grow: 1;
-      }
-    }
-  }
-
-  .gherkin-document-list {
-    font: 14px 'Open Sans', sans-serif;
-    color: #161C24;
-    background: #fff;
-    overflow-x: hidden;
-  }
-
-  .indent {
-    margin-left: 1em;
-  }
-
-  .keyword {
-    font-weight: bold;
-  }
-
-  .step {
-    padding: 0.1em;
-
-    &-text {
-      font-weight: normal;
-    }
-
-    &-param {
-      font-weight: normal;
-    }
-  }
-
-  .step-container {
-    display: flex;
-
-    &__step {
-      flex-grow: 1;
-    }
-  }
-
-  .text_status_icon_container {
-    padding-top: 0.35em;
-    padding-right: 0.5em;
-  }
-
-  .error-message {
+  .cucumber-error {
     padding: 0.5em;
     margin: 0;
     overflow: scroll;
   }
 
-  .tag-list {
-    padding: 0;
-    margin-bottom: 0;
-  }
-
-  .tag {
-    display: inline;
-    list-style-type: none;
-    padding: 4px 8px 4px 8px;
-    margin-right: 6px;
-    background-color: #FFFFFF;
-    border-radius: 6px;
-  }
-
-  p.cucumber-no-results {
+  .cucumber-no-documents {
     font: 14px 'Open Sans', sans-serif;
   }
-}
 
-.anchored-link {
-  position: relative;
-  display: flex;
-  align-items: center;
-  margin-top: 0.3em;
-
-  a {
-    opacity: 0;
-    transition: all 0.35s ease-in-out;
-    position: absolute;
-    left: -20px;
-
-    display: flex;
-    align-items: center;
-  }
-
-  &:hover {
-    a {
-      opacity: 1;
-      width: max-content;
-      transition: all 0.35s ease-in-out;
-    }
-  }
-
-  & > * {
-    height: 100%;
-    margin-top: 0px;
-  }
-
-  h1, h2, h3 {
-    margin-top: 0px
-  }
-
-  .attachment {
+  .cucumber-attachment {
     background-color: rgb(235, 235, 235);
     padding: 0.5em;
 
-    .attachment-icon {
+    &__icon {
       margin-right: 0.5em;
+    }
+
+    &__image {
+      margin-top: 1em;
     }
   }
 
-  .attachment-image {
-    margin-top: 1em;
-  }
+  .cucumber-anchor {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-top: 0.3em;
 
-  .highlight mark {
-    background-color: yellow
-  }
+    &__link {
+      opacity: 0;
+      transition: all 0.35s ease-in-out;
+      position: absolute;
+      left: -20px;
 
-  .cucumberFeature {
-    padding-left: 10px;
+      display: flex;
+      align-items: center;
+    }
+
+    &__icon {
+      margin-right: 0.5em;
+    }
+
+    &:hover {
+      a {
+        opacity: 1;
+        width: max-content;
+        transition: all 0.35s ease-in-out;
+      }
+    }
+
+    & > * {
+      height: 100%;
+      margin-top: 0px;
+    }
   }
 }
 

--- a/react/javascript/src/styles/styles.scss
+++ b/react/javascript/src/styles/styles.scss
@@ -97,7 +97,7 @@ $statusColors:
       display: flex;
 
       &__status {
-        padding-top: 0.35em;
+        padding-top: 0.2em;
         padding-right: 0.5em;
       }
 

--- a/react/javascript/stories/index.stories.tsx
+++ b/react/javascript/stories/index.stories.tsx
@@ -59,15 +59,17 @@ function props(ndjson: string): { gherkinQuery: GherkinQuery, cucumberQuery: Cuc
 storiesOf('Features', module)
   .add('Step Container', () => {
     return <QueriesWrapper {...props(documentList)}>
-      <StepContainer status={messages.TestStepFinished.TestStepResult.Status.PASSED}>
-        <div>Given a passed step</div>
-      </StepContainer>
-      <StepContainer status={messages.TestStepFinished.TestStepResult.Status.FAILED}>
-        <div>When a failed step</div>
-      </StepContainer>
-      <StepContainer status={messages.TestStepFinished.TestStepResult.Status.SKIPPED}>
-        <div>Then a skipped step</div>
-      </StepContainer>
+      <div className="cucumber-steps">
+        <StepContainer status={messages.TestStepFinished.TestStepResult.Status.PASSED}>
+          <div>Given a passed step</div>
+        </StepContainer>
+        <StepContainer status={messages.TestStepFinished.TestStepResult.Status.FAILED}>
+          <div>When a failed step</div>
+        </StepContainer>
+        <StepContainer status={messages.TestStepFinished.TestStepResult.Status.SKIPPED}>
+          <div>Then a skipped step</div>
+        </StepContainer>
+      </div>
     </QueriesWrapper>
   })
   .add('Search bar', () => {

--- a/react/javascript/test/StepTest.tsx
+++ b/react/javascript/test/StepTest.tsx
@@ -72,13 +72,13 @@ describe('<Step>', () => {
 
     const plainTexts = Array.from(
       document.querySelectorAll(
-        '#content h3 span.step-text, #content h3 span.keyword'
+        '#content h3 .cucumber-step__text, #content h3 .cucumber-step__keyword'
       )
     ).map((span) => span.textContent)
     assert.deepStrictEqual(plainTexts, ['Given', 'the ', ' pixies'])
 
     const paramTexts = Array.from(
-      document.querySelectorAll('#content h3 a')
+      document.querySelectorAll('#content h3 .cucumber-step__param')
     ).map((a) => a.textContent)
     assert.deepStrictEqual(paramTexts, ['48'])
   })


### PR DESCRIPTION
## Summary

Integrating and styling `cucumber-react` in another app can prove a bit painful with some missing classes.

The idea is to define semantic CSS classes to ease integration. This PR will mainly focus on the `GherkinDocument` AST rendering.

## Details

The `CSS_map.md` file explains the CSS classes applied in this PR. As it can be seen in the CSS file, there no more need to specify any HTML tag for the styling.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

