### PR TITLE
Remove letter case variations from Gherkin

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -19,6 +19,13 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+* Remove keyword aliases that only differ by letter case (French, Creole).
+  The reason for this is that Cucumber-JVM generates annotation classes for each
+  step keyword, and some file systems are case insensitive. This led to inconsistencies
+  in the classes that were generated during the build. Removing these keywords fixes
+  this problem. Theoretically this should trigger a new major release, but because the
+  change is so minor and will affect very few users we've made this a patch release.
+
 ## [15.0.0] - 2020-08-07
 
 ### Changed

--- a/gherkin/c/gherkin-languages.json
+++ b/gherkin/c/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/dotnet/Gherkin/gherkin-languages.json
+++ b/gherkin/dotnet/Gherkin/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/gherkin-languages.json
+++ b/gherkin/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/go/dialects_builtin.go
+++ b/gherkin/go/dialects_builtin.go
@@ -1274,7 +1274,6 @@ var buildinDialects = gherkinDialectMap{
 				"Scénario",
 			},
 			scenarioOutline: []string{
-				"Plan du scénario",
 				"Plan du Scénario",
 			},
 			examples: []string{
@@ -1629,11 +1628,8 @@ var buildinDialects = gherkinDialectMap{
 				"Senaryo",
 			},
 			scenarioOutline: []string{
-				"Plan senaryo",
 				"Plan Senaryo",
-				"Senaryo deskripsyon",
 				"Senaryo Deskripsyon",
-				"Dyagram senaryo",
 				"Dyagram Senaryo",
 			},
 			examples: []string{
@@ -1642,7 +1638,6 @@ var buildinDialects = gherkinDialectMap{
 			given: []string{
 				"* ",
 				"Sipoze ",
-				"Sipoze ke ",
 				"Sipoze Ke ",
 			},
 			when: []string{

--- a/gherkin/go/gherkin-languages.json
+++ b/gherkin/go/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/go/go.mod
+++ b/gherkin/go/go.mod
@@ -1,6 +1,7 @@
 module github.com/cucumber/gherkin-go/v15
 
 require (
+	github.com/aslakhellesoy/gox v1.0.100 // indirect
 	github.com/cucumber/messages-go/v13 v13.0.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/stretchr/testify v1.6.1

--- a/gherkin/go/go.sum
+++ b/gherkin/go/go.sum
@@ -1,3 +1,5 @@
+github.com/aslakhellesoy/gox v1.0.100 h1:IP+x+v9Wya7OHP1OmaetTFZkL4OYY2/9t+7Ndc61mMo=
+github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -6,12 +8,16 @@ github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
+github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/gherkin/java/src/main/resources/io/cucumber/gherkin/gherkin-languages.json
+++ b/gherkin/java/src/main/resources/io/cucumber/gherkin/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/javascript/src/gherkin-languages.json
+++ b/gherkin/javascript/src/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/objective-c/GherkinLanguages/gherkin-languages.json
+++ b/gherkin/objective-c/GherkinLanguages/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/perl/gherkin-languages.json
+++ b/gherkin/perl/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/python/gherkin/gherkin-languages.json
+++ b/gherkin/python/gherkin/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [

--- a/gherkin/ruby/lib/gherkin/gherkin-languages.json
+++ b/gherkin/ruby/lib/gherkin/gherkin-languages.json
@@ -1288,7 +1288,6 @@
       "Scénario"
     ],
     "scenarioOutline": [
-      "Plan du scénario",
       "Plan du Scénario"
     ],
     "then": [
@@ -1616,7 +1615,6 @@
     "given": [
       "* ",
       "Sipoze ",
-      "Sipoze ke ",
       "Sipoze Ke "
     ],
     "name": "Creole",
@@ -1628,11 +1626,8 @@
       "Senaryo"
     ],
     "scenarioOutline": [
-      "Plan senaryo",
       "Plan Senaryo",
-      "Senaryo deskripsyon",
       "Senaryo Deskripsyon",
-      "Dyagram senaryo",
       "Dyagram Senaryo"
     ],
     "then": [


### PR DESCRIPTION
Remove letter case variations of Gherkin keywords since their presence causes different annotation classes to be generated during the build of Cucumber-JVM (depending on what OS it was built on).

I discovered this when I was checking semantic versioning of Cucumber-JVM, building on MacOS.

```
CHECK_SEMANTIC_VERSION=true mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true

...

[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.12.1:check (check) on project cucumber-java: The following API problems caused the build to fail:
[ERROR] java.class.removed: @interface io.cucumber.java.ht.SipozeKe: Class was removed. (breaks semantic versioning)
```

This is related to https://github.com/cucumber/cucumber-jvm/pull/2085