### PR TITLE
Remove credentials in meta message

### DIFF
--- a/create-meta/ruby/lib/cucumber/create_meta.rb
+++ b/create-meta/ruby/lib/cucumber/create_meta.rb
@@ -44,7 +44,7 @@ module Cucumber
         url: url,
         name: ci_name,
         git: Cucumber::Messages::Meta::CI::Git.new(
-          remote: evaluate(ci_system['git']['remote'], env),
+          remote: clean_sensitive_information(evaluate(ci_system['git']['remote'], env)),
           revision: evaluate(ci_system['git']['revision'], env),
           branch: evaluate(ci_system['git']['branch'], env),
           tag: evaluate(ci_system['git']['tag'], env),

--- a/create-meta/ruby/lib/cucumber/create_meta.rb
+++ b/create-meta/ruby/lib/cucumber/create_meta.rb
@@ -80,6 +80,13 @@ module Cucumber
       m[1]
     end
 
-    module_function :create_meta, :detect_ci, :create_ci, :group1, :evaluate
+    def clean_sensitive_information(value)
+      url_data = value.match(/^(.*?):\/\/(.*?@)?(.*)$/)
+      return "#{url_data[1]}://#{url_data[3]}" if url_data
+
+      value
+    end
+
+    module_function :create_meta, :detect_ci, :create_ci, :group1, :evaluate, :clean_sensitive_information
   end
 end

--- a/create-meta/ruby/spec/cucumber/clean_sensitive_info_spec.rb
+++ b/create-meta/ruby/spec/cucumber/clean_sensitive_info_spec.rb
@@ -1,0 +1,21 @@
+require 'cucumber/create_meta'
+
+describe 'clean_sensitive_information' do
+  it 'leaves the data intact when no sensitive information is detected' do
+    expect(Cucumber::CreateMeta.clean_sensitive_information('pretty safe')).to eq('pretty safe')
+  end
+
+  context 'with URLs' do
+    it 'leaves intact when no password is found' do
+      expect(Cucumber::CreateMeta.clean_sensitive_information('https://example.com/git/repo.git')).to eq('https://example.com/git/repo.git')
+    end
+
+    it 'removes credentials when found' do
+      expect(Cucumber::CreateMeta.clean_sensitive_information('http://login@example.com/git/repo.git')).to eq('http://example.com/git/repo.git')
+    end
+
+    it 'removes credentials and passwords when found' do
+      expect(Cucumber::CreateMeta.clean_sensitive_information('ssh://login:password@example.com/git/repo.git')).to eq('ssh://example.com/git/repo.git')
+    end
+  end
+end

--- a/create-meta/testdata/GitlabCI.txt
+++ b/create-meta/testdata/GitlabCI.txt
@@ -1,0 +1,4 @@
+CI_JOB_URL=https://gitlab.com/cucumber/cucumber/jobs/713869896
+CI_REPOSITORY_URL=https://cukebot:thisIsAVerySensitiveInformation@gitlab.com/cucumber/cucumber.git
+CI_COMMIT_SHA=123456789
+CI_COMMIT_BRANCH=main

--- a/create-meta/testdata/GitlabCI.txt.json
+++ b/create-meta/testdata/GitlabCI.txt.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "remote": "https://gitlab.com/cucumber/cucumber.git",
+    "revision": "123456789",
+    "branch": "main"
+  },
+  "name": "GitLab",
+  "url": "https://gitlab.com/cucumber/cucumber/jobs/713869896"
+}


### PR DESCRIPTION
## Summary

Some CI (like GitLab) may use remote location using login/password (eg: `https://mylogin:mypassword@gitlab-ci.com/org/repo.git`).
The meta message will use it and, if used with [reports](https://reports.cucumber.io), will display it.

The idea is to remove the credentials part of the remote URL (in the previous example, https://gitlab-ci.com/org/repo.git`)

## Motivation and Context

Avoid sharing credentials.

## How Has This Been Tested?

Unit + Integration tests.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] The change has been ported to Java.
- [X] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [X] I've added tests for my code.
- [ ] I have updated the CHANGELOG accordingly.

