### PR TITLE
CVE publication after create-meta 2.0.2 release

### DIFF
--- a/create-meta/CVE-2.0.2.md
+++ b/create-meta/CVE-2.0.2.md
@@ -1,0 +1,38 @@
+### Vulnerability type:
+Other or unknown
+
+### Vendor of the product(s):
+SmartBear
+
+### Affected product(s)/code base:
+ - @cucumber/create-meta < 2.0.2
+ - cucumber/create-meta < 2.0.2
+ - cucumber-create-meta < 2.0.2
+
+### Has vendor confirmed or acknowledged the vulnerability?
+Yes
+
+### Attack type:
+remote
+
+### Impact:
+Information disclosure
+
+### Affected component(s):
+Git repository credentials
+
+### Attack vector(s):
+reading `Meta` message in a report
+
+### Suggested description of the vulnerability for use in the CVE:
+
+`create-meta` creates a `Meta` protobuf message which describes the execution context of a Cucumber run. It provides information about the system where the tests were executed and which Git repository are being tested.
+In some cases, the GIT remote contains credentials (eg: `https://login@password:example.com/git/my_repo.git`) and those credentials were included in the `Meta` message, making it public to anyone who could access the messages (for examples once they have been uploaded to reports.cucumber.io)
+
+### Discoverer(s)/Credits
+Aslak Hellesoy
+
+### References:
+
+### Additional information
+This has been fixed in version 2.0.2 of the `create-meta` library, any credentials in the GIT remote URL are removed.


### PR DESCRIPTION
## Summary

`create-meta` 2.0.2 was released in order to fix a security issue. The goal of this issue is to discuss what we'll post in the CVE.

I used the fields in the [CVE Web form](https://cveform.mitre.org) (selecting "Request a CVE ID" option)  to get a draft of the proposal. 