### PR TITLE
html-formatter: fix when installed locally to node project

### DIFF
--- a/html-formatter/CHANGELOG.md
+++ b/html-formatter/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-* [JavaScript] Fix CSS resolution when installed locally (#1180)
+* [JavaScript] Fix CSS resolution when installed locally [#1180](https://github.com/cucumber/cucumber/pull/1180)
 
 ## [9.0.0] - 2020-08-08
 

--- a/html-formatter/CHANGELOG.md
+++ b/html-formatter/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* [JavaScript] Fix CSS resolution when installed locally (#1180)
+
 ## [9.0.0] - 2020-08-08
 
 ### Changed

--- a/html-formatter/javascript/package.json
+++ b/html-formatter/javascript/package.json
@@ -28,6 +28,7 @@
     "commander": "^6.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "resolve-pkg": "^2.0.0",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/html-formatter/javascript/src/cli-main.ts
+++ b/html-formatter/javascript/src/cli-main.ts
@@ -5,6 +5,7 @@ import {
 } from '@cucumber/messages'
 import program from 'commander'
 import p from '../package.json'
+import resolvePkg from 'resolve-pkg'
 import { pipeline } from 'stream'
 import CucumberHtmlStream from './CucumberHtmlStream'
 
@@ -29,8 +30,8 @@ pipeline(
   process.stdin,
   toMessageStream,
   new CucumberHtmlStream(
-    __dirname +
-      '/../../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css',
+    resolvePkg('@cucumber/react', { cwd: __dirname }) +
+      '/dist/src/styles/cucumber-react.css',
     __dirname + '/../../dist/main.js'
   ),
   process.stdout,


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fixes the `@cucumber/html-formatter` CLI when the package is installed as a project dependency (rather than only working when installed globally).

## Details

Installing to a project like `npm i @cucumber/html-formatter` and then running in an npm script would currently yield an error like:

```
[Error: ENOENT: no such file or directory, open '/Users/davidgoss/Documents/Projects/html-formatter-test/node_modules/@cucumber/html-formatter/dist/src/../../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/davidgoss/Documents/Projects/html-formatter-test/node_modules/@cucumber/html-formatter/dist/src/../../node_modules/@cucumber/react/dist/src/styles/cucumber-react.css'
}
npm ERR! Test failed.  See above for more details.
```

This is due to the relative path to the cucumber react CSS file - this breaks when installed as a dependency, because our own dependencies are usually hoisted up to the `node_modules` of the host project.

This changes to use a reliable function to resolve the path to the `@cucumber/react` package so it works in global or local context.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

