### PR TITLE
Ignore empty lines when reading NDJSON

### DIFF
--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Ignore empty lines rather than throwing an error.
+
 ## [13.0.1] - 2020-08-07
 
 ### Fixed

--- a/messages/go/io/ndjson.go
+++ b/messages/go/io/ndjson.go
@@ -74,7 +74,11 @@ type ndjsonReader struct {
 
 func (this *ndjsonReader) ReadMsg(msg proto.Message) error {
 	if this.scanner.Scan() {
-		return this.unmarshaler.Unmarshal(strings.NewReader(this.scanner.Text()), msg)
+		line := this.scanner.Text()
+		if len(strings.TrimSpace(line)) == 0 {
+			return this.ReadMsg(msg)
+		}
+		return this.unmarshaler.Unmarshal(strings.NewReader(line), msg)
 	}
 	return io.EOF
 }

--- a/messages/go/messages_test.go
+++ b/messages/go/messages_test.go
@@ -87,11 +87,21 @@ func TestMessages(t *testing.T) {
 		require.Equal(t, s, decoded.GetBody())
 	})
 
-	t.Run("reads an attachment with a tiny string as NDJSON", func(t *testing.T) {
+	t.Run("ignores missing fields", func(t *testing.T) {
 		b := &bytes.Buffer{}
 		b.WriteString("{\"unused\": 99}\n")
 		r := messagesio.NewNdjsonReader(b)
 		var decoded Envelope
+		require.NoError(t, r.ReadMsg(&decoded))
+	})
+
+	t.Run("ignores empty lines", func(t *testing.T) {
+		b := &bytes.Buffer{}
+		b.WriteString("{}\n{}\n\n{}\n")
+		r := messagesio.NewNdjsonReader(b)
+		var decoded Envelope
+		require.NoError(t, r.ReadMsg(&decoded))
+		require.NoError(t, r.ReadMsg(&decoded))
 		require.NoError(t, r.ReadMsg(&decoded))
 	})
 }

--- a/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
+++ b/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
@@ -32,7 +32,10 @@ public class NdjsonToMessageIterable implements Iterable<Messages.Envelope> {
             public boolean hasNext() {
                 try {
                     String line = input.readLine();
-                    if(line == null) return false;
+                    if (line == null) return false;
+                    if (line.trim().equals("")) {
+                        return hasNext();
+                    }
                     Messages.Envelope.Builder builder = Messages.Envelope.newBuilder();
                     JSON_PARSER.merge(line, builder);
                     next = builder.build();

--- a/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
@@ -34,4 +34,16 @@ class NdjsonSerializationTest extends MessageSerializationContract {
         assertFalse(iterator.hasNext());
     }
 
+    @Test
+    void ignores_empty_lines() {
+        InputStream input = new ByteArrayInputStream("{}\n{}\n\n{}\n".getBytes(UTF_8));
+        Iterable<Messages.Envelope> incomingMessages = makeMessageIterable(input);
+        Iterator<Messages.Envelope> iterator = incomingMessages.iterator();
+        for(int i = 0; i < 3; i++) {
+            assertTrue(iterator.hasNext());
+            Messages.Envelope envelope = iterator.next();
+            assertEquals(Messages.Envelope.newBuilder().build(), envelope);
+        }
+        assertFalse(iterator.hasNext());
+    }
 }

--- a/messages/javascript/src/NdjsonToMessageStream.ts
+++ b/messages/javascript/src/NdjsonToMessageStream.ts
@@ -25,7 +25,9 @@ export default class NdjsonToMessageStream<T> extends Transform {
     const lines = this.buffer.split('\n')
     this.buffer = lines.pop()
     for (const line of lines) {
-      this.push(this.fromObject(JSON.parse(line)))
+      if (line.trim().length > 0) {
+        this.push(this.fromObject(JSON.parse(line)))
+      }
     }
     callback()
   }

--- a/messages/javascript/test/NdjsonStreamTest.ts
+++ b/messages/javascript/test/NdjsonStreamTest.ts
@@ -125,4 +125,18 @@ describe('NdjsonStream', () => {
 
     assert.deepStrictEqual(incomingMessages, [messages.Envelope.create({})])
   })
+
+  it('ignores empty lines', async () => {
+    const toMessageStream = makeToMessageStream()
+    toMessageStream.write('{}\n{}\n\n{}\n')
+    toMessageStream.end()
+
+    const incomingMessages = await toArray(toMessageStream)
+
+    assert.deepStrictEqual(incomingMessages, [
+      messages.Envelope.create({}),
+      messages.Envelope.create({}),
+      messages.Envelope.create({}),
+    ])
+  })
 })

--- a/messages/ruby/lib/cucumber/messages/ndjson_to_message_enumerator.rb
+++ b/messages/ruby/lib/cucumber/messages/ndjson_to_message_enumerator.rb
@@ -6,6 +6,7 @@ module Cucumber
       def initialize(io)
         super() do |yielder|
           io.each_line do |json|
+            next if json.strip.empty?
             m = Cucumber::Messages::Envelope.from_json(json)
             yielder.yield(m)
           end

--- a/messages/ruby/spec/cucumber/messages/ndjson_serialization_spec.rb
+++ b/messages/ruby/spec/cucumber/messages/ndjson_serialization_spec.rb
@@ -69,6 +69,22 @@ module Cucumber
         expect(incoming_messages.to_a).to(eq(outgoing_messages))
       end
 
+      it "ignores empty lines" do
+        outgoing_messages = [
+          Envelope.new(source: Source.new(data: 'Feature: Hello')),
+          Envelope.new(attachment: Attachment.new(binary: [1,2,3,4].pack('C*')))
+        ]
+
+        io = StringIO.new
+        write_outgoing_messages(outgoing_messages, io)
+        io.write("\n\n")
+
+        io.rewind
+        incoming_messages = NdjsonToMessageEnumerator.new(io)
+
+        expect(incoming_messages.to_a).to(eq(outgoing_messages))
+      end
+
       it "ignores missing fields" do
         io = StringIO.new
         io.puts('{"unused": 99}')


### PR DESCRIPTION
Sometimes an NDJSON stream can contain a newline at the end. This would cause the NDJSON readers to throw an error. With this change, empty lines are ignored (even if they are not at the end).