### PR TITLE
gherkin-c Fixes 1198 can't build with msvc

### DIFF
--- a/gherkin/c/.gitignore
+++ b/gherkin/c/.gitignore
@@ -5,3 +5,6 @@ acceptance/
 .built
 .compared
 .run
+.vs/
+out/
+build/

--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -67,7 +67,11 @@ LIST(APPEND GHERKIN_CLI
 
 
 add_library(gherkin ${GHERKIN_SRS})
-target_link_libraries(gherkin PRIVATE m)
+include(CheckLibraryExists)
+CHECK_LIBRARY_EXISTS(m log10 "" HAVE_LIB_M)   
+if (HAVE_LIB_M)  
+    target_link_libraries(gherkin PRIVATE m)
+endif (HAVE_LIB_M)
 target_include_directories(gherkin PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
 


### PR DESCRIPTION
check for m.lib link to if exists.  Assume not needed if doesn't exist.
Add out/ and build/ to .gitignore

## Summary

Issue 1198

## How Has This Been Tested?
tested build with:
- MSVC
- MSVC-Clang
- GCC Ubuntu 20.04
- Clang Ubuntu 20.04
- OSX Clang AppleClang 12.0.0.12000032

## Types of changes

Changed CMakeLists.txt

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [? ] I have updated the CHANGELOG accordingly.
-- Can do, need guidance if this applies.


