### PR TITLE
gherkin/c: Fixes Issue #1200 build fails when using ninja generator.

### DIFF
--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -135,11 +135,3 @@ install(
     EXPORT "${targets_export_name}"
     NAMESPACE "${namespace}"
     DESTINATION "${config_install_dir}")
-
-# I don't believe this target actually does anything, but keeping except for ninja just in case
-if(NOT ${CMAKE_GENERATOR} STREQUAL "Ninja")
-    add_custom_target(install_${PROJECT_NAME}
-            $(MAKE) install
-            DEPENDS gherkin
-            COMMENT "Installing ${PROJECT_NAME}")
-endif()

--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -130,7 +130,10 @@ install(
     NAMESPACE "${namespace}"
     DESTINATION "${config_install_dir}")
 
-add_custom_target(install_${PROJECT_NAME}
-        $(MAKE) install
-        DEPENDS gherkin
-        COMMENT "Installing ${PROJECT_NAME}")
+# I don't believe this target actually does anything, but keeping except for ninja just in case
+if(NOT ${CMAKE_GENERATOR} STREQUAL "Ninja")
+    add_custom_target(install_${PROJECT_NAME}
+            $(MAKE) install
+            DEPENDS gherkin
+            COMMENT "Installing ${PROJECT_NAME}")
+endif()


### PR DESCRIPTION
Remove dubious custom target in build system is ninja.

## Motivation and Context
Ninja is a cmake build system.  It can't be used on this project due to the syntax of the custom target.  I believe that this custom target is a defect, and can't be used at all, but just in case, I'm only excluding it for the ninja build system.

ninja is what is used by vcpkg, so although this library is included, it fails to build, because of this custom target.

fixes issue #1200 

## How Has This Been Tested?
built using the following scenarios:
- readme.md instructions
   - windows
   - ubuntu 20.04
- msvc ninja
   - msvc
   - msvc-clang
   - ubuntu 20.04 clang
   - ubuntu 20.04 gcc
<!--- Please describe in detail how you tested your changes. -->
for readme instructions:
mkdir build
cd build
cmake ..
cmake --install .

for msvc build:
open folder with msvc
generate build configuration using defaults for:
- x64-Debug
- x64-Clang-Debug
- WSL-Clang-Debug
- WSL-GCC-Debug
for each build configuration, generate cmake cache, and build.

Tests for testdata/good/i18n*.feature fail when built with MSVC.  These tests fail before this change, so no change in behavior.  I am not yet familiar enough with this library to make the changes needed to get these tests to pass.  I will create an issue to track it, and try to fix if able.

## Screenshots (if appropriate):

## Types of changes
Build system change to accomodate cmake ninja generator.

## Checklist:

- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.
   -Can do this if needed, but not a functionality change

