### PR TITLE
gherkin/c: change tests from post build step to tests.

### DIFF
--- a/gherkin/c/CMakeLists.txt
+++ b/gherkin/c/CMakeLists.txt
@@ -1,5 +1,7 @@
 PROJECT(gherkin C)
 cmake_minimum_required(VERSION 3.0)
+enable_testing()
+
 # Install library & headers in your directory
 #SET(CMAKE_INSTALL_PREFIX  "")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -87,13 +89,17 @@ file(GLOB BAD_FEATURE_FILES
 add_custom_target(invo DEPENDS invo)
 add_dependencies(invo gherkinexe)
 FOREACH(ENTITY ${GOOD_FEATURE_FILES})
-    add_custom_command(
-            TARGET gherkinexe
-            POST_BUILD
-            COMMAND gherkinexe  ${ENTITY}
-            DEPENDS invo
+    string(REPLACE "${PROJECT_SOURCE_DIR}" "" TEST_NAME "${ENTITY}")
+    add_test(NAME "${TEST_NAME}"
+        COMMAND gherkinexe  ${ENTITY}
     )
 ENDFOREACH()
+add_custom_command(
+    TARGET gherkinexe
+    COMMENT "Run tests"
+    POST_BUILD
+    COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION>
+)
 ############ Installation section ############
 set(include_install_dir "include")
 set(lib_install_dir "lib/")


### PR DESCRIPTION
run tests post build so build will fail if tests fail.

## Summary

Tests are implemented as a post build step.  Determining what failed is hard when used in this manner.  Tests should be added as ctest tests, which is the norm for cmake.

## Details

Moved tests into add_test
run all tests as a post build step.  **Build will still fail if tests fail**

Output on build if there is a failing tests is now
```
  37/37 Test #37: /testdata/good/very_long.feature ......................................   Passed    4.30 sec

  92% tests passed, 3 tests failed out of 37

  Total Test time (real) =   5.96 sec

  The following tests FAILED:
         11 - /testdata/good/i18n_emoji.feature (Failed)
         12 - /testdata/good/i18n_fr.feature (Failed)
         13 - /testdata/good/i18n_no.feature (Failed)
  Errors while running CTest
```


## Motivation and Context

Some tests fail on windows.  In the existing setup, you get a wall of text, many pages, and build failed.  After change build still fails, but much less text, and now text is useful.  Tells which test failed.

## How Has This Been Tested?

readme.md build instructions for windows 10 using msvc
- Windows currently has some failing tests.  This was existing behavior prior to patch, and out of scope for this PR.  I will make an issue to track these failures and try to fix.
```
  The following tests FAILED:
         11 - /testdata/good/i18n_emoji.feature (Failed)
         12 - /testdata/good/i18n_fr.feature (Failed)
         13 - /testdata/good/i18n_no.feature (Failed)
  Errors while running CTest
```

readme.md build instructions for ubuntu 20.04

## Screenshots (if appropriate):

## Types of changes
cmake generator changes, no functional changes.  Make life easier for new devs.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

