### PR TITLE
Add a "update dependencies" entry for PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,4 +47,5 @@
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have updated the CHANGELOG accordingly.
+- [ ] I have updated the dependencies for the packages (`cd <package>/<language> && make update-dependencies`)
 


### PR DESCRIPTION
## Summary

To ease dependencies updates, a new entry in the checklist for pull requests asks for people making PRs to also run the `update-dependencies` make target (see [this comment in another PR](https://github.com/cucumber/cucumber/pull/1179#issuecomment-696037583))

This should help for the releases process, as we will not have to do this manually for each released package.

I'm not 100% sure about the wording, so feel free to make this more user-friendly :)