### PR TITLE
Fix dependencies in go makefiles

### DIFF
--- a/.templates/go/default.mk
+++ b/.templates/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/cucumber-expressions/go/default.mk
+++ b/cucumber-expressions/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/demo-formatter/go/default.mk
+++ b/demo-formatter/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/gherkin/go/default.mk
+++ b/gherkin/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/json-formatter/go/default.mk
+++ b/json-formatter/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/messages/go/default.mk
+++ b/messages/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')

--- a/tag-expressions/go/default.mk
+++ b/tag-expressions/go/default.mk
@@ -25,7 +25,7 @@ EXE := dist/$(EXE_BASE_NAME)-$(OS)-$(ARCH)
 ifndef NO_CROSS_COMPILE
 EXES = $(patsubst %,dist/$(EXE_BASE_NAME)-%,$(PLATFORMS))
 else
-EXES = $(EXES)
+EXES = $(EXE)
 endif
 
 GO_REPLACEMENTS := $(shell sed -n "/^\s*github.com\/cucumber/p" go.mod | perl -wpe 's/\s*(github.com\/cucumber\/(.*)-go\/v\d+).*/q{replace } . $$1 . q{ => ..\/..\/} . $$2 . q{\/go}/eg')


### PR DESCRIPTION
This fixes the make dependency rules such that running `make` twice in a `go` directory does not build the executables on the 2nd run. This significantly shortens the build time for incremental builds.

This regression of make dependencies was introduced in #1171 