### PR TITLE
create-meta/java: handle null values in ci dict

### DIFF
--- a/create-meta/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
+++ b/create-meta/java/src/main/java/io/cucumber/createmeta/CreateMeta.java
@@ -2,6 +2,7 @@ package io.cucumber.createmeta;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
 import io.cucumber.messages.Messages;
 import io.cucumber.messages.ProtocolVersion;
 
@@ -81,13 +82,13 @@ public class CreateMeta {
     }
 
     private static Messages.Meta.CI createCi(String name, JsonObject ciSystem, Map<String, String> env) {
-        String url = evaluate(ciSystem.getString("url", null), env);
+        String url = evaluate(getString(ciSystem, "url"), env);
         if (url == null) return null;
         JsonObject git = ciSystem.get("git").asObject();
-        String remote = removeUserInfoFromUrl(evaluate(git.getString("remote", null), env));
-        String revision = evaluate(git.getString("revision", null), env);
-        String branch = evaluate(git.getString("branch", null), env);
-        String tag = evaluate(git.getString("tag", null), env);
+        String remote = removeUserInfoFromUrl(evaluate(getString(git, "remote"), env));
+        String revision = evaluate(getString(git, "revision"), env);
+        String branch = evaluate(getString(git, "branch"), env);
+        String tag = evaluate(getString(git, "tag"), env);
 
         Messages.Meta.CI.Builder ciBuilder = Messages.Meta.CI.newBuilder()
                 .setName(name)
@@ -143,5 +144,10 @@ public class CreateMeta {
             return g1;
         }
         return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static String getString(JsonObject json, String name) {
+        JsonValue val = json.get(name);
+        return val.isNull() ? null : val.asString();
     }
 }

--- a/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
+++ b/create-meta/java/src/test/java/io/cucumber/createmeta/CreateMetaTest.java
@@ -56,4 +56,21 @@ class CreateMetaTest {
                 meta.getCi());
     }
 
+    @Test
+    void can_handle_CIs_with_null_in_ciDict() {
+        // choose gocd as example, which has null everywhere except for url and revision
+        HashMap<String, String> env = new HashMap<String, String>() {{
+            put("GO_SERVER_URL", "https://<cihost>/buildurl");
+            put("GO_REVISION", "the-revision");
+        }};
+        Messages.Meta meta = CreateMeta.createMeta("cucumber-jvm", "3.2.1", env);
+        assertEquals(Messages.Meta.CI.newBuilder()
+                        .setName("GoCD")
+                        .setUrl("https://<cihost>/buildurl/???")
+                        .setGit(Messages.Meta.CI.Git.newBuilder()
+                                .setRevision("the-revision")
+                        )
+                        .build(),
+                meta.getCi());
+    }
 }

--- a/create-meta/testdata/CodeShip.txt
+++ b/create-meta/testdata/CodeShip.txt
@@ -1,0 +1,4 @@
+CF_BUILD_URL=https://cihost.com/path/to/the/build
+CF_COMMIT_URL=https://scmhost.com/path/to/the/project
+CF_BRANCH=main
+CF_REVISION=decafbad

--- a/create-meta/testdata/CodeShip.txt.json
+++ b/create-meta/testdata/CodeShip.txt.json
@@ -1,0 +1,9 @@
+{
+  "git": {
+    "branch": "main",
+    "remote": "https://scmhost.com/path/to/the/project",
+    "revision": "decafbad"
+  },
+  "name": "CodeShip",
+  "url": "https://cihost.com/path/to/the/build"
+}

--- a/create-meta/testdata/GoCD.txt
+++ b/create-meta/testdata/GoCD.txt
@@ -1,0 +1,2 @@
+GO_SERVER_URL=https://cihost.com/path/to/the/build
+GO_REVISION=decafbad

--- a/create-meta/testdata/GoCD.txt.json
+++ b/create-meta/testdata/GoCD.txt.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "revision": "decafbad"
+  },
+  "name": "GoCD",
+  "url": "https://cihost.com/path/to/the/build/???"
+}


### PR DESCRIPTION
This fixes #1228 by handling null explicitly.

I'm unsure, if it would be worth to add acceptance tests for all available CIs.