### PR TITLE
include offending line in error message

### DIFF
--- a/messages/CHANGELOG.md
+++ b/messages/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* In case a line cannot be parsed as JSON, throw an error
+  with the offending line in the exception message.
+
 ## [13.2.0] - 2020-11-12
 
 ### Added

--- a/messages/go/io/ndjson.go
+++ b/messages/go/io/ndjson.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bufio"
+	"errors"
 	gogoio "github.com/gogo/protobuf/io"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -74,11 +75,15 @@ type ndjsonReader struct {
 
 func (this *ndjsonReader) ReadMsg(msg proto.Message) error {
 	if this.scanner.Scan() {
-		line := this.scanner.Text()
-		if len(strings.TrimSpace(line)) == 0 {
+		line := strings.TrimSpace(this.scanner.Text())
+		if len(line) == 0 {
 			return this.ReadMsg(msg)
 		}
-		return this.unmarshaler.Unmarshal(strings.NewReader(line), msg)
+		err := this.unmarshaler.Unmarshal(strings.NewReader(line), msg)
+		if err != nil {
+			return errors.New("Not JSON: " + line)
+		}
+		return nil
 	}
 	return io.EOF
 }

--- a/messages/go/messages.pb.go
+++ b/messages/go/messages.pb.go
@@ -1520,7 +1520,8 @@ type GherkinDocument_Feature_FeatureChild_Scenario struct {
 func (*GherkinDocument_Feature_FeatureChild_Rule_) isGherkinDocument_Feature_FeatureChild_Value() {}
 func (*GherkinDocument_Feature_FeatureChild_Background) isGherkinDocument_Feature_FeatureChild_Value() {
 }
-func (*GherkinDocument_Feature_FeatureChild_Scenario) isGherkinDocument_Feature_FeatureChild_Value() {}
+func (*GherkinDocument_Feature_FeatureChild_Scenario) isGherkinDocument_Feature_FeatureChild_Value() {
+}
 
 func (m *GherkinDocument_Feature_FeatureChild) GetValue() isGherkinDocument_Feature_FeatureChild_Value {
 	if m != nil {
@@ -1574,8 +1575,10 @@ type GherkinDocument_Feature_FeatureChild_Rule struct {
 func (m *GherkinDocument_Feature_FeatureChild_Rule) Reset() {
 	*m = GherkinDocument_Feature_FeatureChild_Rule{}
 }
-func (m *GherkinDocument_Feature_FeatureChild_Rule) String() string { return proto.CompactTextString(m) }
-func (*GherkinDocument_Feature_FeatureChild_Rule) ProtoMessage()    {}
+func (m *GherkinDocument_Feature_FeatureChild_Rule) String() string {
+	return proto.CompactTextString(m)
+}
+func (*GherkinDocument_Feature_FeatureChild_Rule) ProtoMessage() {}
 func (*GherkinDocument_Feature_FeatureChild_Rule) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4dc296cbfe5ffcd5, []int{7, 1, 1, 0}
 }
@@ -1940,8 +1943,10 @@ type GherkinDocument_Feature_Scenario_Examples struct {
 func (m *GherkinDocument_Feature_Scenario_Examples) Reset() {
 	*m = GherkinDocument_Feature_Scenario_Examples{}
 }
-func (m *GherkinDocument_Feature_Scenario_Examples) String() string { return proto.CompactTextString(m) }
-func (*GherkinDocument_Feature_Scenario_Examples) ProtoMessage()    {}
+func (m *GherkinDocument_Feature_Scenario_Examples) String() string {
+	return proto.CompactTextString(m)
+}
+func (*GherkinDocument_Feature_Scenario_Examples) ProtoMessage() {}
 func (*GherkinDocument_Feature_Scenario_Examples) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4dc296cbfe5ffcd5, []int{7, 1, 3, 0}
 }

--- a/messages/go/messages_test.go
+++ b/messages/go/messages_test.go
@@ -104,4 +104,14 @@ func TestMessages(t *testing.T) {
 		require.NoError(t, r.ReadMsg(&decoded))
 		require.NoError(t, r.ReadMsg(&decoded))
 	})
+
+	t.Run("includes offending line in error message", func(t *testing.T) {
+		b := &bytes.Buffer{}
+		b.WriteString("BLA BLA")
+		r := messagesio.NewNdjsonReader(b)
+		var decoded Envelope
+		err := r.ReadMsg(&decoded)
+		require.Error(t, err)
+		require.Equal(t, "Not JSON: BLA BLA", err.Error())
+	})
 }

--- a/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
+++ b/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
@@ -41,7 +41,7 @@ public class NdjsonToMessageIterable implements Iterable<Messages.Envelope> {
                     try {
                         JSON_PARSER.merge(line, builder);
                     } catch(InvalidProtocolBufferException e) {
-                        throw new RuntimeException(String.format("Not JSON: %s", line));
+                        throw new RuntimeException(String.format("Not JSON: %s", line), e);
                     }
                     next = builder.build();
                     return true;

--- a/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
+++ b/messages/java/src/main/java/io/cucumber/messages/NdjsonToMessageIterable.java
@@ -1,5 +1,6 @@
 package io.cucumber.messages;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 
 import java.io.BufferedReader;
@@ -37,7 +38,11 @@ public class NdjsonToMessageIterable implements Iterable<Messages.Envelope> {
                         return hasNext();
                     }
                     Messages.Envelope.Builder builder = Messages.Envelope.newBuilder();
-                    JSON_PARSER.merge(line, builder);
+                    try {
+                        JSON_PARSER.merge(line, builder);
+                    } catch(InvalidProtocolBufferException e) {
+                        throw new RuntimeException(String.format("Not JSON: %s", line));
+                    }
                     next = builder.build();
                     return true;
                 } catch (IOException e) {

--- a/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
+++ b/messages/java/src/test/java/io/cucumber/messages/NdjsonSerializationTest.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NdjsonSerializationTest extends MessageSerializationContract {
@@ -45,5 +46,15 @@ class NdjsonSerializationTest extends MessageSerializationContract {
             assertEquals(Messages.Envelope.newBuilder().build(), envelope);
         }
         assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void includes_offending_line_in_error_message() {
+        InputStream input = new ByteArrayInputStream("BLA BLA".getBytes(UTF_8));
+        Iterable<Messages.Envelope> incomingMessages = makeMessageIterable(input);
+        Iterator<Messages.Envelope> iterator = incomingMessages.iterator();
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> assertTrue(iterator.hasNext()));
+        assertEquals(exception.getMessage(), "Not JSON: BLA BLA");
     }
 }

--- a/messages/javascript/src/NdjsonToMessageStream.ts
+++ b/messages/javascript/src/NdjsonToMessageStream.ts
@@ -26,7 +26,12 @@ export default class NdjsonToMessageStream<T> extends Transform {
     this.buffer = lines.pop()
     for (const line of lines) {
       if (line.trim().length > 0) {
-        this.push(this.fromObject(JSON.parse(line)))
+        try {
+          const object = JSON.parse(line)
+          this.push(this.fromObject(object))
+        } catch (err) {
+          return callback(err)
+        }
       }
     }
     callback()
@@ -34,7 +39,12 @@ export default class NdjsonToMessageStream<T> extends Transform {
 
   public _flush(callback: TransformCallback): void {
     if (this.buffer) {
-      this.push(this.fromObject(JSON.parse(this.buffer)))
+      try {
+        const object = JSON.parse(this.buffer)
+        this.push(this.fromObject(object))
+      } catch (err) {
+        return callback(err)
+      }
     }
     callback()
   }

--- a/messages/javascript/src/NdjsonToMessageStream.ts
+++ b/messages/javascript/src/NdjsonToMessageStream.ts
@@ -30,7 +30,7 @@ export default class NdjsonToMessageStream<T> extends Transform {
           const object = JSON.parse(line)
           this.push(this.fromObject(object))
         } catch (err) {
-          return callback(err)
+          return callback(new Error(`Not JSON: ${line}`))
         }
       }
     }
@@ -43,7 +43,7 @@ export default class NdjsonToMessageStream<T> extends Transform {
         const object = JSON.parse(this.buffer)
         this.push(this.fromObject(object))
       } catch (err) {
-        return callback(err)
+        return callback(new Error(`Not JSONs: ${this.buffer}`))
       }
     }
     callback()

--- a/messages/javascript/test/NdjsonStreamTest.ts
+++ b/messages/javascript/test/NdjsonStreamTest.ts
@@ -142,9 +142,15 @@ describe('NdjsonStream', () => {
 
   it('includes offending line in error message', async () => {
     const toMessageStream = makeToMessageStream()
-    toMessageStream.write('{}\nBLA BLA\n\n{}\n')
-    toMessageStream.end()
-
-    await assert.rejects(() => toArray(toMessageStream), 'Not JSON: BLA BLA')
+    await assert.rejects(
+      async () => {
+        toMessageStream.write('{}\nBLA BLA\n\n{}\n')
+        toMessageStream.end()
+        await toArray(toMessageStream)
+      },
+      {
+        message: 'Not JSON: BLA BLA',
+      }
+    )
   })
 })

--- a/messages/javascript/test/NdjsonStreamTest.ts
+++ b/messages/javascript/test/NdjsonStreamTest.ts
@@ -139,4 +139,12 @@ describe('NdjsonStream', () => {
       messages.Envelope.create({}),
     ])
   })
+
+  it('includes offending line in error message', async () => {
+    const toMessageStream = makeToMessageStream()
+    toMessageStream.write('{}\nBLA BLA\n\n{}\n')
+    toMessageStream.end()
+
+    await assert.rejects(() => toArray(toMessageStream), 'Not JSON: BLA BLA')
+  })
 })

--- a/messages/ruby/lib/cucumber/messages/ndjson_to_message_enumerator.rb
+++ b/messages/ruby/lib/cucumber/messages/ndjson_to_message_enumerator.rb
@@ -5,9 +5,13 @@ module Cucumber
     class NdjsonToMessageEnumerator < Enumerator
       def initialize(io)
         super() do |yielder|
-          io.each_line do |json|
-            next if json.strip.empty?
-            m = Cucumber::Messages::Envelope.from_json(json)
+          io.each_line do |line|
+            next if line.strip.empty?
+            begin
+              m = Cucumber::Messages::Envelope.from_json(line)
+            rescue => e
+              raise "Not JSON: #{line.strip}"
+            end
             yielder.yield(m)
           end
         end

--- a/messages/ruby/spec/cucumber/messages/ndjson_serialization_spec.rb
+++ b/messages/ruby/spec/cucumber/messages/ndjson_serialization_spec.rb
@@ -95,6 +95,16 @@ module Cucumber
         expect(incoming_messages.to_a).to(eq([Envelope.new]))
       end
 
+      it "includes offending line in error message" do
+        io = StringIO.new
+        io.puts('BLA BLA')
+
+        io.rewind
+        incoming_messages = NdjsonToMessageEnumerator.new(io)
+
+        expect { incoming_messages.to_a }.to(raise_error('Not JSON: BLA BLA'))
+      end
+
       def write_outgoing_messages(messages, out)
         messages.each do |message|
           message.write_ndjson_to(out)


### PR DESCRIPTION
When the NDJSON stream contains lines that are not valid JSON, we want the error to include the line to make it easier to diagnose the problem.

