### PR TITLE
gherkin-elixir: Add missing library runtime dependency

### DIFF
--- a/gherkin/elixir/lib/gherkin/lexicon.ex
+++ b/gherkin/elixir/lib/gherkin/lexicon.ex
@@ -1,6 +1,6 @@
 defmodule CucumberGherkin.Lexicon do
   @moduledoc false
-  @default_lexicon_path [File.cwd!(), "resources", "gherkin_languages.json"] |> Path.join()
+  @default_lexicon_path Path.join(__DIR__, "../../resources/gherkin_languages.json")
   @feature_keywords ["feature"]
   @scens_both ["scenario", "scenarioOutline"]
   @step_keywords ["given", "when", "then", "and", "but"]
@@ -8,8 +8,11 @@ defmodule CucumberGherkin.Lexicon do
   @rule_keywords ["rule"]
   @examples_keywords ["examples"]
 
-  def load!(), do: @default_lexicon_path |> File.read!() |> Jason.decode!()
-  def load_lang(lang) when is_binary(lang), do: load!() |> Map.fetch(lang)
+  @external_resource @default_lexicon_path
+
+  @lexicon @default_lexicon_path |> File.read!() |> Jason.decode!()
+
+  def load_lang(lang) when is_binary(lang), do: Map.fetch(@lexicon, lang)
 
   def load_keywords(FeatureLine, lex), do: fetch_and_flatten(@feature_keywords, lex)
   def load_keywords(ScenarioLine, lex), do: fetch_and_flatten(@scens_both, lex)

--- a/gherkin/elixir/mix.exs
+++ b/gherkin/elixir/mix.exs
@@ -42,7 +42,8 @@ defmodule CucumberGherkin.MixProject do
     [
       licenses: ["MIT"],
       source_url: @github,
-      links: %{"GitHub" => @github}
+      links: %{"GitHub" => @github},
+      files: ~w(LICENSE README.md lib mix.exs resources)
     ]
   end
 end


### PR DESCRIPTION
<!-- NAMING YOUR PULL REQUEST: Please prefix your PR with the name of the sub-project -->
<!-- e.g. `tag-expressions: Refactor checks` -->
<!-- This makes it easier to get some context when reading the names of issues -->

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This PR adds the `resource` folder to the set of files distributed in Hex. Also, loads the contents of `gherkin_languages.json` in compile time.

## Motivation and Context

If you try to use the current published library in Hex, you get the following error:

```
** (File.Error) could not read file ".../deps/cucumber_gherkin/resources/gherkin_languages.json": no such file or directory
    (elixir 1.11.1) lib/file.ex:354: File.read!/1
    (cucumber_gherkin 16.0.0) lib/gherkin/lexicon.ex:11: CucumberGherkin.Lexicon.load!/0
    (cucumber_gherkin 16.0.0) lib/gherkin/lexicon.ex:12: CucumberGherkin.Lexicon.load_lang/1
    ...
```
This is because the `resources` folder is not distributed in Hex. Fixing this issue is just half of the issue. Later, when distributing an app built using `cucumber_gherking`, for example, using `mix release`, this folder must be also reachable. There are two ways to fix this, add this file to the Erlang `priv` folder, or just read it at compile time and avoid any external file dependency. This PR implements the later.

## How Has This Been Tested?

I uploaded a patched version of the library to Hex. It's available from [here](https://hex.pm/packages/cucumber_gherkin_hotfix). 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG accordingly.

