### PR TITLE
cucumber-expressions/java: Expose parser api

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Ast.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Ast.java
@@ -1,14 +1,17 @@
 package io.cucumber.cucumberexpressions;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import static java.util.Arrays.asList;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
+import org.apiguardian.api.API;
 
-final class Ast {
+@API(status = API.Status.INTERNAL)
+public final class Ast {
 
     private static final char escapeCharacter = '\\';
     private static final char alternationCharacter = '/';
@@ -17,14 +20,14 @@ final class Ast {
     private static final char beginOptionalCharacter = '(';
     private static final char endOptionalCharacter = ')';
 
-    interface Located {
+	public interface Located {
         int start();
 
         int end();
 
     }
 
-    static final class Node implements Located {
+	public static final class Node implements Located {
 
         private final Type type;
         private final List<Node> nodes;
@@ -33,7 +36,7 @@ final class Ast {
         private final int end;
 
         Node(Type type, int start, int end, String token) {
-            this(type, start, end, null, token);
+			this(type, start, end, Collections.emptyList(), token);
         }
 
         Node(Type type, int start, int end, List<Node> nodes) {
@@ -42,14 +45,14 @@ final class Ast {
 
         private Node(Type type, int start, int end, List<Node> nodes, String token) {
             this.type = requireNonNull(type);
-            this.nodes = nodes;
+			this.nodes = Collections.unmodifiableList(nodes);
             this.token = token;
             this.start = start;
             this.end = end;
 
         }
 
-        enum Type {
+		public enum Type {
             TEXT_NODE,
             OPTIONAL_NODE,
             ALTERNATION_NODE,
@@ -66,15 +69,15 @@ final class Ast {
             return end;
         }
 
-        List<Node> nodes() {
+		public List<Node> nodes() {
             return nodes;
         }
 
-        Type type() {
+		public Type type() {
             return type;
         }
 
-        String text() {
+		public String text() {
             if (nodes == null)
                 return token;
 
@@ -144,7 +147,7 @@ final class Ast {
 
     }
 
-    static final class Token implements Located {
+	static final class Token implements Located {
 
         final String text;
         final Token.Type type;
@@ -161,7 +164,7 @@ final class Ast {
         static boolean canEscape(Integer token) {
             if (Character.isWhitespace(token)) {
                 return true;
-            }
+            } 
             switch (token) {
                 case (int) escapeCharacter:
                 case (int) alternationCharacter:
@@ -233,7 +236,7 @@ final class Ast {
                     .toString();
         }
 
-        enum Type {
+		enum Type {
             START_OF_LINE,
             END_OF_LINE,
             WHITE_SPACE,

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -1,7 +1,15 @@
 package io.cucumber.cucumberexpressions;
 
-import io.cucumber.cucumberexpressions.Ast.Node;
-import org.apiguardian.api.API;
+import static io.cucumber.cucumberexpressions.Ast.Node.Type.OPTIONAL_NODE;
+import static io.cucumber.cucumberexpressions.Ast.Node.Type.PARAMETER_NODE;
+import static io.cucumber.cucumberexpressions.Ast.Node.Type.TEXT_NODE;
+import static io.cucumber.cucumberexpressions.CucumberExpressionException.createAlternativeMayNotBeEmpty;
+import static io.cucumber.cucumberexpressions.CucumberExpressionException.createAlternativeMayNotExclusivelyContainOptionals;
+import static io.cucumber.cucumberexpressions.CucumberExpressionException.createOptionalIsNotAllowedInOptional;
+import static io.cucumber.cucumberexpressions.CucumberExpressionException.createOptionalMayNotBeEmpty;
+import static io.cucumber.cucumberexpressions.CucumberExpressionException.createParameterIsNotAllowedInOptional;
+import static io.cucumber.cucumberexpressions.UndefinedParameterTypeException.createUndefinedParameterType;
+import static java.util.stream.Collectors.joining;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -9,18 +17,9 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import static io.cucumber.cucumberexpressions.Ast.Node.Type.OPTIONAL_NODE;
-import static io.cucumber.cucumberexpressions.Ast.Node.Type.PARAMETER_NODE;
-import static io.cucumber.cucumberexpressions.Ast.Node.Type.TEXT_NODE;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createAlternativeMayNotBeEmpty;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createAlternativeMayNotExclusivelyContainOptionals;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createInvalidParameterTypeName;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createOptionalIsNotAllowedInOptional;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createOptionalMayNotBeEmpty;
-import static io.cucumber.cucumberexpressions.CucumberExpressionException.createParameterIsNotAllowedInOptional;
-import static io.cucumber.cucumberexpressions.ParameterType.isValidParameterTypeName;
-import static io.cucumber.cucumberexpressions.UndefinedParameterTypeException.createUndefinedParameterType;
-import static java.util.stream.Collectors.joining;
+import org.apiguardian.api.API;
+
+import io.cucumber.cucumberexpressions.Ast.Node;
 
 @API(status = API.Status.STABLE)
 public final class CucumberExpression implements Expression {
@@ -177,5 +176,10 @@ public final class CucumberExpression implements Expression {
     public Pattern getRegexp() {
         return treeRegexp.pattern();
     }
+
+	@Override
+	public ExpressionType getType() {
+		return ExpressionType.CUCUMBER;
+	}
 
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionParser.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionParser.java
@@ -1,13 +1,5 @@
 package io.cucumber.cucumberexpressions;
 
-import io.cucumber.cucumberexpressions.Ast.Node;
-import io.cucumber.cucumberexpressions.Ast.Token;
-import io.cucumber.cucumberexpressions.Ast.Token.Type;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static io.cucumber.cucumberexpressions.Ast.Node.Type.ALTERNATION_NODE;
 import static io.cucumber.cucumberexpressions.Ast.Node.Type.ALTERNATIVE_NODE;
 import static io.cucumber.cucumberexpressions.Ast.Node.Type.EXPRESSION_NODE;
@@ -28,7 +20,18 @@ import static io.cucumber.cucumberexpressions.CucumberExpressionException.create
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
-final class CucumberExpressionParser {
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apiguardian.api.API;
+
+import io.cucumber.cucumberexpressions.Ast.Node;
+import io.cucumber.cucumberexpressions.Ast.Token;
+import io.cucumber.cucumberexpressions.Ast.Token.Type;
+
+@API(status = API.Status.INTERNAL)
+public final class CucumberExpressionParser {
 
     /*
      * text := whitespace | ')' | '}' | .
@@ -160,7 +163,7 @@ final class CucumberExpressionParser {
             )
     );
 
-    Node parse(String expression) {
+	public Node parse(String expression) {
         CucumberExpressionTokenizer tokenizer = new CucumberExpressionTokenizer();
         List<Token> tokens = tokenizer.tokenize(expression);
         Result result = cucumberExpressionParser.parse(expression, tokens, 0);

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Expression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Expression.java
@@ -1,17 +1,23 @@
 package io.cucumber.cucumberexpressions;
 
-import org.apiguardian.api.API;
-
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apiguardian.api.API;
 
 @API(status = API.Status.STABLE)
 public interface Expression {
+
+	enum ExpressionType {
+		CUCUMBER, REGULAR;
+	}
+
     List<Argument<?>> match(String text, Type... typeHints);
 
     Pattern getRegexp();
 
     String getSource();
+
+	ExpressionType getType();
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ExpressionFactory.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/ExpressionFactory.java
@@ -1,10 +1,12 @@
 package io.cucumber.cucumberexpressions;
 
-import org.apiguardian.api.API;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import org.apiguardian.api.API;
+
+import io.cucumber.cucumberexpressions.Expression.ExpressionType;
 
 /**
  * Creates a {@link CucumberExpression} or {@link RegularExpression} from a {@link String}
@@ -41,7 +43,7 @@ public final class ExpressionFactory {
 
     private RegularExpression createRegularExpressionWithAnchors(String expressionString) {
         try {
-            return new RegularExpression(Pattern.compile(expressionString), parameterTypeRegistry);
+			return new RegularExpression(Pattern.compile(expressionString), parameterTypeRegistry);
         } catch (PatternSyntaxException e) {
             if (PARAMETER_PATTERN.matcher(expressionString).find()) {
                 throw new CucumberExpressionException("You cannot use anchors (^ or $) in Cucumber Expressions. Please remove them from " + expressionString, e);
@@ -49,4 +51,12 @@ public final class ExpressionFactory {
             throw e;
         }
     }
+
+	public static ExpressionType detectExpressionType(String expressionString) {
+		if (BEGIN_ANCHOR.matcher(expressionString).find() || END_ANCHOR.matcher(expressionString).find()
+				|| SCRIPT_STYLE_REGEXP.matcher(expressionString).find()) {
+			return ExpressionType.REGULAR;
+		}
+		return ExpressionType.CUCUMBER;
+	}
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
@@ -1,14 +1,25 @@
 package io.cucumber.cucumberexpressions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 
-final class GroupBuilder {
+import org.apiguardian.api.API;
+
+@API(status = API.Status.INTERNAL)
+public final class GroupBuilder {
     private final List<GroupBuilder> groupBuilders = new ArrayList<>();
-    private boolean capturing = true;
+	private final boolean capturing;
+	private final int startIndex;
     private String source;
+	private int endIndex;
+
+	GroupBuilder(int startIndex, boolean capturing) {
+		this.startIndex = startIndex;
+		this.capturing = capturing;
+	}
 
     void add(GroupBuilder groupBuilder) {
         groupBuilders.add(groupBuilder);
@@ -23,22 +34,18 @@ final class GroupBuilder {
         return new Group(matcher.group(groupIndex), matcher.start(groupIndex), matcher.end(groupIndex), children);
     }
 
-    void setNonCapturing() {
-        this.capturing = false;
-    }
-
-    boolean isCapturing() {
+	public boolean isCapturing() {
         return capturing;
     }
 
-    public void moveChildrenTo(GroupBuilder groupBuilder) {
+	void moveChildrenTo(GroupBuilder groupBuilder) {
         for (GroupBuilder child : groupBuilders) {
             groupBuilder.add(child);
         }
     }
 
     public List<GroupBuilder> getChildren() {
-        return groupBuilders;
+		return Collections.unmodifiableList(groupBuilders);
     }
 
     public String getSource() {
@@ -48,4 +55,23 @@ final class GroupBuilder {
     void setSource(String source) {
         this.source = source;
     }
+
+	/**
+	 * @return the start index of the group in the original regular expression
+	 *         string
+	 */
+	public int getStartIndex() {
+		return startIndex;
+	}
+
+	/**
+	 * @return the end index of the group in the original regular expression string
+	 */
+	public int getEndIndex() {
+		return endIndex;
+	}
+
+	void setEndIndex(int endIndex) {
+		this.endIndex = endIndex;
+	}
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
@@ -1,13 +1,13 @@
 package io.cucumber.cucumberexpressions;
 
-import org.apiguardian.api.API;
+import static io.cucumber.cucumberexpressions.ParameterType.createAnonymousParameterType;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static io.cucumber.cucumberexpressions.ParameterType.createAnonymousParameterType;
+import org.apiguardian.api.API;
 
 @API(status = API.Status.STABLE)
 public final class RegularExpression implements Expression {
@@ -81,4 +81,9 @@ public final class RegularExpression implements Expression {
     public String getSource() {
         return expressionRegexp.pattern();
     }
+
+	@Override
+	public ExpressionType getType() {
+		return ExpressionType.REGULAR;
+	}
 }


### PR DESCRIPTION
## Summary

as discussed with @mpkorstanje I'd like to reuse the parsing of expressions in the cucumber-eclipse project to supply the user with advanced editing capabilities.

## Included changes
- Ast parser class is public now
- Expression's carry the type of the expression + Expressionfactory has methods to guess if a string is a Cucumber or regular expression
- GroupBuilder carries information about the start/end index, this simplifies the parser in cucumber-expression and can be reused by downstream projects to get the bounds of capture groups

