### PR TITLE
cucumber-expressions/java: Expose regex group parser api

### DIFF
--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Group.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/Group.java
@@ -3,9 +3,13 @@ package io.cucumber.cucumberexpressions;
 import org.apiguardian.api.API;
 
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 @API(status = API.Status.STABLE)
 public class Group {
@@ -42,5 +46,28 @@ public class Group {
         return groups.stream()
                 .map(Group::getValue)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Parse a {@link Pattern} into collection of {@link Group}s
+     * 
+     * @param expression the expression to decompose
+     * @return A collection of {@link Group}s, possibly empty but never
+     *         <code>null</code>
+     */
+    public static Collection<Group> parse(Pattern expression) {
+        GroupBuilder builder = TreeRegexp.createGroupBuilder(expression);
+        return toGroups(builder.getChildren());
+    }
+
+    private static List<Group> toGroups(List<GroupBuilder> children) {
+        List<Group> list = new ArrayList<>();
+        if (children != null) {
+            for (GroupBuilder child : children) {
+                list.add(new Group(child.getSource(), child.getStartIndex(), child.getEndIndex(),
+                        toGroups(child.getChildren())));
+            }
+        }
+        return list;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
@@ -10,6 +10,7 @@ final class GroupBuilder {
     private boolean capturing = true;
     private String source;
     private int startIndex;
+    private int endIndex;
 
     GroupBuilder(int startIndex) {
         this.startIndex = startIndex;
@@ -56,5 +57,13 @@ final class GroupBuilder {
 
     int getStartIndex() {
         return startIndex;
+    }
+
+    int getEndIndex() {
+        return endIndex;
+    }
+
+    void setEndIndex(int endIndex) {
+        this.endIndex = endIndex;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/GroupBuilder.java
@@ -9,6 +9,11 @@ final class GroupBuilder {
     private final List<GroupBuilder> groupBuilders = new ArrayList<>();
     private boolean capturing = true;
     private String source;
+    private int startIndex;
+
+    GroupBuilder(int startIndex) {
+        this.startIndex = startIndex;
+    }
 
     void add(GroupBuilder groupBuilder) {
         groupBuilders.add(groupBuilder);
@@ -31,21 +36,25 @@ final class GroupBuilder {
         return capturing;
     }
 
-    public void moveChildrenTo(GroupBuilder groupBuilder) {
+    void moveChildrenTo(GroupBuilder groupBuilder) {
         for (GroupBuilder child : groupBuilders) {
             groupBuilder.add(child);
         }
     }
 
-    public List<GroupBuilder> getChildren() {
+    List<GroupBuilder> getChildren() {
         return groupBuilders;
     }
 
-    public String getSource() {
+    String getSource() {
         return source;
     }
 
     void setSource(String source) {
         this.source = source;
+    }
+
+    int getStartIndex() {
+        return startIndex;
     }
 }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
@@ -27,7 +27,7 @@ final class TreeRegexp {
         this.groupBuilder = createGroupBuilder(pattern);
     }
 
-    private static GroupBuilder createGroupBuilder(Pattern pattern) {
+    static GroupBuilder createGroupBuilder(Pattern pattern) {
         String source = pattern.pattern();
         Deque<GroupBuilder> stack = new ArrayDeque<>(singleton(new GroupBuilder(0)));
         boolean escaping = false;
@@ -54,6 +54,7 @@ final class TreeRegexp {
                 } else {
                     gb.moveChildrenTo(stack.peek());
                 }
+                gb.setEndIndex(i);
             }
             escaping = c == '\\' && !escaping;
         }

--- a/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
+++ b/cucumber-expressions/java/src/main/java/io/cucumber/cucumberexpressions/TreeRegexp.java
@@ -29,8 +29,7 @@ final class TreeRegexp {
 
     private static GroupBuilder createGroupBuilder(Pattern pattern) {
         String source = pattern.pattern();
-        Deque<GroupBuilder> stack = new ArrayDeque<>(singleton(new GroupBuilder()));
-        Deque<Integer> groupStartStack = new ArrayDeque<>();
+        Deque<GroupBuilder> stack = new ArrayDeque<>(singleton(new GroupBuilder(0)));
         boolean escaping = false;
         boolean charClass = false;
 
@@ -41,18 +40,16 @@ final class TreeRegexp {
             } else if (c == ']' && !escaping) {
                 charClass = false;
             } else if (c == '(' && !escaping && !charClass) {
-                groupStartStack.push(i);
                 boolean nonCapturing = isNonCapturingGroup(source, i);
-                GroupBuilder groupBuilder = new GroupBuilder();
+                GroupBuilder groupBuilder = new GroupBuilder(i);
                 if (nonCapturing) {
                     groupBuilder.setNonCapturing();
                 }
                 stack.push(groupBuilder);
             } else if (c == ')' && !escaping && !charClass) {
                 GroupBuilder gb = stack.pop();
-                int groupStart = groupStartStack.pop();
                 if (gb.isCapturing()) {
-                    gb.setSource(source.substring(groupStart + 1, i));
+                    gb.setSource(source.substring(gb.getStartIndex() + 1, i));
                     stack.peek().add(gb);
                 } else {
                     gb.moveChildrenTo(stack.peek());


### PR DESCRIPTION
## Summary

Make the RegExp Group parsing of Cucumber accessible in a way  that it could be used for descending processing steps.

## Motivation and Context

I'm currently overhaul the [cucumber-eclipse plugin](https://github.com/cucumber/cucumber-eclipse) to provide better editing capabilities and user experience.

There are these main goals:

1. reuse as much code as possible from cucumber-jvm to prevent diverging results between IDE and the actual cucumber run and reduce code-duplication/implementation of features already available (especially parsers)
2. provide a better user-experience, e.g user should be able to tab-trhough parameters and simply type instead of placing cursor manually

With this change it is possible to use the same regex group parsing that cucumber-jvm uses.

## How Has This Been Tested?

I use a modified version of cucumber in development.

## Screenshots (if appropriate):
![grafik](https://user-images.githubusercontent.com/1331477/106362525-9e8d5600-6323-11eb-8d1e-22d0a773142d.png)


