### PR TITLE
[gherkin-perl]: Add release machinery

### DIFF
--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -96,3 +96,6 @@ lib/Gherkin/Generated/Parser.pm: gherkin.berp gherkin-perl.razor
 	# Remove BOM
 	awk 'NR==1{sub(/^\xef\xbb\xbf/,"")}{print}' < $@ > $@.nobom
 	mv $@.nobom $@
+
+pre-release: update-version
+.PHONY: pre-release


### PR DESCRIPTION
## Summary

Make the release process work for Gherkin's Perl implementation

## Details

The Makefile is missing the `pre-release` target.

## Motivation and Context

Couldn't commit directly to `master` due to it being a restricted branch at the time (@aslakhellesoy says due to a running CircleCI build).