### PR TITLE
[gherkin-perl] Fine-tune release engineering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ docker-run-with-secrets:
 	docker run \
 	  --volume "${shell pwd}":/app \
 	  --volume "${HOME}/.m2/repository":/home/cukebot/.m2/repository \
+	  --volume "${shell pwd}/../secrets/.pause":/home/cukebot/.pause \
 	  --volume "${shell pwd}/../secrets/.gem":/home/cukebot/.gem \
 	  --volume "${shell pwd}/../secrets/.ssh":/home/cukebot/.ssh \
 	  --volume "${shell pwd}/../secrets/.npmrc":/home/cukebot/.npmrc \

--- a/gherkin/perl/.gitignore
+++ b/gherkin/perl/.gitignore
@@ -5,4 +5,4 @@ perl5/
 .cpanfile_dependencies
 cpanfile.snapshot
 Gherkin-*
-CHANGES
+CHANGELOG.md

--- a/gherkin/perl/MANIFEST.SKIP
+++ b/gherkin/perl/MANIFEST.SKIP
@@ -1,0 +1,11 @@
+^Gherkin-
+^gherkin-
+^gherkin.berp
+^helper-scripts/
+^testdata/
+^acceptance/
+^perl5/
+^Makefile$
+^MANIFEST.SKIP
+^.*~
+^VERSION$

--- a/gherkin/perl/Makefile
+++ b/gherkin/perl/Makefile
@@ -50,11 +50,11 @@ acceptance/testdata/%.feature.errors.ndjson: testdata/%.feature testdata/%.featu
 	PERL5LIB=./perl5/lib/perl5 bin/gherkin-generate-ast $< > $@
 	diff --unified <(jq "." $<.errors.ndjson) <(jq "." $@)
 
-CHANGES:
-	cp ../CHANGELOG.md CHANGES
+CHANGELOG.md: ../CHANGELOG.md
+	cp ../CHANGELOG.md CHANGELOG.md
 
 # Get to a point where dzil can be run
-predistribution: test CHANGES
+predistribution: test CHANGELOG.md
 # --notest to keep the number of dependencies low: it doesn't install the
 # testing dependencies of the dependencies.
 	cpanm --notest --local-lib ./perl5 --installdeps --with-develop .

--- a/gherkin/perl/cpanfile
+++ b/gherkin/perl/cpanfile
@@ -1,3 +1,5 @@
+
+requires "perl", "5.10.1";
 requires "Cpanel::JSON::XS";
 requires "Class::XSAccessor";
 requires "IO::Scalar";

--- a/gherkin/perl/dist.ini
+++ b/gherkin/perl/dist.ini
@@ -1,13 +1,12 @@
 name      = Gherkin
 abstract  = A parser and compiler for the Gherkin language
 main_module = lib/Gherkin.pm
-author    = 'Erik Huelsmann <ehuels@gmail.com>'
-author    = 'Peter Sergeant <pete@clueball.com>'
-author    = 'Cucumber Ltd'
-author    = 'Gaspar Nagy'
+author    = Erik Huelsmann <ehuels@gmail.com>
+author    = Peter Sergeant <pete@clueball.com>
+author    = Cucumber Ltd
+author    = Gaspar Nagy
 license   = MIT
 is_trial  = 0
-perl      = 5.14
 copyright_holder = Erik Huelsmann, Peter Sergeant, Cucumber Ltd, Gaspar Nagy
 
 [MetaResources]
@@ -16,18 +15,15 @@ repository.url    = https://github.com/cucumber/gherkin-perl.git
 repository.web    = https://github.com/cucumber/gherkin-perl
 repository.type   = git
 
-[GatherDir]
-exclude_filename = Makefile
+[@Filter]
+-bundle=@Basic
+-remove=Readme
+-remove=ConfirmRelease
+-remove=License
 
-[MetaYAML]
-[ExtraTests]
-[MakeMaker]
-[Manifest]
-[TestRelease]
+[MetaJSON]
 [PkgVersion]
 [Prereqs::FromCPANfile]
-[ConfirmRelease]
-[UploadToCPAN]
 
 [Hook::VersionProvider]
 . = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
## Summary

Fix a number of issues in the Gherkin Perl release process

## Details

1. [Test failures in CPANTESTERS](http://matrix.cpantesters.org/?dist=Gherkin+17.0.1) due to incorrect declaration of minimum Perl version
2. Release archive contains several undesirable artifacts (perl5/ subdirectory, test directories)
3. Changelog not updated on 17.0.1 release (because 17.0.0 was released from the same repo)
4. Release CHANGELOG.md as itself instead of as CHANGES (which is rendered as plain text)
5. Make release process truely non-interactive

## Motivation and Context

Note that all the removed lines in brackets are now hidden behind the `[@Filter]\n-bundle=@Basic` bit. 

## How Has This Been Tested?

This has been tested locally by regenerating the release archive for 17.0.1, which is 8MB on CPAN, but only 31kB locally, after these changes.


## Types of changes

Bugfixes for the release engineering, if you will.

## Checklist:

Porting of the change is not applicable.

The changelog has not been updated; if we consider it desirable, I could add:

* Minimum Perl dependency specification fixed
* Dist packaging fixed not to include development artifacts
