### PR TITLE
messages/java: Use single property for protobuf version

### DIFF
--- a/messages/java/pom.xml
+++ b/messages/java/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.messages</project.Automatic-Module-Name>
+        <protobuf.version>3.15.5</protobuf.version>
     </properties>
 
     <scm>
@@ -28,17 +29,17 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.15.5</version>
+            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>3.15.5</version>
+            <version>${protobuf.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.7.1</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Renovate keeps creating 2 different MR's for each dependency. This is annoying and consuming time on CI.
By using a single version property, Renovate will only create 1 MR.
