### PR TITLE
Fix the release process for javascript modules

### DIFF
--- a/.templates/javascript/default.mk
+++ b/.templates/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/compatibility-kit/javascript/default.mk
+++ b/compatibility-kit/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/compatibility-kit/javascript/package.json
+++ b/compatibility-kit/javascript/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "scripts": {
     "test": "echo 'no tests'",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "devDependencies": {
     "@cucumber/fake-cucumber": "^10.0.0",

--- a/create-meta/javascript/default.mk
+++ b/create-meta/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/create-meta/javascript/package.json
+++ b/create-meta/javascript/package.json
@@ -7,7 +7,7 @@
   "bin": {},
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc --build tsconfig.build.json",
     "print-meta": "ts-node --require tsconfig-paths/register ./src/printMeta.ts"
   },
   "repository": {

--- a/cucumber-expressions/javascript/default.mk
+++ b/cucumber-expressions/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -6,7 +6,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/fake-cucumber/javascript/default.mk
+++ b/fake-cucumber/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/fake-cucumber/javascript/package.json
+++ b/fake-cucumber/javascript/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint --ext ts --max-warnings 0 src test",
     "lint-fix": "eslint --ext ts --max-warnings 0 --fix src test",
     "coverage": "nyc --reporter=html --reporter=text mocha",
-    "build": "tsc",
-    "prepublishOnly": "tsc"
+    "build": "tsc --build tsconfig.build.json",
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/gherkin-streams/javascript/default.mk
+++ b/gherkin-streams/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/gherkin-streams/javascript/package.json
+++ b/gherkin-streams/javascript/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@cucumber/messages": "^14.0.1",

--- a/gherkin-utils/javascript/default.mk
+++ b/gherkin-utils/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/gherkin-utils/javascript/package.json
+++ b/gherkin-utils/javascript/package.json
@@ -7,7 +7,7 @@
   "bin": {},
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/gherkin/javascript/default.mk
+++ b/gherkin/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/gherkin/javascript/package.json
+++ b/gherkin/javascript/package.json
@@ -6,7 +6,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/html-formatter/javascript/default.mk
+++ b/html-formatter/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/html-formatter/javascript/package.json
+++ b/html-formatter/javascript/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc && webpack-cli && cp src/index.mustache.html dist/src && cp node_modules/@cucumber/react/dist/src/styles/cucumber-react.css dist"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@cucumber/messages": "^14.0.1",

--- a/json-formatter/javascript-testdata/default.mk
+++ b/json-formatter/javascript-testdata/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/json-to-messages/javascript-testdata/default.mk
+++ b/json-to-messages/javascript-testdata/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/json-to-messages/javascript/default.mk
+++ b/json-to-messages/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/json-to-messages/javascript/package.json
+++ b/json-to-messages/javascript/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/message-streams/javascript/default.mk
+++ b/message-streams/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/message-streams/javascript/package.json
+++ b/message-streams/javascript/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@cucumber/messages": "^14.0.1",

--- a/messages/javascript/default.mk
+++ b/messages/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/messages/javascript/package.json
+++ b/messages/javascript/package.json
@@ -15,7 +15,7 @@
     "test": "mocha",
     "pbjs": "pbjs --force-number --target static-module --wrap commonjs messages.proto --out src/messages.js",
     "pbts": "pbts src/messages.js > src/messages.d.ts",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "dependencies": {
     "@types/uuid": "^8.3.0",

--- a/query/javascript/default.mk
+++ b/query/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/query/javascript/package.json
+++ b/query/javascript/package.json
@@ -6,7 +6,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/react/javascript/default.mk
+++ b/react/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/tag-expressions/javascript/default.mk
+++ b/tag-expressions/javascript/default.mk
@@ -46,6 +46,9 @@ ifeq ($(IS_TESTDATA),-testdata)
 	# no-op
 else
 ifneq (true,$(PRIVATE))
+	pushd ../.. && \
+	$(NPM) run build && \
+	popd
 	$(NPM) publish --access public
 else
 	@echo "Not publishing private npm module"

--- a/tag-expressions/javascript/package.json
+++ b/tag-expressions/javascript/package.json
@@ -6,7 +6,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "test": "mocha",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc --build tsconfig.build.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build of javascript modules has to be done from the root folder of
the mono-repo. So `default.mk` has been updated to do that.

`package.json` have also been updated. `prepublishOnly` has been kept
and fixed as kinda last validation before publish.

`html-formatter` `prepublishOnly` script does not execute webpack
anymore as this is now done using `make` thanks to the Makefile.
