### PR TITLE
build: fix files spec in package.json for query, cucumber-expressions

### DIFF
--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -33,10 +33,6 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   },
-  "files": [
-    "src/",
-    "dist/src/"
-  ],
   "dependencies": {
     "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0"
   },

--- a/cucumber-expressions/javascript/package.json
+++ b/cucumber-expressions/javascript/package.json
@@ -34,7 +34,8 @@
     "typescript": "^4.2.3"
   },
   "files": [
-    "*"
+    "src/",
+    "dist/src/"
   ],
   "dependencies": {
     "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0"

--- a/query/CHANGELOG.md
+++ b/query/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Fix issue with compiled files not appearing in published package
+
 ## [9.0.1] - 2021-04-03
 
 ### Added

--- a/query/javascript/package.json
+++ b/query/javascript/package.json
@@ -32,10 +32,6 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   },
-  "files": [
-    "src/",
-    "dist/src/"
-  ],
   "dependencies": {
     "@cucumber/messages": "^15.0.0",
     "@teppeis/multimaps": "^2.0.0"

--- a/query/javascript/package.json
+++ b/query/javascript/package.json
@@ -33,7 +33,8 @@
     "typescript": "^4.2.3"
   },
   "files": [
-    "*"
+    "src/",
+    "dist/src/"
   ],
   "dependencies": {
     "@cucumber/messages": "^15.0.0",


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3192745/113477235-5e0f9d00-9478-11eb-9ef9-fd46ba510938.png)

After:

![image](https://user-images.githubusercontent.com/3192745/113477240-62d45100-9478-11eb-92ef-2b1a1e575243.png)

Seems likely that npm7 has different handling of `files` (specifically of `"*"` in relation to what's gitignored), though I can't find documentation to prove that.

The lone `index.js` making its way in was perhaps because of the reference to it in the `main` field.