### PR TITLE
cck: make javascript package publishable

### DIFF
--- a/compatibility-kit/javascript/package.json
+++ b/compatibility-kit/javascript/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cucumber/compatibility-kit",
   "version": "4.0.0",
-  "private": true,
   "description": "Test data used to validate a Cucumber implementation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Not sure if this was intentional - looks to have been added as part of the big workspaces PR.

`@cucumber/compatibility-kit@4.0.0` is not on npm and I suspect this may be why - `npm publish` would have aborted with this in.