### PR TITLE
Add UndefinedParameterTypeError#undefined_parameter_type_name

### DIFF
--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * [Ruby] Add `UndefinedParameterTypeError#undefined_parameter_type_name`
+  ([#1460](https://github.com/cucumber/cucumber/pull/1460)
+   [aslakhellesoy])
 
 ### Changed
 

--- a/cucumber-expressions/CHANGELOG.md
+++ b/cucumber-expressions/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* [Ruby] Add `UndefinedParameterTypeError#undefined_parameter_type_name`
+
 ### Changed
 
 ### Deprecated

--- a/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
+++ b/cucumber-expressions/ruby/lib/cucumber/cucumber_expressions/errors.rb
@@ -171,12 +171,15 @@ This Cucumber Expression has a problem at column #{index + 1}:
     end
 
     class UndefinedParameterTypeError < CucumberExpressionError
-      def initialize(node, expression, parameter_type_name)
+      attr_reader :undefined_parameter_type_name
+
+      def initialize(node, expression, undefined_parameter_type_name)
         super(build_message(node.start,
                             expression,
                             point_at_located(node),
-                            "Undefined parameter type '#{parameter_type_name}'",
-                            "Please register a ParameterType for '#{parameter_type_name}'"))
+                            "Undefined parameter type '#{undefined_parameter_type_name}'",
+                            "Please register a ParameterType for '#{undefined_parameter_type_name}'"))
+        @undefined_parameter_type_name = undefined_parameter_type_name
       end
     end
 

--- a/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/cucumber-expressions/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -150,6 +150,19 @@ module Cucumber
         expect(args[0].value(World.new)).to eq('widget:bolt')
       end
 
+      it "reports undefined parameter type name" do
+        parameter_type_registry = ParameterTypeRegistry.new
+
+        begin
+          CucumberExpression.new(
+              'I have {int} {widget}(s) in {word}',
+              parameter_type_registry
+          )
+        rescue UndefinedParameterTypeError => e
+          expect(e.undefined_parameter_type_name).to eq('widget')
+        end
+      end
+
       def match(expression, text)
         cucumber_expression = CucumberExpression.new(expression, ParameterTypeRegistry.new)
         args = cucumber_expression.match(text)


### PR DESCRIPTION
This accessor on `UndefinedParameterTypeError` already exists on the Java and TypeScript implementations.

Adding this will let us access the name of the undefined parameter type more cleanly in https://github.com/cucumber/cucumber-ruby/blob/4c09cb7f2e5d3fa8f34721ef917749c786fc0976/lib/cucumber/glue/registry_and_more.rb#L93-L94