### PR TITLE
gherkin-perl: Reinstate Perl 5.10.1 compatibility

### DIFF
--- a/gherkin/CHANGELOG.md
+++ b/gherkin/CHANGELOG.md
@@ -18,6 +18,10 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Removed
 
 ### Fixed
+* [Perl] Reinstate Perl 5.10.1 compatibility.
+  ([#1495](https://github.com/cucumber/cucumber/pull/1495)
+   [#1494](https://github.com/cucumber/cucumber/issues/1494)
+   [ehuelsmann])
 
 ## [18.1.1] - 2021-04-22
 

--- a/gherkin/perl/lib/Gherkin/Pickles/Compiler.pm
+++ b/gherkin/perl/lib/Gherkin/Pickles/Compiler.pm
@@ -32,7 +32,7 @@ sub compile {
                 $pickle_sink
                 );
         } else {
-            ...;
+            die "Unimplemented";
         }
     }
 
@@ -168,7 +168,7 @@ sub _compile_rule {
                 $pickle_sink
                 );
         } else {
-            ...;
+            die "Unimplemented";
         }
     }
 }


### PR DESCRIPTION

## Summary

Close #1494: Reinstate Perl 5.10.1 compatibility

## Details

The 'yada-yada' operator (triple-dot) was added to Perl 5.12. It's functionally equivalent to `die "Unimplemented";`. The rest of the code base is 5.10.1 compliant. These two (minor) issues do not seem like a good reason to increase the requirement.

## How Has This Been Tested?

`make test` in the docker development environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

