### PR TITLE
gherkin-streams: accept an optional `relativeTo` path for uris

### DIFF
--- a/gherkin-streams/CHANGELOG.md
+++ b/gherkin-streams/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Add ability to specify a `relativeTo` path for cleaner emitted `uri`s [#1510](https://github.com/cucumber/cucumber/pull/1510)
+
 ### Changed
 
 ### Deprecated

--- a/gherkin-streams/javascript/README.md
+++ b/gherkin-streams/javascript/README.md
@@ -1,3 +1,40 @@
 # Gherkin Streams
 
 This module contains utilities to use the Gherkin library with streams.
+
+## Usage
+
+```javascript
+const { fromPaths } = require('@cucumber/gherkin-streams')
+
+const options = {
+  includeSource: true,
+  includeGherkinDocument: true,
+  includePickles: true,
+}
+const stream = fromPaths(['features/hello.feature'])
+
+// Pipe the stream to another stream that can read messages.
+stream.pipe(...)
+```
+
+### Shortening URIs with `relativeTo`
+
+You can include `relativeTo` option to avoid emitting longer or absolute URIs, instead making them only relative to the current working directory (or whatever makes sense for your use case):
+
+```javascript
+const { fromPaths } = require('@cucumber/gherkin-streams')
+
+// imagine `discoverPaths()` is a function that returns absolute paths
+const paths = discoverPaths();
+const options = {
+  includeSource: true,
+  includeGherkinDocument: true,
+  includePickles: true,
+  relativeTo: process.cwd()
+}
+const stream = fromPaths(paths)
+
+// Pipe the stream to another stream that can read messages.
+stream.pipe(...)
+```

--- a/gherkin-streams/javascript/src/GherkinStreams.ts
+++ b/gherkin-streams/javascript/src/GherkinStreams.ts
@@ -6,7 +6,11 @@ import fs from 'fs'
 import { IGherkinOptions } from '@cucumber/gherkin'
 import makeGherkinOptions from './makeGherkinOptions'
 
-function fromPaths(paths: readonly string[], options: IGherkinOptions): Readable {
+function fromPaths(
+  paths: readonly string[],
+  options: IGherkinOptions,
+  relativeTo?: string
+): Readable {
   const pathsCopy = paths.slice()
   options = makeGherkinOptions(options)
   const combinedMessageStream = new PassThrough({

--- a/gherkin-streams/javascript/src/GherkinStreams.ts
+++ b/gherkin-streams/javascript/src/GherkinStreams.ts
@@ -6,11 +6,11 @@ import fs from 'fs'
 import { IGherkinOptions } from '@cucumber/gherkin'
 import makeGherkinOptions from './makeGherkinOptions'
 
-function fromPaths(
-  paths: readonly string[],
-  options: IGherkinOptions,
+export interface IGherkinStreamOptions extends IGherkinOptions {
   relativeTo?: string
-): Readable {
+}
+
+function fromPaths(paths: readonly string[], options: IGherkinStreamOptions): Readable {
   const pathsCopy = paths.slice()
   options = makeGherkinOptions(options)
   const combinedMessageStream = new PassThrough({
@@ -31,7 +31,7 @@ function fromPaths(
       // so we have to manually propagate errors.
       fs.createReadStream(path, { encoding: 'utf-8' })
         .on('error', (err) => combinedMessageStream.emit('error', err))
-        .pipe(new SourceMessageStream(path, relativeTo))
+        .pipe(new SourceMessageStream(path, options.relativeTo))
         .on('error', (err) => combinedMessageStream.emit('error', err))
         .pipe(parserMessageStream)
         .on('error', (err) => combinedMessageStream.emit('error', err))

--- a/gherkin-streams/javascript/src/GherkinStreams.ts
+++ b/gherkin-streams/javascript/src/GherkinStreams.ts
@@ -31,7 +31,7 @@ function fromPaths(
       // so we have to manually propagate errors.
       fs.createReadStream(path, { encoding: 'utf-8' })
         .on('error', (err) => combinedMessageStream.emit('error', err))
-        .pipe(new SourceMessageStream(path))
+        .pipe(new SourceMessageStream(path, relativeTo))
         .on('error', (err) => combinedMessageStream.emit('error', err))
         .pipe(parserMessageStream)
         .on('error', (err) => combinedMessageStream.emit('error', err))

--- a/gherkin-streams/javascript/src/SourceMessageStream.ts
+++ b/gherkin-streams/javascript/src/SourceMessageStream.ts
@@ -1,5 +1,6 @@
 import { makeSourceEnvelope } from '@cucumber/gherkin'
 import { Transform, TransformCallback } from 'stream'
+import { relative } from 'path'
 
 /**
  * Stream that reads a string and writes a single Source message.
@@ -7,7 +8,7 @@ import { Transform, TransformCallback } from 'stream'
 export default class SourceMessageStream extends Transform {
   private buffer = Buffer.alloc(0)
 
-  constructor(private readonly uri: string) {
+  constructor(private readonly uri: string, private readonly relativeTo?: string) {
     super({ readableObjectMode: true, writableObjectMode: false })
   }
 
@@ -18,7 +19,10 @@ export default class SourceMessageStream extends Transform {
 
   public _flush(callback: TransformCallback) {
     const data = this.buffer.toString('utf8')
-    const chunk = makeSourceEnvelope(data, this.uri)
+    const chunk = makeSourceEnvelope(
+      data,
+      this.relativeTo ? relative(this.relativeTo, this.uri) : this.uri
+    )
     this.push(chunk)
     callback()
   }

--- a/gherkin-streams/javascript/src/index.ts
+++ b/gherkin-streams/javascript/src/index.ts
@@ -1,3 +1,3 @@
-import GherkinStreams from './GherkinStreams'
+import GherkinStreams, { IGherkinStreamOptions } from './GherkinStreams'
 
-export { GherkinStreams }
+export { GherkinStreams, IGherkinStreamOptions }

--- a/gherkin-streams/javascript/test/StreamTest.ts
+++ b/gherkin-streams/javascript/test/StreamTest.ts
@@ -20,6 +20,16 @@ describe('gherkin', () => {
     )
   })
 
+  it('emits uris relative to a given path', async () => {
+    const envelopes = await streamToArray(
+      GherkinStreams.fromPaths(['testdata/good/minimal.feature'], defaultOptions, 'testdata/good')
+    )
+    assert.strictEqual(envelopes.length, 3)
+    assert.strictEqual(envelopes[0].source.uri, 'minimal.feature')
+    assert.strictEqual(envelopes[1].gherkinDocument.uri, 'minimal.feature')
+    assert.strictEqual(envelopes[2].pickle.uri, 'minimal.feature')
+  })
+
   it('parses gherkin from STDIN', async () => {
     const source = makeSourceEnvelope(
       `Feature: Minimal

--- a/gherkin-streams/javascript/test/StreamTest.ts
+++ b/gherkin-streams/javascript/test/StreamTest.ts
@@ -12,6 +12,9 @@ describe('gherkin', () => {
       GherkinStreams.fromPaths(['testdata/good/minimal.feature'], defaultOptions)
     )
     assert.strictEqual(envelopes.length, 3)
+    assert.strictEqual(envelopes[0].source.uri, 'testdata/good/minimal.feature')
+    assert.strictEqual(envelopes[1].gherkinDocument.uri, 'testdata/good/minimal.feature')
+    assert.strictEqual(envelopes[2].pickle.uri, 'testdata/good/minimal.feature')
   })
 
   it('throws an error when the path is a directory', async () => {

--- a/gherkin-streams/javascript/test/StreamTest.ts
+++ b/gherkin-streams/javascript/test/StreamTest.ts
@@ -22,7 +22,10 @@ describe('gherkin', () => {
 
   it('emits uris relative to a given path', async () => {
     const envelopes = await streamToArray(
-      GherkinStreams.fromPaths(['testdata/good/minimal.feature'], defaultOptions, 'testdata/good')
+      GherkinStreams.fromPaths(['testdata/good/minimal.feature'], {
+        ...defaultOptions,
+        relativeTo: 'testdata/good',
+      })
     )
     assert.strictEqual(envelopes.length, 3)
     assert.strictEqual(envelopes[0].source.uri, 'minimal.feature')

--- a/gherkin/javascript/README.md
+++ b/gherkin/javascript/README.md
@@ -4,16 +4,4 @@ Gherkin parser/compiler for JavaScript. Please see [Gherkin](https://github.com/
 
 ## Usage
 
-```javascript
-const gherkin = require('gherkin')
-
-const options = {
-  includeSource: true,
-  includeGherkinDocument: true,
-  includePickles: true,
-}
-const stream = gherkin.fromPaths(['features/hello.feature'])
-
-// Pipe the stream to another stream that can read messages.
-stream.pipe(...)
-```
+Typical usage is via [the `gherkin-streams` package](https://www.npmjs.com/package/@cucumber/gherkin-streams).

--- a/gherkin/javascript/README.md
+++ b/gherkin/javascript/README.md
@@ -4,4 +4,4 @@ Gherkin parser/compiler for JavaScript. Please see [Gherkin](https://github.com/
 
 ## Usage
 
-Typical usage is via [the `gherkin-streams` package](https://www.npmjs.com/package/@cucumber/gherkin-streams).
+Typical usage is via [the `gherkin-streams` package](../../gherkin-streams/javascript).


### PR DESCRIPTION


## Summary

If `relativeTo` is provided in the options object for `fromPaths`, we'll calculate the `uri` for the `source` message (which is reused in subsequent ones) relative to that.

## Motivation and Context

This is useful where e.g. we have a set of absolute paths for features which were found based on user input, but we don't want to show the full absolute path in reports etc - instead we want to show them relative to the root of the project we're running from (or something else in other edge cases where people use Gherkin directly).

See https://github.com/cucumber/cucumber-js/issues/1534#issuecomment-754716365

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The change has been ported to Java.
- [ ] The change has been ported to Ruby.
- [ ] The change has been ported to JavaScript.
- [ ] The change has been ported to Go.
- [ ] The change has been ported to .NET.
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.

